### PR TITLE
[fix]: cursorConnt.color notify the text_line to repaint if it was di…

### DIFF
--- a/lib/src/widgets/text_line.dart
+++ b/lib/src/widgets/text_line.dart
@@ -413,7 +413,7 @@ class RenderEditableTextLine extends RenderEditableBox {
 
     color = c;
     if (containsTextSelection()) {
-      markNeedsPaint();
+      safeMarkNeedsPaint();
     }
   }
 
@@ -425,7 +425,7 @@ class RenderEditableTextLine extends RenderEditableBox {
     final containsSelection = containsTextSelection();
     if (attached && containsCursor()) {
       cursorCont.removeListener(markNeedsLayout);
-      cursorCont.color.removeListener(markNeedsPaint);
+      cursorCont.color.removeListener(safeMarkNeedsPaint);
     }
 
     textSelection = t;
@@ -433,11 +433,11 @@ class RenderEditableTextLine extends RenderEditableBox {
     _containsCursor = null;
     if (attached && containsCursor()) {
       cursorCont.addListener(markNeedsLayout);
-      cursorCont.color.addListener(markNeedsPaint);
+      cursorCont.color.addListener(safeMarkNeedsPaint);
     }
 
     if (containsSelection || containsTextSelection()) {
-      markNeedsPaint();
+      safeMarkNeedsPaint();
     }
   }
 
@@ -642,7 +642,7 @@ class RenderEditableTextLine extends RenderEditableBox {
     }
     if (containsCursor()) {
       cursorCont.addListener(markNeedsLayout);
-      cursorCont.color.addListener(markNeedsPaint);
+      cursorCont.color.addListener(safeMarkNeedsPaint);
     }
   }
 
@@ -654,7 +654,7 @@ class RenderEditableTextLine extends RenderEditableBox {
     }
     if (containsCursor()) {
       cursorCont.removeListener(markNeedsLayout);
-      cursorCont.color.removeListener(markNeedsPaint);
+      cursorCont.color.removeListener(safeMarkNeedsPaint);
     }
   }
 
@@ -882,6 +882,14 @@ class RenderEditableTextLine extends RenderEditableBox {
       offset: position.offset - getContainer().documentOffset,
       affinity: position.affinity,
     );
+  }
+
+  void safeMarkNeedsPaint() {
+    if (!attached) {
+      //Should not paint if it was unattach.
+      return;
+    }
+    safeMarkNeedsPaint();
   }
 }
 


### PR DESCRIPTION
Problem: 
cursorConnt.color notify the text_line to repaint even though the text_line was already disposed which cause the     assert(!_debugDisposed) issue in markNeedsPaint.

```
void markNeedsPaint() {
    assert(!_debugDisposed); 
   ....
}
```
The Call Stack:
![image](https://user-images.githubusercontent.com/86001920/138560063-ff010bf4-23e5-450c-8682-e4db4d81feb3.png)

Reproduce step:
Deleting the number list item quickly(as shown below), the exception will be reproduced.
![image](https://user-images.githubusercontent.com/86001920/138560157-f39ed5ad-0e80-4b25-b9ac-f7f7d556c497.png)

Solution: Wrap the markNeedsPaint with condition checked:
```
void safeMarkNeedsPaint() {
    if (!attached) {
      //Should not paint if it was unattach.
      return;
    }
    markNeedsPaint();
  }
```









