### PR TITLE
Text Alignment functions + Block Format standards

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,9 +4,6 @@ analyzer:
   errors:
     undefined_prefixed_name: ignore
     unsafe_html: ignore
-    # Just for not cluttering my vscode main project problems, enable these later for pull requests
-    todo: ignore
-    unused_element: ignore
 linter:
   rules:
     - always_declare_return_types

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,6 +4,9 @@ analyzer:
   errors:
     undefined_prefixed_name: ignore
     unsafe_html: ignore
+    # Just for not cluttering my vscode main project problems, enable these later for pull requests
+    todo: ignore
+    unused_element: ignore
 linter:
   rules:
     - always_declare_return_types

--- a/example/lib/pages/home_page.dart
+++ b/example/lib/pages/home_page.dart
@@ -149,18 +149,23 @@ class _HomePageState extends State<HomePage> {
       onVideoPickCallback: _onVideoPickCallback,
       // uncomment to provide a custom "pick from" dialog.
       // mediaPickSettingSelector: _selectMediaPickSetting,
+      showAlignmentButtons: true,
     );
     if (kIsWeb) {
       toolbar = QuillToolbar.basic(
-          controller: _controller!,
-          onImagePickCallback: _onImagePickCallback,
-          webImagePickImpl: _webImagePickImpl);
+        controller: _controller!,
+        onImagePickCallback: _onImagePickCallback,
+        webImagePickImpl: _webImagePickImpl,
+        showAlignmentButtons: true,
+      );
     }
     if (_isDesktop()) {
       toolbar = QuillToolbar.basic(
-          controller: _controller!,
-          onImagePickCallback: _onImagePickCallback,
-          filePickImpl: openFileSystemPickerForDesktop);
+        controller: _controller!,
+        onImagePickCallback: _onImagePickCallback,
+        filePickImpl: openFileSystemPickerForDesktop,
+        showAlignmentButtons: true,
+      );
     }
 
     return SafeArea(

--- a/example/macos/Runner/DebugProfile.entitlements
+++ b/example/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -4,9 +4,9 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <url_launcher_windows/url_launcher_plugin.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
-  UrlLauncherPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("UrlLauncherPlugin"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/lib/src/models/documents/attribute.dart
+++ b/lib/src/models/documents/attribute.dart
@@ -111,6 +111,13 @@ class Attribute<T> {
     Attribute.indent.key,
   });
 
+  static final Set<String> exclusiveBlockKeys = LinkedHashSet.of({
+    Attribute.header.key,
+    Attribute.list.key,
+    Attribute.codeBlock.key,
+    Attribute.blockQuote.key,
+  });
+
   static Attribute<int?> get h1 => HeaderAttribute(level: 1);
 
   static Attribute<int?> get h2 => HeaderAttribute(level: 2);

--- a/lib/src/models/rules/format.dart
+++ b/lib/src/models/rules/format.dart
@@ -39,10 +39,23 @@ class ResolveLineFormatRule extends FormatRule {
       final tmp = Delta();
       var offset = 0;
 
+      // Enforce Block Format exclusivity by rule
+      final removedBlocks = Attribute.exclusiveBlockKeys.contains(attribute.key)
+          ? op.attributes?.keys
+                  .where((key) =>
+                      Attribute.exclusiveBlockKeys.contains(key) &&
+                      attribute.key != key &&
+                      attribute.value != null)
+                  .map((key) => MapEntry<String, dynamic>(key, null)) ??
+              []
+          : <MapEntry<String, dynamic>>[];
+
       for (var lineBreak = text.indexOf('\n');
           lineBreak >= 0;
           lineBreak = text.indexOf('\n', offset)) {
-        tmp..retain(lineBreak - offset)..retain(1, attribute.toJson());
+        tmp
+          ..retain(lineBreak - offset)
+          ..retain(1, attribute.toJson()..addEntries(removedBlocks));
         offset = lineBreak + 1;
       }
       tmp.retain(text.length - offset);
@@ -57,7 +70,19 @@ class ResolveLineFormatRule extends FormatRule {
         delta.retain(op.length!);
         continue;
       }
-      delta..retain(lineBreak)..retain(1, attribute.toJson());
+      // Enforce Block Format exclusivity by rule
+      final removedBlocks = Attribute.exclusiveBlockKeys.contains(attribute.key)
+          ? op.attributes?.keys
+                  .where((key) =>
+                      Attribute.exclusiveBlockKeys.contains(key) &&
+                      attribute.key != key &&
+                      attribute.value != null)
+                  .map((key) => MapEntry<String, dynamic>(key, null)) ??
+              []
+          : <MapEntry<String, dynamic>>[];
+      delta
+        ..retain(lineBreak)
+        ..retain(1, attribute.toJson()..addEntries(removedBlocks));
       break;
     }
     return delta;

--- a/lib/src/widgets/raw_editor.dart
+++ b/lib/src/widgets/raw_editor.dart
@@ -313,8 +313,12 @@ class RawEditorState extends EditorState
       return defaultStyles!.code!.verticalSpacing;
     } else if (attrs.containsKey(Attribute.indent.key)) {
       return defaultStyles!.indent!.verticalSpacing;
+    } else if (attrs.containsKey(Attribute.list.key)) {
+      return defaultStyles!.lists!.verticalSpacing;
+    } else if (attrs.containsKey(Attribute.align.key)) {
+      return defaultStyles!.align!.verticalSpacing;
     }
