### PR TITLE
Bumps `flutter_colorpicker` and `photo_view` versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   collection: ^1.15.0
-  flutter_colorpicker: ^0.4.0
+  flutter_colorpicker: ^0.5.0
   flutter_keyboard_visibility: ^5.0.0
   image_picker: ^0.8.2
   photo_view: ^0.11.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter_colorpicker: ^0.5.0
   flutter_keyboard_visibility: ^5.0.0
   image_picker: ^0.8.2
-  photo_view: ^0.11.1
+  photo_view: ^0.12.0
   quiver: ^3.0.0
   string_validator: ^0.3.0
   tuple: ^2.0.0


### PR DESCRIPTION
Both pubs have breaking changes updates with the Flutter beta channel. See:

- https://pub.dev/packages/photo_view/changelog#0120httpsgithubcomrenancaraujophoto_viewreleasestag0120---19-jul-2021
- https://pub.dev/packages/flutter_colorpicker/changelog#050

I would also recommend to perform a new release since current latest version will not work anymore when `Flutter beta` gets merged in `stable`