### PR TITLE
Add ability to hide/show Left, Center, Right and Justify alignment buttons

### DIFF
--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -281,6 +281,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           SelectAlignmentButton(
             controller: controller,
             iconSize: toolbarIconSize,
+            iconTheme: iconTheme,
           ),
         if (isButtonGroupShown[1] &&
             (isButtonGroupShown[2] ||

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -288,8 +288,8 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             controller: controller,
             iconSize: toolbarIconSize,
             iconTheme: iconTheme,
-            showCenterAlignment: showCenterAlignment              
-            showRightAlignment: showRightAlignment              
+            showCenterAlignment: showCenterAlignment,              
+            showRightAlignment: showRightAlignment,              
             showJustifyAlignment: showJustifyAlignment,
           ),
         if (isButtonGroupShown[1] &&

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -79,7 +79,8 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     bool showBackgroundColorButton = true,
     bool showClearFormat = true,
     bool showAlignmentButtons = false,
-    bool showJustifyAlignment = false,
+    bool showJustifyAlignment = true,
+    bool showRightAlignment = true,
     bool showHeaderStyle = true,
     bool showListNumbers = true,
     bool showListBullets = true,
@@ -132,6 +133,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           onVideoPickCallback != null,
       showAlignmentButtons,
       showJustifyAlignment,  
+      showRightAlignment,
       showHeaderStyle,
       showListNumbers || showListBullets || showListCheck || showCodeBlock,
       showQuote || showIndent,
@@ -284,7 +286,8 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             controller: controller,
             iconSize: toolbarIconSize,
             iconTheme: iconTheme,
-            showJustifyAlignment: showJustifyAlignment
+            showJustifyAlignment: showJustifyAlignment,
+            showRightAlignment: showRightAlignment
           ),
         if (isButtonGroupShown[1] &&
             (isButtonGroupShown[2] ||

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -79,6 +79,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     bool showBackgroundColorButton = true,
     bool showClearFormat = true,
     bool showAlignmentButtons = false,
+    bool showJustifyAlignment = false,
     bool showHeaderStyle = true,
     bool showListNumbers = true,
     bool showListBullets = true,
@@ -130,6 +131,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           onImagePickCallback != null ||
           onVideoPickCallback != null,
       showAlignmentButtons,
+      showJustifyAlignment,  
       showHeaderStyle,
       showListNumbers || showListBullets || showListCheck || showCodeBlock,
       showQuote || showIndent,
@@ -282,6 +284,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             controller: controller,
             iconSize: toolbarIconSize,
             iconTheme: iconTheme,
+            showJustifyAlignment: showJustifyAlignment
           ),
         if (isButtonGroupShown[1] &&
             (isButtonGroupShown[2] ||

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -79,8 +79,9 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     bool showBackgroundColorButton = true,
     bool showClearFormat = true,
     bool showAlignmentButtons = false,
-    bool showJustifyAlignment = true,
+    bool showCenterAlignment = true,
     bool showRightAlignment = true,
+    bool showJustifyAlignment = true,
     bool showHeaderStyle = true,
     bool showListNumbers = true,
     bool showListBullets = true,
@@ -132,8 +133,9 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           onImagePickCallback != null ||
           onVideoPickCallback != null,
       showAlignmentButtons,
-      showJustifyAlignment,  
+      showCenterAlignment,
       showRightAlignment,
+      showJustifyAlignment,  
       showHeaderStyle,
       showListNumbers || showListBullets || showListCheck || showCodeBlock,
       showQuote || showIndent,
@@ -286,8 +288,9 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             controller: controller,
             iconSize: toolbarIconSize,
             iconTheme: iconTheme,
+            showCenterAlignment: showCenterAlignment              
+            showRightAlignment: showRightAlignment              
             showJustifyAlignment: showJustifyAlignment,
-            showRightAlignment: showRightAlignment
           ),
         if (isButtonGroupShown[1] &&
             (isButtonGroupShown[2] ||

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -79,6 +79,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     bool showBackgroundColorButton = true,
     bool showClearFormat = true,
     bool showAlignmentButtons = false,
+    bool showLeftAlignment = true,
     bool showCenterAlignment = true,
     bool showRightAlignment = true,
     bool showJustifyAlignment = true,
@@ -133,6 +134,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           onImagePickCallback != null ||
           onVideoPickCallback != null,
       showAlignmentButtons,
+      showLeftAlignment,
       showCenterAlignment,
       showRightAlignment,
       showJustifyAlignment,  
@@ -288,6 +290,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             controller: controller,
             iconSize: toolbarIconSize,
             iconTheme: iconTheme,
+            showLeftAlignment: showLeftAlignment,    
             showCenterAlignment: showCenterAlignment,              
             showRightAlignment: showRightAlignment,              
             showJustifyAlignment: showJustifyAlignment,

--- a/lib/src/widgets/toolbar/select_alignment_button.dart
+++ b/lib/src/widgets/toolbar/select_alignment_button.dart
@@ -67,7 +67,7 @@ class _SelectAlignmentButtonState extends State<SelectAlignmentButton> {
 
     final theme = Theme.of(context);
     
-    final buttonCount = 2 + ((widget.showRightAlignment) ? 1 : 0) + ((widget.showJustifyAlignment) ? 1 : 0);
+    final buttonCount = 2 + ((widget.showRightAlignment?) ? 1 : 0) + ((widget.showJustifyAlignment?) ? 1 : 0);
 
     return Row(
       mainAxisSize: MainAxisSize.min,

--- a/lib/src/widgets/toolbar/select_alignment_button.dart
+++ b/lib/src/widgets/toolbar/select_alignment_button.dart
@@ -47,25 +47,25 @@ class _SelectAlignmentButtonState extends State<SelectAlignmentButton> {
       Attribute.leftAlignment: Attribute.leftAlignment.value!,
       Attribute.centerAlignment: Attribute.centerAlignment.value!,
       Attribute.rightAlignment: Attribute.rightAlignment.value!,
-      if (widget.showJustifyAlignment) Attribute.justifyAlignment: Attribute.justifyAlignment.value!,
+      if (widget.showJustifyAlignment!) Attribute.justifyAlignment: Attribute.justifyAlignment.value!,
     };
 
     final _valueAttribute = <Attribute>[
       Attribute.leftAlignment,
       Attribute.centerAlignment,
       Attribute.rightAlignment,
-      if (widget.showJustifyAlignment) Attribute.justifyAlignment
+      if (widget.showJustifyAlignment!) Attribute.justifyAlignment
     ];
     final _valueString = <String>[
       Attribute.leftAlignment.value!,
       Attribute.centerAlignment.value!,
       Attribute.rightAlignment.value!,
-      if (widget.showJustifyAlignment) Attribute.justifyAlignment.value!,
+      if (widget.showJustifyAlignment!) Attribute.justifyAlignment.value!,
     ];
 
     final theme = Theme.of(context);
     
-    final buttonCount = (widget.showJustifyAlignment == true) ? 4 : 3;
+    final buttonCount = (widget.showJustifyAlignment? == true) ? 4 : 3;
 
     return Row(
       mainAxisSize: MainAxisSize.min,

--- a/lib/src/widgets/toolbar/select_alignment_button.dart
+++ b/lib/src/widgets/toolbar/select_alignment_button.dart
@@ -65,7 +65,7 @@ class _SelectAlignmentButtonState extends State<SelectAlignmentButton> {
 
     final theme = Theme.of(context);
     
-    final buttonCount = (widget.showJustifyAlignment? == true) ? 4 : 3;
+    final buttonCount = (widget.showJustifyAlignment == true) ? 4 : 3;
 
     return Row(
       mainAxisSize: MainAxisSize.min,

--- a/lib/src/widgets/toolbar/select_alignment_button.dart
+++ b/lib/src/widgets/toolbar/select_alignment_button.dart
@@ -13,6 +13,7 @@ class SelectAlignmentButton extends StatefulWidget {
     this.iconSize = kDefaultIconSize,
     this.iconTheme,
     this.showJustifyAlignment,
+    this.showRightAlignment,
     Key? key,
   }) : super(key: key);
 
@@ -21,6 +22,7 @@ class SelectAlignmentButton extends StatefulWidget {
 
   final QuillIconTheme? iconTheme;
   final bool? showJustifyAlignment;
+  final bool? showRightAlignment;
 
   @override
   _SelectAlignmentButtonState createState() => _SelectAlignmentButtonState();
@@ -46,20 +48,20 @@ class _SelectAlignmentButtonState extends State<SelectAlignmentButton> {
     final _valueToText = <Attribute, String>{
       Attribute.leftAlignment: Attribute.leftAlignment.value!,
       Attribute.centerAlignment: Attribute.centerAlignment.value!,
-      Attribute.rightAlignment: Attribute.rightAlignment.value!,
+      if (widget.showRightAlignment!) Attribute.rightAlignment: Attribute.rightAlignment.value!,
       if (widget.showJustifyAlignment!) Attribute.justifyAlignment: Attribute.justifyAlignment.value!,
     };
 
     final _valueAttribute = <Attribute>[
       Attribute.leftAlignment,
       Attribute.centerAlignment,
-      Attribute.rightAlignment,
+      if (widget.showRightAlignment!) Attribute.rightAlignment,
       if (widget.showJustifyAlignment!) Attribute.justifyAlignment
     ];
     final _valueString = <String>[
       Attribute.leftAlignment.value!,
       Attribute.centerAlignment.value!,
-      Attribute.rightAlignment.value!,
+      if (widget.showRightAlignment!) Attribute.rightAlignment.value!,
       if (widget.showJustifyAlignment!) Attribute.justifyAlignment.value!,
     ];
 

--- a/lib/src/widgets/toolbar/select_alignment_button.dart
+++ b/lib/src/widgets/toolbar/select_alignment_button.dart
@@ -47,27 +47,29 @@ class _SelectAlignmentButtonState extends State<SelectAlignmentButton> {
       Attribute.leftAlignment: Attribute.leftAlignment.value!,
       Attribute.centerAlignment: Attribute.centerAlignment.value!,
       Attribute.rightAlignment: Attribute.rightAlignment.value!,
-      Attribute.justifyAlignment: Attribute.justifyAlignment.value!,
+      if (showJustifyAlignment) Attribute.justifyAlignment: Attribute.justifyAlignment.value!,
     };
 
     final _valueAttribute = <Attribute>[
       Attribute.leftAlignment,
       Attribute.centerAlignment,
       Attribute.rightAlignment,
-      Attribute.justifyAlignment
+      if (showJustifyAlignment) Attribute.justifyAlignment
     ];
     final _valueString = <String>[
       Attribute.leftAlignment.value!,
       Attribute.centerAlignment.value!,
       Attribute.rightAlignment.value!,
-      Attribute.justifyAlignment.value!,
+      if (showJustifyAlignment) Attribute.justifyAlignment.value!,
     ];
 
     final theme = Theme.of(context);
+    
+    final buttonCount = (showJustifyAlignment == true) ? 4 : 3;
 
     return Row(
       mainAxisSize: MainAxisSize.min,
-      children: List.generate(4, (index) {
+      children: List.generate(buttonCount, (index) {
         return Padding(
           padding: const EdgeInsets.symmetric(horizontal: !kIsWeb ? 1.0 : 5.0),
           child: ConstrainedBox(

--- a/lib/src/widgets/toolbar/select_alignment_button.dart
+++ b/lib/src/widgets/toolbar/select_alignment_button.dart
@@ -67,7 +67,7 @@ class _SelectAlignmentButtonState extends State<SelectAlignmentButton> {
 
     final theme = Theme.of(context);
     
-    final buttonCount = 2 + ((widget.showRightAlignment?) ? 1 : 0) + ((widget.showJustifyAlignment?) ? 1 : 0);
+    final buttonCount = 2 + ((widget.showRightAlignment!) ? 1 : 0) + ((widget.showJustifyAlignment!) ? 1 : 0);
 
     return Row(
       mainAxisSize: MainAxisSize.min,

--- a/lib/src/widgets/toolbar/select_alignment_button.dart
+++ b/lib/src/widgets/toolbar/select_alignment_button.dart
@@ -47,25 +47,25 @@ class _SelectAlignmentButtonState extends State<SelectAlignmentButton> {
       Attribute.leftAlignment: Attribute.leftAlignment.value!,
       Attribute.centerAlignment: Attribute.centerAlignment.value!,
       Attribute.rightAlignment: Attribute.rightAlignment.value!,
-      if (showJustifyAlignment) Attribute.justifyAlignment: Attribute.justifyAlignment.value!,
+      if (widget.showJustifyAlignment) Attribute.justifyAlignment: Attribute.justifyAlignment.value!,
     };
 
     final _valueAttribute = <Attribute>[
       Attribute.leftAlignment,
       Attribute.centerAlignment,
       Attribute.rightAlignment,
-      if (showJustifyAlignment) Attribute.justifyAlignment
+      if (widget.showJustifyAlignment) Attribute.justifyAlignment
     ];
     final _valueString = <String>[
       Attribute.leftAlignment.value!,
       Attribute.centerAlignment.value!,
       Attribute.rightAlignment.value!,
-      if (showJustifyAlignment) Attribute.justifyAlignment.value!,
+      if (widget.showJustifyAlignment) Attribute.justifyAlignment.value!,
     ];
 
     final theme = Theme.of(context);
     
-    final buttonCount = (showJustifyAlignment == true) ? 4 : 3;
+    final buttonCount = (widget.showJustifyAlignment == true) ? 4 : 3;
 
     return Row(
       mainAxisSize: MainAxisSize.min,

--- a/lib/src/widgets/toolbar/select_alignment_button.dart
+++ b/lib/src/widgets/toolbar/select_alignment_button.dart
@@ -67,7 +67,7 @@ class _SelectAlignmentButtonState extends State<SelectAlignmentButton> {
 
     final theme = Theme.of(context);
     
-    final buttonCount = (widget.showJustifyAlignment == true) ? 4 : 3;
+    final buttonCount = 2 + ((widget.showRightAlignment) ? 1 : 0) + ((widget.showJustifyAlignment) ? 1 : 0);
 
     return Row(
       mainAxisSize: MainAxisSize.min,

--- a/lib/src/widgets/toolbar/select_alignment_button.dart
+++ b/lib/src/widgets/toolbar/select_alignment_button.dart
@@ -12,6 +12,7 @@ class SelectAlignmentButton extends StatefulWidget {
     required this.controller,
     this.iconSize = kDefaultIconSize,
     this.iconTheme,
+    this.showJustifyAlignment,
     Key? key,
   }) : super(key: key);
 
@@ -19,6 +20,7 @@ class SelectAlignmentButton extends StatefulWidget {
   final double iconSize;
 
   final QuillIconTheme? iconTheme;
+  final bool showJustifyAlignment;
 
   @override
   _SelectAlignmentButtonState createState() => _SelectAlignmentButtonState();

--- a/lib/src/widgets/toolbar/select_alignment_button.dart
+++ b/lib/src/widgets/toolbar/select_alignment_button.dart
@@ -12,6 +12,7 @@ class SelectAlignmentButton extends StatefulWidget {
     required this.controller,
     this.iconSize = kDefaultIconSize,
     this.iconTheme,
+    this.showLeftAlignment,
     this.showCenterAlignment,
     this.showRightAlignment,
     this.showJustifyAlignment,
@@ -22,6 +23,7 @@ class SelectAlignmentButton extends StatefulWidget {
   final double iconSize;
 
   final QuillIconTheme? iconTheme;
+  final bool? showLeftAlignment;
   final bool? showCenterAlignment;
   final bool? showRightAlignment;
   final bool? showJustifyAlignment;
@@ -48,20 +50,20 @@ class _SelectAlignmentButtonState extends State<SelectAlignmentButton> {
   @override
   Widget build(BuildContext context) {
     final _valueToText = <Attribute, String>{
-      Attribute.leftAlignment: Attribute.leftAlignment.value!,
-      Attribute.centerAlignment: Attribute.centerAlignment.value!,
+      if (widget.showLeftAlignment!) Attribute.leftAlignment: Attribute.leftAlignment.value!,
+      if (widget.showCenterAlignment!) Attribute.centerAlignment: Attribute.centerAlignment.value!,
       if (widget.showRightAlignment!) Attribute.rightAlignment: Attribute.rightAlignment.value!,
       if (widget.showJustifyAlignment!) Attribute.justifyAlignment: Attribute.justifyAlignment.value!,
     };
 
     final _valueAttribute = <Attribute>[
-      Attribute.leftAlignment,
+      if (widget.showLeftAlignment!) Attribute.leftAlignment,
       if (widget.showCenterAlignment!) Attribute.centerAlignment,
       if (widget.showRightAlignment!) Attribute.rightAlignment,
       if (widget.showJustifyAlignment!) Attribute.justifyAlignment
     ];
     final _valueString = <String>[
-      Attribute.leftAlignment.value!,
+      if (widget.showLeftAlignment!) Attribute.leftAlignment.value!,
       if (widget.showCenterAlignment!) Attribute.centerAlignment.value!,
       if (widget.showRightAlignment!) Attribute.rightAlignment.value!,
       if (widget.showJustifyAlignment!) Attribute.justifyAlignment.value!,
@@ -69,7 +71,7 @@ class _SelectAlignmentButtonState extends State<SelectAlignmentButton> {
 
     final theme = Theme.of(context);
     
-    final buttonCount = 1 + ((widget.showCenterAlignment!) ? 1 : 0) + ((widget.showRightAlignment!) ? 1 : 0) + ((widget.showJustifyAlignment!) ? 1 : 0);
+    final buttonCount = ((widget.showLeftAlignment!) ? 1 : 0) + ((widget.showCenterAlignment!) ? 1 : 0) + ((widget.showRightAlignment!) ? 1 : 0) + ((widget.showJustifyAlignment!) ? 1 : 0);
 
     return Row(
       mainAxisSize: MainAxisSize.min,

--- a/lib/src/widgets/toolbar/select_alignment_button.dart
+++ b/lib/src/widgets/toolbar/select_alignment_button.dart
@@ -20,7 +20,7 @@ class SelectAlignmentButton extends StatefulWidget {
   final double iconSize;
 
   final QuillIconTheme? iconTheme;
-  final bool showJustifyAlignment;
+  final bool? showJustifyAlignment;
 
   @override
   _SelectAlignmentButtonState createState() => _SelectAlignmentButtonState();

--- a/lib/src/widgets/toolbar/select_alignment_button.dart
+++ b/lib/src/widgets/toolbar/select_alignment_button.dart
@@ -12,8 +12,9 @@ class SelectAlignmentButton extends StatefulWidget {
     required this.controller,
     this.iconSize = kDefaultIconSize,
     this.iconTheme,
-    this.showJustifyAlignment,
+    this.showCenterAlignment,
     this.showRightAlignment,
+    this.showJustifyAlignment,
     Key? key,
   }) : super(key: key);
 
@@ -21,8 +22,9 @@ class SelectAlignmentButton extends StatefulWidget {
   final double iconSize;
 
   final QuillIconTheme? iconTheme;
-  final bool? showJustifyAlignment;
+  final bool? showCenterAlignment;
   final bool? showRightAlignment;
+  final bool? showJustifyAlignment;
 
   @override
   _SelectAlignmentButtonState createState() => _SelectAlignmentButtonState();
@@ -54,20 +56,20 @@ class _SelectAlignmentButtonState extends State<SelectAlignmentButton> {
 
     final _valueAttribute = <Attribute>[
       Attribute.leftAlignment,
-      Attribute.centerAlignment,
+      if (widget.showCenterAlignment!) Attribute.centerAlignment,
       if (widget.showRightAlignment!) Attribute.rightAlignment,
       if (widget.showJustifyAlignment!) Attribute.justifyAlignment
     ];
     final _valueString = <String>[
       Attribute.leftAlignment.value!,
-      Attribute.centerAlignment.value!,
+      if (widget.showCenterAlignment!) Attribute.centerAlignment.value!,
       if (widget.showRightAlignment!) Attribute.rightAlignment.value!,
       if (widget.showJustifyAlignment!) Attribute.justifyAlignment.value!,
     ];
 
     final theme = Theme.of(context);
     
-    final buttonCount = 2 + ((widget.showRightAlignment!) ? 1 : 0) + ((widget.showJustifyAlignment!) ? 1 : 0);
+    final buttonCount = 1 + ((widget.showCenterAlignment!) ? 1 : 0) + ((widget.showRightAlignment!) ? 1 : 0) + ((widget.showJustifyAlignment!) ? 1 : 0);
 
     return Row(
       mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
New bools added `showLeftAlignment`, `showCenterAlignment`, `showRightAlignment` and `showJustifyAlignment` allow us to turn those specific buttons on or off.  

This is in reference to issue https://github.com/singerdmx/flutter-quill/issues/449

(this is now my second ever PR!  this is fun..)