-    return defaultStyles!.lists!.verticalSpacing;
+    return const Tuple2(0, 0);
   }
 
   @override

--- a/lib/src/widgets/simple_viewer.dart
+++ b/lib/src/widgets/simple_viewer.dart
@@ -295,8 +295,12 @@ class _QuillSimpleViewerState extends State<QuillSimpleViewer>
       return defaultStyles!.code!.verticalSpacing;
     } else if (attrs.containsKey(Attribute.indent.key)) {
       return defaultStyles!.indent!.verticalSpacing;
+    } else if (attrs.containsKey(Attribute.list.key)) {
+      return defaultStyles!.lists!.verticalSpacing;
+    } else if (attrs.containsKey(Attribute.align.key)) {
+      return defaultStyles!.align!.verticalSpacing;
     }
-    return defaultStyles!.lists!.verticalSpacing;
+    return const Tuple2(0, 0);
   }
 
   void _nullSelectionChanged(

--- a/lib/src/widgets/text_block.dart
+++ b/lib/src/widgets/text_block.dart
@@ -213,11 +213,16 @@ class EditableTextBlock extends StatelessWidget {
       extraIndent = 16.0 * indent.value;
     }
 
+    var baseIndent = 0.0;
+
     if (attrs.containsKey(Attribute.blockQuote.key)) {
       return 16.0 + extraIndent;
+    } else if (attrs.containsKey(Attribute.list.key) ||
+        attrs.containsKey(Attribute.codeBlock.key)) {
+      baseIndent = 32.0;
     }
 
-    return 32.0 + extraIndent;
+    return baseIndent + extraIndent;
   }
 
   Tuple2 _getSpacingForLine(

--- a/lib/src/widgets/text_line.dart
+++ b/lib/src/widgets/text_line.dart
@@ -104,11 +104,11 @@ class TextLine extends StatelessWidget {
   TextAlign _getTextAlign() {
     final alignment = line.style.attributes[Attribute.align.key];
     if (alignment == Attribute.leftAlignment) {
-      return TextAlign.left;
+      return TextAlign.start;
     } else if (alignment == Attribute.centerAlignment) {
       return TextAlign.center;
     } else if (alignment == Attribute.rightAlignment) {
-      return TextAlign.right;
+      return TextAlign.end;
     } else if (alignment == Attribute.justifyAlignment) {
       return TextAlign.justify;
     }
@@ -140,13 +140,20 @@ class TextLine extends StatelessWidget {
 
     textStyle = textStyle.merge(m[header] ?? defaultStyles.paragraph!.style);
 
-    final block = line.style.getBlockExceptHeader();
+    // Only retrieve exclusive block format for the line style purpose
+    Attribute? block;
+    line.style.getBlocksExceptHeader().forEach((key, value) {
+      if (Attribute.exclusiveBlockKeys.contains(key)) {
+        block = value;
+      }
+    });
+
     TextStyle? toMerge;
     if (block == Attribute.blockQuote) {
       toMerge = defaultStyles.quote!.style;
     } else if (block == Attribute.codeBlock) {
       toMerge = defaultStyles.code!.style;
-    } else if (block != null) {
+    } else if (block == Attribute.list) {
       toMerge = defaultStyles.lists!.style;
     }
 

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -14,6 +14,7 @@ import 'toolbar/image_button.dart';
 import 'toolbar/indent_button.dart';
 import 'toolbar/insert_embed_button.dart';
 import 'toolbar/link_style_button.dart';
+import 'toolbar/select_alignment_button.dart';
 import 'toolbar/select_header_style_button.dart';
 import 'toolbar/toggle_check_list_button.dart';
 import 'toolbar/toggle_style_button.dart';
@@ -29,6 +30,7 @@ export 'toolbar/insert_embed_button.dart';
 export 'toolbar/link_style_button.dart';
 export 'toolbar/quill_dropdown_button.dart';
 export 'toolbar/quill_icon_button.dart';
+export 'toolbar/select_alignment_button.dart';
 export 'toolbar/select_header_style_button.dart';
 export 'toolbar/toggle_check_list_button.dart';
 export 'toolbar/toggle_style_button.dart';
@@ -71,6 +73,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     bool showColorButton = true,
     bool showBackgroundColorButton = true,
     bool showClearFormat = true,
+    bool showAlignmentButtons = false,
     bool showHeaderStyle = true,
     bool showListNumbers = true,
     bool showListBullets = true,
@@ -105,6 +108,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           showClearFormat ||
           onImagePickCallback != null ||
           onVideoPickCallback != null,
+      showAlignmentButtons,
       showHeaderStyle,
       showListNumbers || showListBullets || showListCheck || showCodeBlock,
       showQuote || showIndent,
@@ -220,7 +224,23 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             (isButtonGroupShown[1] ||
                 isButtonGroupShown[2] ||
                 isButtonGroupShown[3] ||
-                isButtonGroupShown[4]))
+                isButtonGroupShown[4] ||
+                isButtonGroupShown[5]))
+          VerticalDivider(
+            indent: 12,
+            endIndent: 12,
+            color: Colors.grey.shade400,
+          ),
+        if (showAlignmentButtons)
+          SelectAlignmentButton(
+            controller: controller,
+            iconSize: toolbarIconSize,
+          ),
+        if (isButtonGroupShown[1] &&
+            (isButtonGroupShown[2] ||
+                isButtonGroupShown[3] ||
+                isButtonGroupShown[4] ||
+                isButtonGroupShown[5]))
           VerticalDivider(
             indent: 12,
             endIndent: 12,
@@ -231,10 +251,10 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             controller: controller,
             iconSize: toolbarIconSize,
           ),
-        if (isButtonGroupShown[1] &&
-            (isButtonGroupShown[2] ||
-                isButtonGroupShown[3] ||
-                isButtonGroupShown[4]))
+        if (isButtonGroupShown[2] &&
+            (isButtonGroupShown[3] ||
+                isButtonGroupShown[4] ||
+                isButtonGroupShown[5]))
           VerticalDivider(
             indent: 12,
             endIndent: 12,
@@ -268,8 +288,8 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             icon: Icons.code,
             iconSize: toolbarIconSize,
           ),
-        if (isButtonGroupShown[2] &&
-            (isButtonGroupShown[3] || isButtonGroupShown[4]))
+        if (isButtonGroupShown[3] &&
+            (isButtonGroupShown[4] || isButtonGroupShown[5]))
           VerticalDivider(
             indent: 12,
             endIndent: 12,
@@ -296,7 +316,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             controller: controller,
             isIncrease: false,
           ),
-        if (isButtonGroupShown[3] && isButtonGroupShown[4])
+        if (isButtonGroupShown[4] && isButtonGroupShown[5])
           VerticalDivider(
             indent: 12,
             endIndent: 12,

--- a/lib/src/widgets/toolbar/select_alignment_button.dart
+++ b/lib/src/widgets/toolbar/select_alignment_button.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../../models/documents/attribute.dart';
+import '../../models/documents/style.dart';
+import '../controller.dart';
+import '../toolbar.dart';
+
+class SelectAlignmentButton extends StatefulWidget {
+  const SelectAlignmentButton({
+    required this.controller,
+    this.iconSize = kDefaultIconSize,
+    Key? key,
+  }) : super(key: key);
+
+  final QuillController controller;
+  final double iconSize;
+
+  @override
+  _SelectAlignmentButtonState createState() => _SelectAlignmentButtonState();
+}
+
+class _SelectAlignmentButtonState extends State<SelectAlignmentButton> {
+  Attribute? _value;
+
+  Style get _selectionStyle => widget.controller.getSelectionStyle();
+
+  @override
+  void initState() {
+    super.initState();
+    setState(() {
+      _value = _selectionStyle.attributes[Attribute.align.key] ??
+          Attribute.leftAlignment;
+    });
+    widget.controller.addListener(_didChangeEditingValue);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final _valueToText = <Attribute, String>{
+      Attribute.leftAlignment: Attribute.leftAlignment.value!,
+      Attribute.centerAlignment: Attribute.centerAlignment.value!,
+      Attribute.rightAlignment: Attribute.rightAlignment.value!,
+      Attribute.justifyAlignment: Attribute.justifyAlignment.value!,
+    };
+
+    final _valueAttribute = <Attribute>[
+      Attribute.leftAlignment,
+      Attribute.centerAlignment,
+      Attribute.rightAlignment,
+      Attribute.justifyAlignment
+    ];
+    final _valueString = <String>[
+      Attribute.leftAlignment.value!,
+      Attribute.centerAlignment.value!,
+      Attribute.rightAlignment.value!,
+      Attribute.justifyAlignment.value!,
+    ];
+
+    final theme = Theme.of(context);
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: List.generate(4, (index) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: !kIsWeb ? 1.0 : 5.0),
+          child: ConstrainedBox(
+            constraints: BoxConstraints.tightFor(
+              width: widget.iconSize * kIconButtonFactor,
+              height: widget.iconSize * kIconButtonFactor,
+            ),
+            child: RawMaterialButton(
+              hoverElevation: 0,
+              highlightElevation: 0,
+              elevation: 0,
+              visualDensity: VisualDensity.compact,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(2)),
+              fillColor: _valueToText[_value] == _valueString[index]
+                  ? theme.toggleableActiveColor
+                  : theme.canvasColor,
+              onPressed: () => _valueAttribute[index] == Attribute.leftAlignment
+                  ? widget.controller
+                      .formatSelection(Attribute.clone(Attribute.align, null))
+                  : widget.controller.formatSelection(_valueAttribute[index]),
+              child: Icon(
+                _valueString[index] == Attribute.leftAlignment.value
+                    ? Icons.format_align_left
+                    : _valueString[index] == Attribute.centerAlignment.value
+                        ? Icons.format_align_center
+                        : _valueString[index] == Attribute.rightAlignment.value
+                            ? Icons.format_align_right
+                            : Icons.format_align_justify,
+                size: widget.iconSize,
+                color: _valueToText[_value] == _valueString[index]
+                    ? theme.primaryIconTheme.color
+                    : theme.iconTheme.color,
+              ),
+            ),
+          ),
+        );
+      }),
+    );
+  }
+
+  void _didChangeEditingValue() {
+    setState(() {
+      _value = _selectionStyle.attributes[Attribute.align.key] ??
+          Attribute.leftAlignment;
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant SelectAlignmentButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_didChangeEditingValue);
+      widget.controller.addListener(_didChangeEditingValue);
+      _value = _selectionStyle.attributes[Attribute.align.key] ??
+          Attribute.leftAlignment;
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_didChangeEditingValue);
+    super.dispose();
+  }
+}

