### PR TITLE
Updates `Document.toJson` to map from raw operations

### DIFF
--- a/lib/models/quill_delta.dart
+++ b/lib/models/quill_delta.dart
@@ -265,7 +265,7 @@ class Delta {
   List<Operation> toList() => List.from(_operations);
 
   /// Returns JSON-serializable version of this delta.
-  List toJson() => toList();
+  List toJson() => toList().map((operation) => operation.toJson()).toList();
 
   /// Returns `true` if this delta is empty.
   bool get isEmpty => _operations.isEmpty;


### PR DESCRIPTION
Currently, the `Document.toJson()` does nothing but remove the type-safety from `Document.toList()`.

In my use-case (and I think what will for the majority of the use-cases for this library), when calling `toJson`, one would expect this `List` to have a raw representation of a `Map`, meaning, a `List<Map>`, and not a `List<Operation>`.

What occurs today is that whenever we call a `Document().toJson()`, we still need to iterate through all `Operation` to parse each individually `toJson` as well, which is the same as calling `Document().toList()`.