### PR TITLE
[fix]: The selection effect can't be seen as the textLine with backgr…

### DIFF
--- a/lib/src/widgets/text_line.dart
+++ b/lib/src/widgets/text_line.dart
@@ -812,15 +812,6 @@ class RenderEditableTextLine extends RenderEditableBox {
     if (_body != null) {
       final parentData = _body!.parentData as BoxParentData;
       final effectiveOffset = offset + parentData.offset;
-      if (enableInteractiveSelection &&
-          line.documentOffset <= textSelection.end &&
-          textSelection.start <= line.documentOffset + line.length - 1) {
-        final local = localSelection(line, textSelection, false);
-        _selectedRects ??= _body!.getBoxesForSelection(
-          local,
-        );
-        _paintSelection(context, effectiveOffset);
-      }
 
       if (hasFocus &&
           cursorCont.show.value &&
@@ -836,6 +827,17 @@ class RenderEditableTextLine extends RenderEditableBox {
           containsCursor() &&
           cursorCont.style.paintAboveText) {
         _paintCursor(context, effectiveOffset, line.hasEmbed);
+      }
+
+      // paint the selection on the top
+      if (enableInteractiveSelection &&
+          line.documentOffset <= textSelection.end &&
+          textSelection.start <= line.documentOffset + line.length - 1) {
+        final local = localSelection(line, textSelection, false);
+        _selectedRects ??= _body!.getBoxesForSelection(
+          local,
+        );
+        _paintSelection(context, effectiveOffset);
       }
     }
   }


### PR DESCRIPTION
Problem: 
The selection effect can't be seen if the TextLine with background effect because the selection is painted before the TextLine.

![image](https://user-images.githubusercontent.com/86001920/138638593-6088fe64-d9b8-4569-bddd-95abac241281.png)

Solution: 
Painting the selection effect above others.

![image](https://user-images.githubusercontent.com/86001920/138639004-ed465ac4-1684-4ebd-83dd-7cbe65bc7f05.png)


