### PR TITLE
☝️ Update deprecated code

### DIFF
--- a/lib/widgets/raw_editor.dart
+++ b/lib/widgets/raw_editor.dart
@@ -1029,7 +1029,7 @@ class RawEditorState extends EditorState
   }
 
   @override
-  void hideToolbar() {
+  void hideToolbar([bool hideHandles = true]) {
     if (getSelectionOverlay()?.toolbar != null) {
       getSelectionOverlay()?.hideToolbar();
     }
@@ -1131,6 +1131,10 @@ class RawEditorState extends EditorState
       closeConnectionIfNeeded();
     }
   }
+
+  @override
+  void userUpdateTextEditingValue(
+      TextEditingValue value, SelectionChangedCause cause) {}
 }
 
 class _Editor extends MultiChildRenderObjectWidget {

--- a/lib/widgets/text_selection.dart
+++ b/lib/widgets/text_selection.dart
@@ -155,8 +155,12 @@ class EditorTextSelectionOverlay {
       default:
         throw 'Invalid position';
     }
-    selectionDelegate.textEditingValue =
-        value.copyWith(selection: newSelection, composing: TextRange.empty);
+
+    selectionDelegate.userUpdateTextEditingValue(
+      value.copyWith(selection: newSelection, composing: TextRange.empty),
+      SelectionChangedCause.drag,
+    );
+
     selectionDelegate.bringIntoView(textPosition);
   }
 


### PR DESCRIPTION
This PR adds support for Flutter 2.0.1+

In `raw_editor.dart`:

* add new `[bool hideHandles]` parameter for `hideToolbar()` override
* add new `userUpdateTextEditingValue()` override (not sure if the method's body should stay empty)

In `text_selection.dart `:

* use `selectionDelegate.userUpdateTextEditingValue()` method instead of `selectionDelegate.textEditingValue = ...` affectation
 
The error messages was:

```
'RawEditorState.hideToolbar' ('void Function()') isn't a valid override of 
'TextSelectionDelegate.hideToolbar' ('void Function([bool])').
```

```
Missing concrete implementation of 'TextSelectionDelegate.userUpdateTextEditingValue'.
Try implementing the missing method, or make the class abstract.
```

```
'textEditingValue' is deprecated and shouldn't be used. 
Use the userUpdateTextEditingValue instead. This feature was deprecated after v1.26.0-17.2.pre..
Try replacing the use of the deprecated member with the replacement.
```

This code has been tested against:

```shell
[✓] Flutter (Channel beta, 2.1.0-12.2.pre, on macOS 11.2.3 20D91 darwin-x64, locale en-GB)
    • Flutter version 2.1.0-12.2.pre at /Users/rootasjey/dev/flutter
    • Framework revision 5bedb7b1d5 (2 weeks ago), 2021-03-17 17:06:30 -0700
    • Engine revision 711ab3fda0
    • Dart version 2.13.0 (build 2.13.0-116.0.dev)
```