### PR TITLE
Fix colors for alignment icons in the toolbar

### DIFF
--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -281,6 +281,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           SelectAlignmentButton(
             controller: controller,
             iconSize: toolbarIconSize,
+            iconTheme: iconTheme,
           ),
         if (isButtonGroupShown[1] &&
             (isButtonGroupShown[2] ||


### PR DESCRIPTION
Fixes the alignment toolbar icons to use the IconTheme as mentioned in this Issue https://github.com/singerdmx/flutter-quill/issues/450

(PS this is my first ever pull request, yay!)