### PR TITLE
Update quiver hashcode dependency

### DIFF
--- a/lib/models/documents/attribute.dart
+++ b/lib/models/documents/attribute.dart
@@ -1,4 +1,4 @@
-import 'package:quiver_hashcode/hashcode.dart';
+import 'package:quiver/core.dart';
 
 enum AttributeScope {
   INLINE, // refer to https://quilljs.com/docs/formats/#inline

--- a/lib/models/documents/style.dart
+++ b/lib/models/documents/style.dart
@@ -1,6 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:flutter_quill/models/documents/attribute.dart';
-import 'package:quiver_hashcode/hashcode.dart';
+import 'package:quiver/core.dart';
 
 /* Collection of style attributes */
 class Style {

--- a/lib/models/quill_delta.dart
+++ b/lib/models/quill_delta.dart
@@ -7,7 +7,7 @@ library quill_delta;
 import 'dart:math' as math;
 
 import 'package:collection/collection.dart';
-import 'package:quiver_hashcode/hashcode.dart';
+import 'package:quiver/core.dart';
 
 const _attributeEquality = DeepCollectionEquality();
 const _valueEquality = DeepCollectionEquality();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -276,19 +276,12 @@ packages:
     source: hosted
     version: "4.1.0"
   quiver:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
-  quiver_hashcode:
-    dependency: "direct main"
-    description:
-      name: quiver_hashcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -300,7 +293,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -349,7 +342,7 @@ packages:
       name: tuple
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "2.0.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,9 +12,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  quiver_hashcode: ^2.0.0
+  quiver: ^3.0.0
   collection: ^1.15.0
-  tuple: ^1.0.3
+  tuple: ^2.0.0
   url_launcher: ^6.0.0
   flutter_colorpicker: ^0.3.5
   image_picker: ^0.7.2


### PR DESCRIPTION
Development on the quiver_* subpackages has been discontinued in favour
of the main quiver package at https://github.com/google/quiver-dart. The
code itself is identical, but is more actively maintained.

Updated the dependency on the tuple package to 2.0.0, since it also
depends on quiver 3.0.0. Both packages has been migrated to null-safety
at those versions.