### PR TITLE
add base64 image support in _defaultEmbedBuilder and Remove base64 header from image url

### DIFF
--- a/lib/widgets/editor.dart
+++ b/lib/widgets/editor.dart
@@ -93,12 +93,21 @@ abstract class RenderAbstractEditor {
   void selectPosition(SelectionChangedCause cause);
 }
 
+String removeBase64Header(String url){
+  if(url.contains("base64")){
+    return url.split(",")[1];
+  }
+  return url;
+}
+
 Widget _defaultEmbedBuilder(BuildContext context, leaf.Embed node) {
   switch (node.value.type) {
     case 'image':
-      String imageUrl = node.value.data;
+      String imageUrl = removeBase64Header(node.value.data);
       return imageUrl.startsWith('http')
           ? Image.network(imageUrl)
+          : isBase64(imageUrl)
+          ? Image.memory(base64.decode(imageUrl))
           : Image.file(io.File(imageUrl));
     default:
       throw UnimplementedError(
@@ -411,7 +420,7 @@ class _QuillEditorSelectionGestureDetectorBuilder
     if (getEditor()!.widget.readOnly && segment.value is BlockEmbed) {
       BlockEmbed blockEmbed = segment.value as BlockEmbed;
       if (blockEmbed.type == 'image') {
-        final String imageUrl = blockEmbed.data;
+        final String imageUrl = removeBase64Header(blockEmbed.data);
         Navigator.push(
           getEditor()!.context,
           MaterialPageRoute(

--- a/lib/widgets/editor.dart
+++ b/lib/widgets/editor.dart
@@ -93,8 +93,8 @@ abstract class RenderAbstractEditor {
   void selectPosition(SelectionChangedCause cause);
 }
 
-String removeBase64Header(String url){
-  if(url.contains("base64")){
+String _standardizeImageUrl(String url) {
+  if (url.contains("base64")) {
     return url.split(",")[1];
   }
   return url;
@@ -103,12 +103,12 @@ String removeBase64Header(String url){
 Widget _defaultEmbedBuilder(BuildContext context, leaf.Embed node) {
   switch (node.value.type) {
     case 'image':
-      String imageUrl = removeBase64Header(node.value.data);
+      String imageUrl = _standardizeImageUrl(node.value.data);
       return imageUrl.startsWith('http')
           ? Image.network(imageUrl)
           : isBase64(imageUrl)
-          ? Image.memory(base64.decode(imageUrl))
-          : Image.file(io.File(imageUrl));
+              ? Image.memory(base64.decode(imageUrl))
+              : Image.file(io.File(imageUrl));
     default:
       throw UnimplementedError(
           'Embeddable type "${node.value.type}" is not supported by default embed '
@@ -420,7 +420,7 @@ class _QuillEditorSelectionGestureDetectorBuilder
     if (getEditor()!.widget.readOnly && segment.value is BlockEmbed) {
       BlockEmbed blockEmbed = segment.value as BlockEmbed;
       if (blockEmbed.type == 'image') {
-        final String imageUrl = removeBase64Header(blockEmbed.data);
+        final String imageUrl = _standardizeImageUrl(blockEmbed.data);
         Navigator.push(
           getEditor()!.context,
           MaterialPageRoute(


### PR DESCRIPTION
add base64 image support in _defaultEmbedBuilder 
also in case of viewing image base64 there are some images with "data:image/jpeg;base64" header , which gives an error 
( *can't open file* ) so I made a function to remove "data:image/jpeg;base64" if exists.

