### PR TITLE
Generic error when instantiating a `Document.fromJson` with an empty `List` (or `Delta`)

### DIFF
--- a/lib/models/documents/document.dart
+++ b/lib/models/documents/document.dart
@@ -223,7 +223,12 @@ class Document {
   String toPlainText() => _root.children.map((e) => e.toPlainText()).join();
 
   void _loadDocument(Delta doc) {
+    if (doc.isEmpty) {
+      throw ArgumentError.value(doc, 'Document Delta cannot be empty.');
+    }
+
     assert((doc.last.data as String).endsWith('\n'));
+
     var offset = 0;
     for (final op in doc.toList()) {
       if (!op.isInsert) {


### PR DESCRIPTION
When calling the `Document.fromJson` with an empty `List`, the following error is thrown:

```
Bad state: No element

The relevant error-causing widget was
EditorPage
lib/main.dart:10
When the exception was thrown, this was the stack
#0      List.last (dart:core-patch/growable_array.dart:337:5)
#1      Delta.last
package:flutter_quill/models/quill_delta.dart:289
#2      Document._loadDocument
package:flutter_quill/…/documents/document.dart:226
#3      new Document.fromJson
package:flutter_quill/…/documents/document.dart:23
#4      _EditorPageState._updateListener
package:memo_builder/pages/editor_page.dart:30
...
════════════════════════════════════════════════════════════════════════════════

```

Obviously this is an error due to the list being empty, but I think a more specific error should be thrown if this case occur, and not a "Bad State".

This occurs because the `Delta` accepts an empty `List`, but the `Document`, after creating this `Delta`, calls `_loadDocument(_delta)` in the constructor body, which makes the following assertion:

`assert((doc.last.data as String).endsWith('\n'));`

And it's expected, as `doc.last` doesn't exist.

---

Apparently this insert `Operation` with a `\n` is required by the `Document`'s `Delta`, so I added a runtime error with a better description for this error.

I've decided to add a runtime (and not a debug assertion), because this will always crash the application when calling `final node = _root.last` anyways, so we must enforce it not only in debug mode.

---

There's also the alternative to add a default argument is `doc.isEmpty`, but I don't know if this should be the responsibility of `flutter-quill`.