### PR TITLE
Option added to controller to keep inline style on new lines

### DIFF
--- a/lib/src/widgets/controller.dart
+++ b/lib/src/widgets/controller.dart
@@ -14,7 +14,9 @@ class QuillController extends ChangeNotifier {
   QuillController({
     required this.document,
     required TextSelection selection,
-  }) : _selection = selection;
+    bool keepStyleOnNewLine = false,
+  })  : _selection = selection,
+        _keepStyleOnNewLine = keepStyleOnNewLine;
 
   factory QuillController.basic() {
     return QuillController(
@@ -25,6 +27,10 @@ class QuillController extends ChangeNotifier {
 
   /// Document managed by this controller.
   final Document document;
+
+  /// Tells whether to keep or reset the [toggledStyle]
+  /// when user adds a new line.
+  final bool _keepStyleOnNewLine;
 
   /// Currently selected text within the [document].
   TextSelection get selection => _selection;
@@ -135,7 +141,14 @@ class QuillController extends ChangeNotifier {
       }
     }
 
-    toggledStyle = Style();
+    if (_keepStyleOnNewLine) {
+      final style = getSelectionStyle();
+      final notInlineStyle = style.attributes.values.where((s) => !s.isInline);
+      toggledStyle = style.removeAll(notInlineStyle.toSet());
+    } else {
+      toggledStyle = Style();
+    }
+
     if (textSelection != null) {
       if (delta == null || delta.isEmpty) {
         _updateSelection(textSelection, ChangeSource.LOCAL);


### PR DESCRIPTION
Hi !

I need to keep inline styles (bold, italic, underline, etc) even when I add a new line. It is annoying for the user to activate it multiple times for each line.
I think adding the optional parameter `keepStyleOnNewLine` with a default value of false can allow this behavior. When this parameter is set to true, inline attributes won't be removed from style.

Don't hesitate to tell me if this functionnality is breaking current code.

Also, maybe the name keepStyleOnNewLine isn't perfect, if you have a better idea, I'll take it !

Thank you ! :)  