### PR TITLE
Rebuild editor when keyboard is already open

### DIFF
--- a/lib/widgets/editor.dart
+++ b/lib/widgets/editor.dart
@@ -866,6 +866,11 @@ class RenderEditor extends RenderEditableContainerBox
     );
   }
 
+  /// Returns the y-offset of the editor at which [selection] is visible.
+  ///
+  /// The offset is the distance from the top of the editor and is the minimum
+  /// from the current scroll position until [selection] becomes visible.
+  /// Returns null if [selection] is already visible.
   double? getOffsetToRevealCursor(
       double viewportHeight, double scrollOffset, double offsetInViewport) {
     List<TextSelectionPoint> endpoints = getEndpointsForSelection(selection);

--- a/lib/widgets/raw_editor.dart
+++ b/lib/widgets/raw_editor.dart
@@ -886,15 +886,11 @@ class RawEditorState extends EditorState
   }
 
   void _didChangeTextEditingValue() {
-    if (kIsWeb) {
-      _onChangeTextEditingValue();
-      requestKeyboard();
-      return;
-    }
+    _onChangeTextEditingValue();
 
-    if (_keyboardVisible) {
-      _onChangeTextEditingValue();
-    } else {
+    if (kIsWeb) {
+      requestKeyboard();
+    } else if (!_keyboardVisible) {
       requestKeyboard();
     }
   }

--- a/lib/widgets/raw_editor.dart
+++ b/lib/widgets/raw_editor.dart
@@ -702,6 +702,7 @@ class RawEditorState extends EditorState
       _keyboardVisible = true;
     } else {
       _keyboardVisibilityController = KeyboardVisibilityController();
+      _keyboardVisible = _keyboardVisibilityController!.isVisible;
       _keyboardVisibilitySubscription =
           _keyboardVisibilityController?.onChange.listen((bool visible) {
         _keyboardVisible = visible;
@@ -886,11 +887,15 @@ class RawEditorState extends EditorState
   }
 
   void _didChangeTextEditingValue() {
-    _onChangeTextEditingValue();
-
     if (kIsWeb) {
+      _onChangeTextEditingValue();
       requestKeyboard();
-    } else if (!_keyboardVisible) {
+      return;
+    }
+
+    if (_keyboardVisible) {
+      _onChangeTextEditingValue();
+    } else {
       requestKeyboard();
     }
   }


### PR DESCRIPTION
If the keyboard is already open, but the editor thinks that the
keyboard is not open, the text will not be updated when writing.

This can easily happen if one has a `TabBarView` with two children,
each with an `QuillEditor`, see the video and code for an example:

<details><summary>Video</summary>

https://user-images.githubusercontent.com/10923085/112652803-196b7c80-8e4e-11eb-8596-12ed42d71876.mov

</details>

<details><summary>Example</summary>

```dart
import 'package:flutter/material.dart';
import 'package:flutter_quill/widgets/controller.dart';
import 'package:flutter_quill/widgets/editor.dart';

void main() => runApp(MyApp());

class MyApp extends StatefulWidget {
  @override
  _MyAppState createState() => _MyAppState();
}

class _MyAppState extends State<MyApp> {
  late QuillController _controller1;
  late QuillController _controller2;

  @override
  void initState() {
    _controller1 = QuillController.basic();
    _controller2 = QuillController.basic();
    super.initState();
  }

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: DefaultTabController(
        length: 2,
        child: Scaffold(
          appBar: AppBar(
            title: Text('Flutter Quill tabs demo'),
            bottom: TabBar(
              tabs: [
                Tab(text: 'First'),
                Tab(text: 'Second'),
              ],
            ),
          ),
          body: TabBarView(
            children: [
              QuillEditor.basic(controller: _controller1, readOnly: false),
              QuillEditor.basic(controller: _controller2, readOnly: false),
            ],
          ),
        ),
      ),
    );
  }
}
```
</details>