### PR TITLE
Fix a bug that Embed could be together with Text

### DIFF
--- a/lib/src/widgets/text_line.dart
+++ b/lib/src/widgets/text_line.dart
@@ -37,8 +37,17 @@ class TextLine extends StatelessWidget {
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
 
-    if (line.hasEmbed) {
-      final embed = line.children.single as Embed;
+    // In rare circumstances, the line could contain an Embed & a Text of
+    // newline, which is unexpected and probably we should find out the
+    // root cause
+    final childCount = line.childCount;
+    if (line.hasEmbed ||
+        (childCount > 1 && line.children.first is Embed))
+    {
+      if (childCount > 1) {
+        print('Unexpected - TextLine Embed as 1st child but multiple children');
+      }
+      final embed = line.children.first as Embed;
       return EmbedProxy(embedBuilder(context, embed));
     }
 

--- a/lib/src/widgets/text_line.dart
+++ b/lib/src/widgets/text_line.dart
@@ -44,9 +44,6 @@ class TextLine extends StatelessWidget {
     if (line.hasEmbed ||
         (childCount > 1 && line.children.first is Embed))
     {
-      if (childCount > 1) {
-        print('Unexpected - TextLine Embed as 1st child but multiple children');
-      }
       final embed = line.children.first as Embed;
       return EmbedProxy(embedBuilder(context, embed));
     }


### PR DESCRIPTION
It happens from time to time (not consistently), e.g. an image and a newline are fed into the same `Line`, so that this line would crash https://github.com/singerdmx/flutter-quill/blob/master/lib/src/widgets/text_line.dart#L119

It shouldn't feed both `Embed` & `Text` to a same `Line` in the first place, but I couldn't figure out the root cause for that - if someone has idea how to debug the root cause it would be great (for some reason putting breakpoints in `text_line.dart` causes weird behavior in Android Studio - is it only me?)