### PR TITLE
Avoid runtime error when placed inside TabBarView

### DIFF
--- a/lib/src/widgets/toolbar/arrow_indicated_button_list.dart
+++ b/lib/src/widgets/toolbar/arrow_indicated_button_list.dart
@@ -60,6 +60,8 @@ class _ArrowIndicatedButtonListState extends State<ArrowIndicatedButtonList>
   }
 
   void _handleScroll() {
+    if (!mounted) return;
+
     setState(() {
       _showLeftArrow =
           _controller.position.minScrollExtent != _controller.position.pixels;


### PR DESCRIPTION
The `setState` gets called during changing the TabBar index, which leads to "calling setState on dispose" error. This fix just checks the `mounted` flag to avoid calling `setState` in such situation.
