### PR TITLE
Fixes crashing disposed listeners on a bunch of widgets

### DIFF
--- a/lib/widgets/controller.dart
+++ b/lib/widgets/controller.dart
@@ -32,6 +32,13 @@ class QuillController extends ChangeNotifier {
   Style toggledStyle = Style();
   bool ignoreFocusOnTextChange = false;
 
+  /// Controls whether this [QuillController] instance has already been disposed
+  /// of
+  /// 
+  /// This is a safe approach to make sure that listeners don't crash when
+  /// adding, removing or listeners to this instance.
+  bool _isDisposed = false;
+
   // item1: Document state before [change].
   //
   // item2: Change delta applied to the document.
@@ -184,8 +191,30 @@ class QuillController extends ChangeNotifier {
   }
 
   @override
+  void addListener(VoidCallback listener) {
+    // By using `_isDisposed`, make sure that `addListener` won't be called on a
+    // disposed `ChangeListener`
+    if (!_isDisposed) {
+      super.addListener(listener);
+    }
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    // By using `_isDisposed`, make sure that `removeListener` won't be called
+    // on a disposed `ChangeListener`
+    if (!_isDisposed) {
+      super.removeListener(listener);
+    }
+  }
+
+  @override
   void dispose() {
-    document.close();
+    if (!_isDisposed) {
+      document.close();
+    }
+
+    _isDisposed = true;
     super.dispose();
   }
 


### PR DESCRIPTION
When a `QuillController` is disposed and then a new instance is added to any `QuillToolbar` or `QuillEditor`, a bunch of listeners fail to remove because it has already been disposed of, mostly because of this specific call:

`oldWidget.controller.removeListener(_didChangeEditingValue);`

I have created a [gist](https://gist.github.com/matuella/41dda6c2058126c151896c23182f6ebc) for anyone interested in checking out a really easy reproduction.

<details>
  <summary>Full error when tapping the error mentioned</summary>

```
════════ Exception caught by widgets library ═══════════════════════════════════
The following assertion was thrown building Visibility(visible, maintainState, maintainAnimation, maintainSize, maintainSemantics, maintainInteractivity):
A QuillController was used after being disposed.

Once you have called dispose() on a QuillController, it can no longer be used.
The relevant error-causing widget was
QuillToolbar
lib/main_test.dart:39
When the exception was thrown, this was the stack
#0      ChangeNotifier._debugAssertNotDisposed.<anonymous closure>
package:flutter/…/foundation/change_notifier.dart:117
#1      ChangeNotifier._debugAssertNotDisposed
package:flutter/…/foundation/change_notifier.dart:123
#2      ChangeNotifier.removeListener
package:flutter/…/foundation/change_notifier.dart:195
#3      _ToggleStyleButtonState.didUpdateWidget
package:flutter_quill/widgets/toolbar.dart:236
#4      StatefulElement.update
package:flutter/…/widgets/framework.dart:4682
...
════════════════════════════════════════════════════════════════════════════════

════════ Exception caught by widgets library ═══════════════════════════════════
A QuillController was used after being disposed.
The relevant error-causing widget was
QuillToolbar
lib/main_test.dart:39
════════════════════════════════════════════════════════════════════════════════

════════ Exception caught by widgets library ═══════════════════════════════════
A QuillController was used after being disposed.
The relevant error-causing widget was
QuillToolbar
lib/main_test.dart:39
════════════════════════════════════════════════════════════════════════════════

════════ Exception caught by widgets library ═══════════════════════════════════
A QuillController was used after being disposed.
The relevant error-causing widget was
QuillToolbar
lib/main_test.dart:39
════════════════════════════════════════════════════════════════════════════════

════════ Exception caught by widgets library ═══════════════════════════════════
A QuillController was used after being disposed.
The relevant error-causing widget was
QuillToolbar
lib/main_test.dart:39
════════════════════════════════════════════════════════════════════════════════
```

</details>