### PR TITLE
Fixes for flutter web

### DIFF
--- a/lib/src/models/documents/attribute.dart
+++ b/lib/src/models/documents/attribute.dart
@@ -193,7 +193,7 @@ class Attribute<T> {
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-    if (other is! Attribute<T>) return false;
+    if (other is! Attribute) return false;
     final typedOther = other;
     return key == typedOther.key &&
         scope == typedOther.scope &&

--- a/lib/src/widgets/raw_editor.dart
+++ b/lib/src/widgets/raw_editor.dart
@@ -126,8 +126,7 @@ class RawEditorState extends EditorState
 
   DefaultStyles? _styles;
 
-  final ClipboardStatusNotifier? _clipboardStatus =
-      kIsWeb ? null : ClipboardStatusNotifier();
+  final ClipboardStatusNotifier _clipboardStatus = ClipboardStatusNotifier();
   final LayerLink _toolbarLayerLink = LayerLink();
   final LayerLink _startHandleLayerLink = LayerLink();
   final LayerLink _endHandleLayerLink = LayerLink();
@@ -318,7 +317,7 @@ class RawEditorState extends EditorState
   void initState() {
     super.initState();
 
-    _clipboardStatus?.addListener(_onChangedClipboardStatus);
+    _clipboardStatus.addListener(_onChangedClipboardStatus);
 
     widget.controller.addListener(() {
       _didChangeTextEditingValue(widget.controller.ignoreFocusOnTextChange);
@@ -438,8 +437,9 @@ class RawEditorState extends EditorState
     widget.focusNode.removeListener(_handleFocusChanged);
     _focusAttachment!.detach();
     _cursorCont.dispose();
-    _clipboardStatus?.removeListener(_onChangedClipboardStatus);
-    _clipboardStatus?.dispose();
+    _clipboardStatus
+      ..removeListener(_onChangedClipboardStatus)
+      ..dispose();
     super.dispose();
   }
 
@@ -518,7 +518,7 @@ class RawEditorState extends EditorState
         this,
         DragStartBehavior.start,
         null,
-        _clipboardStatus!,
+        _clipboardStatus,
       );
       _selectionOverlay!.handlesVisible = _shouldShowSelectionHandles();
       _selectionOverlay!.showHandles();


### PR DESCRIPTION
Added a fix for Attribute object comparison that was stopping the correct text styles being applied to headers (h1, h2, h3).

Fixed an issue in flutter web that was caused by ClipboardStatusNotifier being set to null. The clipboard is now supported on web via a browser permission popup so this should no longer need to be set to null on web.

```The following TypeErrorImpl was thrown while dispatching notifications for FocusNode:
Unexpected null value.

When the exception was thrown, this was the stack
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 236:49      throw_
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart 518:63  nullCheck
packages/flutter_quill/widgets/raw_editor.dart 973:25                             [_updateOrDisposeSelectionOverlayIfNeeded]
packages/flutter_quill/widgets/raw_editor.dart 984:5                              [_handleFocusChanged]
packages/flutter/src/foundation/change_notifier.dart 243:16                       notifyListeners
...
The FocusNode sending notification was: FocusNode#4fe41([PRIMARY FOCUS])
    context: RawEditor-[LabeledGlobalKey<EditorState>#1ed0a]
    PRIMARY FOCUS
```