### PR TITLE
Custom rules & optionally auto add newline for image embeds

### DIFF
--- a/lib/models/rules/rule.dart
+++ b/lib/models/rules/rule.dart
@@ -28,6 +28,8 @@ abstract class Rule {
 class Rules {
   Rules(this._rules);
 
+  List<Rule> _customRules = [];
+
   final List<Rule> _rules;
   static final Rules _instance = Rules([
     const FormatLinkAtCaretPositionRule(),
@@ -49,10 +51,14 @@ class Rules {
 
   static Rules getInstance() => _instance;
 
+  void setCustomRules(List<Rule> customRules) {
+    _customRules = customRules;
+  }
+
   Delta apply(RuleType ruleType, Document document, int index,
       {int? len, Object? data, Attribute? attribute}) {
     final delta = document.toDelta();
-    for (final rule in _rules) {
+    for (final rule in _customRules + _rules) {
       if (rule.type != ruleType) {
         continue;
       }

--- a/lib/widgets/controller.dart
+++ b/lib/widgets/controller.dart
@@ -80,12 +80,13 @@ class QuillController extends ChangeNotifier {
   bool get hasRedo => document.hasRedo;
 
   void replaceText(
-      int index, int len, Object? data, TextSelection? textSelection, {bool ignoreFocus = false}) {
+      int index, int len, Object? data, TextSelection? textSelection,
+      {bool ignoreFocus = false, bool autoAppendNewlineAfterImage = true}) {
     assert(data is String || data is Embeddable);
 
     Delta? delta;
     if (len > 0 || data is! String || data.isNotEmpty) {
-      delta = document.replace(index, len, data);
+      delta = document.replace(index, len, data, autoAppendNewlineAfterImage: autoAppendNewlineAfterImage);
       var shouldRetainDelta = toggledStyle.isNotEmpty &&
           delta.isNotEmpty &&
           delta.length <= 2 &&


### PR DESCRIPTION
So that client can override certain rules which take priority, and can control when not to have additional newlines added for image embeds