--- a/lib/src/widgets/toolbar/toggle_check_list_button.dart
+++ b/lib/src/widgets/toolbar/toggle_check_list_button.dart
@@ -81,17 +81,13 @@ class _ToggleCheckListButtonState extends State<ToggleCheckListButton> {
 
   @override
   Widget build(BuildContext context) {
-    final isInCodeBlock =
-        _selectionStyle.attributes.containsKey(Attribute.codeBlock.key);
-    final isEnabled =
-        !isInCodeBlock || Attribute.list.key == Attribute.codeBlock.key;
     return widget.childBuilder(
       context,
       Attribute.unchecked,
       widget.icon,
       widget.fillColor,
       _isToggled,
-      isEnabled ? _toggleAttribute : null,
+      _toggleAttribute,
       widget.iconSize,
     );
   }

--- a/lib/src/widgets/toolbar/toggle_style_button.dart
+++ b/lib/src/widgets/toolbar/toggle_style_button.dart
@@ -56,17 +56,13 @@ class _ToggleStyleButtonState extends State<ToggleStyleButton> {
 
   @override
   Widget build(BuildContext context) {
-    final isInCodeBlock =
-        _selectionStyle.attributes.containsKey(Attribute.codeBlock.key);
-    final isEnabled =
-        !isInCodeBlock || widget.attribute.key == Attribute.codeBlock.key;
     return widget.childBuilder(
       context,
       widget.attribute,
       widget.icon,
       widget.fillColor,
       _isToggled,
-      isEnabled ? _toggleAttribute : null,
+      _toggleAttribute,
       widget.iconSize,
     );
   }


### PR DESCRIPTION
Hi,

This PR involves the following changes

- Finalized Text Alignment functionalities including its behavior, its effect against other block formats, and its toolbar buttons.
- Quill JS Block Formats standards including their exclusivity and inclusivity behaviors as  discussed in this [discussion](https://github.com/singerdmx/flutter-quill/discussions/375).

Listed below are notable changes with their locations. I'll try to be as brief as possible while still explains clearly of what they are trying to do.

### Enforce Block Format exclusivity by rule

Change locations:

- lib/src/models/rules/format.dart:42
- lib/src/models/rules/format.dart:73

Since the `ResolveLineFormatRule` class rule is to resolve the line format, then I think the block format exclusivity should also be handled and enforced here. The `removedBlocks` variable will contain unsets (value = null) for any existing operation exclusive attributes, therefore it will act like a "toggle" to turn off existing exclusive format and turn on the new
exclusive format.

### `Block` style now can contain multiple attributes

Change locations:

- lib/src/models/documents/nodes/line.dart:215

The current implementation of applying block styles (prior this PR change) is actually "replacing" an existing block styles (`parentStyle`) with `newStyle` which has a side effect. For example, for a sample text that contains nested list like this:

```
1. This is a text
   a. This is a sub text
```

Its Delta representation in `flutter-quill` is already correct, which is like this:

```json
[
  {"insert": "This is a text"},
  {"insert": "\n", "attributes": {"list": "ordered"}},
  {"insert": "This is a sub text"},
  {"insert":"\n", "attributes": {"list": "ordered", "indent": 1}}
]
```

But, the constructed `Block` instances styles in the `Document` is like the following (these are their `toString()` results):

```
// This is the `Block` for the first text:
Block (§ {{list: Attribute{key: list, scope: AttributeScope.BLOCK, value: ordered}}}
  └ ¶ Instance of 'Text' ⏎ {Attribute{key: list, scope: AttributeScope.BLOCK, value: ordered}})

// This is the `Block` for the second text:
Block (§ {{indent: Attribute{key: indent, scope: AttributeScope.BLOCK, value: 1}}}
  └ ¶ Instance of 'Text' ⏎ {Attribute{key: list, scope: AttributeScope.BLOCK, value: ordered}, Attribute{key: indent, scope: AttributeScope.BLOCK, value: 1}})
```

Notice that the second text's `Block` style is only have `indent` and without `list`, which makes it difficult to detect its continuation with the previous parent indent, and also this block style is kind of ambiguous (is it only a standard indented text
without list? or inside a list?). At the moment of writing, this information is needed in the `EditableTextBlock._getIndentWidth()` to produce the correct indent value. So here we attempt to merge the existing `Block` style (which has `list`) with the newly applied block style (which has `indent`). While doing this, we try to respect the block style exclusivity rules too (from `Attribute.exclusiveBlockKeys`). **IMPORTANT NOTE**: this change allows the `Block`'s style to contain more than one Quill Block Formats, but still respect the exclusivity. For example, now it can contains variety of Block Formats like these:

- One exclusive: `{ "header": 1 }`
- One exclusive + one inclusive: `{ "list": "ordered", "align": "center" }`
- One exclusive + two inclusives: `{ "code-block": true, "indent": 1, "align": "center" }`

Any exclusive style shall be guaranteed to exist only as one style among several inclusive styles. The "dangerous" part for now is, the `Style.getBlockExceptHeader()` method now becomes ambiguous as this method only returns one block style. So now we have to be careful for its usage. I've checked the `getBlockExceptHeader()` references and it has been used in several places. For most usages, it's only used for flow control only (only checks for its presence), except the one in the `TextLine._getLineStyle()` where it is used as a base style for the line. Read the modification in the `_getLineStyle()` for details.

### More specific conditionals to handle different formats

Change locations:

- lib/src/widgets/text_block.dart:216
  Not all Block elements should have extra indents (as demonstrated on Windows WordPad and MacOS TextEdit). The following lists all possible block attributes with their effects:
  - IndentAttribute: already handled on the original code (adds multiplied indentation value)
  - BlockQuoteAttribute: already handled on the original code (adds 16.0)
  -   ListAttribute: preserve original code intention (adds 32.0)
  - CodeBlockAttribute: preserve original code intention (adds 32.0)
  - HeaderAttribute: should not add indentation
  - AlignAttribute: should not add indentation

- lib/src/widgets/text_line.dart:107
  Adapt to more generic alignments to prepare RTL support if needed later.

- lib/src/widgets/text_line.dart:143
  The `block` style has been modified to return only one exclusive style, and at this point, it can only be either `blockQuote`, `codeBlock`, or `list` (as `header` is already processed earlier). The rest inclusive block styles such as `indent`, `align`, and `direction` should not affect the text style whatsoever, as by design, those inclusive styles are only affecting layouts, not text styles.

- lib/src/widgets/raw_editor.dart:316
- lib/src/widgets/simple_viewer.dart:298
- lib/src/widgets/text_line.dart:156
  Added more specific conditions to not always defaulted to `lists` style.

### Toolbar button for Text Alignment

Change locations:

- lib/src/widgets/toolbar.dart:(various line numbers)
  Added alignment buttons in toolbar.

### Remove some existing Toolbar behaviors in regards of the new Block Format Exclusivity rule

Change locations:

- lib/src/widgets/toolbar/toggle_check_list_button.dart:84
- lib/src/widgets/toolbar/toggle_style_list_button.dart:59

I've removed the `isInCodeBlock` checking here. I know that this is required to disable other toolbar buttons while in CodeBlock mode. But, since the block format exclusivity is now centrally handled in `ResolveLineFormatRule` class, I feel that handling at the toolbar level is not necessary anymore (CMIIW).
