### PR TITLE
add the parameter to hide the camera button

### DIFF
--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -74,6 +74,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     bool showHistory = true,
     bool showHorizontalRule = false,
     bool multiRowsDisplay = true,
+    bool showCamera = true,
     OnImagePickCallback? onImagePickCallback,
     FilePickImpl? filePickImpl,
     WebImagePickImpl? webImagePickImpl,
@@ -172,7 +173,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             filePickImpl: filePickImpl,
             webImagePickImpl: webImagePickImpl,
           ),
-        if (onImagePickCallback != null)
+        if (onImagePickCallback != null && showCamera)
           ImageButton(
             icon: Icons.photo_camera,
             iconSize: toolbarIconSize,


### PR DESCRIPTION
As stated in the title, there's chance that we do not want to use the camera feature.

Besides, there are issues on the camera feature which will be discussed in another issue post.