### PR TITLE
Fixed dragging right handle scrolling issue

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -903,7 +903,19 @@ class RenderEditor extends RenderEditableContainerBox
   double? getOffsetToRevealCursor(
       double viewportHeight, double scrollOffset, double offsetInViewport) {
     final endpoints = getEndpointsForSelection(selection);
-    final endpoint = endpoints.first;
+    
+    // when we drag the right handle, we should get the last point
+    TextSelectionPoint endpoint;
+    if (selection.isCollapsed) {
+      endpoint = endpoints.first;
+    } else {
+      if (selection is DragTextSelection) {
+        endpoint = (selection as DragTextSelection).first ? endpoints.first : endpoints.last;
+      } else {
+        endpoint = endpoints.first;
+      }
+    }
+    
     final child = childAtPosition(selection.extent);
     const kMargin = 8.0;
 

--- a/lib/src/widgets/text_selection.dart
+++ b/lib/src/widgets/text_selection.dart
@@ -23,6 +23,41 @@ TextSelection localSelection(Node node, TextSelection selection, fromParent) {
 
 enum _TextSelectionHandlePosition { START, END }
 
+/// internal use, used to get drag direction information
+class DragTextSelection extends TextSelection {
+  final bool first;
+
+  const DragTextSelection({
+    int baseOffset = 0,
+    int extentOffset = 0,
+    TextAffinity affinity = TextAffinity.downstream,
+    bool isDirectional = false,
+    this.first = true,
+  }) : super(
+          baseOffset: baseOffset,
+          extentOffset: extentOffset,
+          affinity: affinity,
+          isDirectional: isDirectional,
+        );
+
+  @override
+  DragTextSelection copyWith({
+    int? baseOffset,
+    int? extentOffset,
+    TextAffinity? affinity,
+    bool? isDirectional,
+    bool? first,
+  }) {
+    return DragTextSelection(
+      baseOffset: baseOffset ?? this.baseOffset,
+      extentOffset: extentOffset ?? this.extentOffset,
+      affinity: affinity ?? this.affinity,
+      isDirectional: isDirectional ?? this.isDirectional,
+      first: first ?? this.first,
+    );
+  }
+}
+
 class EditorTextSelectionOverlay {
   EditorTextSelectionOverlay(
     this.value,
@@ -156,9 +191,20 @@ class EditorTextSelectionOverlay {
       default:
         throw 'Invalid position';
     }
+    
+    final currSelection = newSelection != null
+        ? DragTextSelection(
+            baseOffset: newSelection.baseOffset,
+            extentOffset: newSelection.extentOffset,
+            affinity: newSelection.affinity,
+            isDirectional: newSelection.isDirectional,
+            first: position == _TextSelectionHandlePosition.START,
+          )
+        : null;
+        
     selectionDelegate
       ..userUpdateTextEditingValue(
-          value.copyWith(selection: newSelection, composing: TextRange.empty),
+          value.copyWith(selection: currSelection, composing: TextRange.empty),
           SelectionChangedCause.drag)
       ..bringIntoView(textPosition);
   }


### PR DESCRIPTION
when a large piece of text is in the selected state, the left handle is out of the display area. dragging the right handle causes the wrong scroll position. scrolling always locates the left handle, and the scroll does not automatically move down when the right handle is dragged down