### PR TITLE
Fix "Show toolbar" bug

### DIFF
--- a/lib/widgets/raw_editor.dart
+++ b/lib/widgets/raw_editor.dart
@@ -1094,22 +1094,18 @@ class RawEditorState extends EditorState
 
   @override
   bool showToolbar() {
-    if (_selectionOverlay == null || _selectionOverlay!.toolbar != null) {
-      // Web is using native dom elements to enable clipboard functionality of the
-      // toolbar: copy, paste, select, cut. It might also provide additional
-      // functionality depending on the browser (such as translate). Due to this
-      // we should not show a Flutter toolbar for the editable text elements.
-      if (kIsWeb) {
-        return false;
-      }
-
-      if (_selectionOverlay == null || _selectionOverlay!.toolbar != null) {
-        return false;
-      }
-
-      _selectionOverlay!.showToolbar();
-      return true;
+    // Web is using native dom elements to enable clipboard functionality of the
+    // toolbar: copy, paste, select, cut. It might also provide additional
+    // functionality depending on the browser (such as translate). Due to this
+    // we should not show a Flutter toolbar for the editable text elements.
+    if (kIsWeb) {
+      return false;
     }
+    if (_selectionOverlay == null || _selectionOverlay!.toolbar != null) {
+      return false;
+    }
+
+    _selectionOverlay!.showToolbar();
     return true;
   }
 


### PR DESCRIPTION
During the migration to NNBD a bug occurred that prevents the toolbar from
being displayed. The code changes revert to the original code without bug.

Closes #112 and #119.