### PR TITLE
Fix empty line height bug

### DIFF
--- a/lib/widgets/text_line.dart
+++ b/lib/widgets/text_line.dart
@@ -44,12 +44,11 @@ class TextLine extends StatelessWidget {
       return EmbedProxy(embedBuilder(context, embed));
     }
 
-    TextSpan textSpan = _buildTextSpan(context);
-    StrutStyle strutStyle =
-        StrutStyle.fromTextStyle(textSpan.style!, forceStrutHeight: true);
+    final textSpan = _buildTextSpan(context);
+    final strutStyle = StrutStyle.fromTextStyle(textSpan.style!);
     final textAlign = _getTextAlign();
     RichText child = RichText(
-      text: TextSpan(children: [textSpan]),
+      text: textSpan,
       textAlign: textAlign,
       textDirection: textDirection,
       strutStyle: strutStyle,


### PR DESCRIPTION
In `QuillEditor` we display paragraphs using `RichText`. The height of a
`RichText` is calculated using a `TextPainter`, basically like this:
```dart
const textSpan = TextSpan(
  children: [
    TextSpan(text: 'Foo '),
    TextSpan(text: 'Bar', style: TextStyle(fontSize: 20, height: 1)),
  ],
  style: TextStyle(color: Colors.black, fontSize: 16),
);
final textPainter = TextPainter(text: textSpan, textDirection: TextDirection.ltr)..layout();
print('Height of textspan: ${textPainter.height}');
// Height of textspan: 20
```

Our code looks basically like this for an empty line:
```dart
const textSpan = TextSpan(
  children: [TextSpan(children: [], style: TextStyle(color: Colors.black, fontSize: 20))],
  style: null,
);
final textPainter = TextPainter(text: textSpan, textDirection: TextDirection.ltr)..layout();
print('Height of textspan: ${textPainter.height}');
// Height of textspan: 16
```
Now the line wrongly has the height 16 instead of 20, which cuts off the bottom
(see issue #133) from the text. To fix this, I moved the inner `TextSpan` one
layer higher.

Now the problem occurred that a line with several heights has the size of the
strut, because we enforce this size. I couldn't figure out why the strut size
is enforced, so I removed the behavior and a line with multiple sizes is now
displayed correctly.

The code changes also solve an annoying bug that causes a small line shift 
when writing the first letter in a line.

Closes #133.