### PR TITLE
update colorpicker to prevent error xcode build

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   collection: ^1.15.0
-  flutter_colorpicker: ^0.4.0
+  flutter_colorpicker: ^0.5.0
   flutter_keyboard_visibility: ^5.0.0
   image_picker: ^0.8.2
   photo_view: ^0.12.0


### PR DESCRIPTION
Updating package `flutter_colorpicker` to prevent error which explained on issue #311 