### PR TITLE
RawEditor update to support putting QuillEditor inside a Scrollable view

### DIFF
--- a/lib/src/widgets/raw_editor.dart
+++ b/lib/src/widgets/raw_editor.dart
@@ -564,7 +564,7 @@ class RawEditorState extends EditorState
 
     _showCaretOnScreenScheduled = true;
     SchedulerBinding.instance!.addPostFrameCallback((_) {
-      if (widget.scrollable) {
+      if (widget.scrollable || _scrollController.hasClients) {
         _showCaretOnScreenScheduled = false;
 
         final renderEditor = getRenderEditor();
@@ -608,6 +608,7 @@ class RawEditorState extends EditorState
   void requestKeyboard() {
     if (_hasFocus) {
       openConnectionIfNeeded();
+      _showCaretOnScreen();
     } else {
       widget.focusNode.requestFocus();
     }


### PR DESCRIPTION
Hi,

First of all, thank you for your work on this package, it is really great !!

Here is the purpose of this PR :

I had to put a **QuillEditor** inside a **SingleChildScrollView** but this scrollView wasn't scrolling automatically when the text entered was down the screen. I needed the editor to be expandable and not scrolling by itself.

Example : 

![screen_capture_1](https://user-images.githubusercontent.com/46108869/131350188-bb6f18ca-90f7-42f9-860e-a04de47099d7.gif)


The solution I found was to use the **ScrollController** passed to the **QuillEditor** widget in the **SingleChildScrollView** containing the **QuillEditor**. Like so, the `_showCaretOnScreen` method from **RawEditor** calls the **ScrollController** used by the **SingleChildScrollView** to scroll if it has clients.

The result is the following : 

![screen_capture](https://user-images.githubusercontent.com/46108869/131349616-32dc8d75-ed58-4438-a6f2-f223a9dbf56a.gif)

The blue part is a **Container** with the Flutter logo in it. The purple part is the **QuillEditor**. Both of them are part of a **Column** contained inside a **SingleChildScrollView**.

The code used is the following : 

```dart
class _ScrollPage extends StatefulWidget {
  const _ScrollPage({
    Key? key,
  }) : super(key: key);

  @override
  _ScrollPageState createState() => _ScrollPageState();
}

class _ScrollPageState extends State<_ScrollPage> {
  late final QuillController controller;
  late final ScrollController scrollController;
  late final FocusNode focusNode;

  @override
  void initState() {
    super.initState();
    controller = QuillController.basic();
    scrollController = ScrollController();
    focusNode = FocusNode();
  }

  @override
  void dispose() {
    controller.dispose();
    scrollController.dispose();
    focusNode.dispose();
    super.dispose();
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: SafeArea(
        child: SingleChildScrollView(
          controller: scrollController,
          child: Column(
            children: [
              Container(
                color: Colors.blue[400],
                height: 200,
                child: const Center(child: FlutterLogo(size: 150)),
              ),
              Container(
                color: Colors.purple[100],
                child: Flexible(
                  child: QuillEditor(
                    controller: controller,
                    focusNode: focusNode,
                    scrollController: scrollController,
                    scrollable: false,
                    padding: const EdgeInsets.all(16),
                    autoFocus: true,
                    readOnly: false,
                    expands: false,
                  ),
                ),
              ),
            ],
          ),
        ),
      ),
    );
  }
}
```

Please, let me now if this change is causing conflicts with the current behavior.

Thank you !

(This PR is also fixing the issue discused here https://github.com/singerdmx/flutter-quill/discussions/291)
