### PR TITLE
Add ability to hide/show Left, Center, Right and Justify alignment buttons

### DIFF
--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -79,6 +79,10 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     bool showBackgroundColorButton = true,
     bool showClearFormat = true,
     bool showAlignmentButtons = false,
+    bool showLeftAlignment = true,
+    bool showCenterAlignment = true,
+    bool showRightAlignment = true,
+    bool showJustifyAlignment = true,
     bool showHeaderStyle = true,
     bool showListNumbers = true,
     bool showListBullets = true,
@@ -130,6 +134,10 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           onImagePickCallback != null ||
           onVideoPickCallback != null,
       showAlignmentButtons,
+      showLeftAlignment,
+      showCenterAlignment,
+      showRightAlignment,
+      showJustifyAlignment, 
       showHeaderStyle,
       showListNumbers || showListBullets || showListCheck || showCodeBlock,
       showQuote || showIndent,
@@ -282,6 +290,10 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             controller: controller,
             iconSize: toolbarIconSize,
             iconTheme: iconTheme,
+            showLeftAlignment: showLeftAlignment,    
+            showCenterAlignment: showCenterAlignment,              
+            showRightAlignment: showRightAlignment,              
+            showJustifyAlignment: showJustifyAlignment,
           ),
         if (isButtonGroupShown[1] &&
             (isButtonGroupShown[2] ||

--- a/lib/src/widgets/toolbar/select_alignment_button.dart
+++ b/lib/src/widgets/toolbar/select_alignment_button.dart
@@ -12,6 +12,10 @@ class SelectAlignmentButton extends StatefulWidget {
     required this.controller,
     this.iconSize = kDefaultIconSize,
     this.iconTheme,
+    this.showLeftAlignment,
+    this.showCenterAlignment,
+    this.showRightAlignment,
+    this.showJustifyAlignment,
     Key? key,
   }) : super(key: key);
 
@@ -19,6 +23,10 @@ class SelectAlignmentButton extends StatefulWidget {
   final double iconSize;
 
   final QuillIconTheme? iconTheme;
+  final bool? showLeftAlignment;
+  final bool? showCenterAlignment;
+  final bool? showRightAlignment;
+  final bool? showJustifyAlignment;
 
   @override
   _SelectAlignmentButtonState createState() => _SelectAlignmentButtonState();
@@ -42,30 +50,32 @@ class _SelectAlignmentButtonState extends State<SelectAlignmentButton> {
   @override
   Widget build(BuildContext context) {
     final _valueToText = <Attribute, String>{
-      Attribute.leftAlignment: Attribute.leftAlignment.value!,
-      Attribute.centerAlignment: Attribute.centerAlignment.value!,
-      Attribute.rightAlignment: Attribute.rightAlignment.value!,
-      Attribute.justifyAlignment: Attribute.justifyAlignment.value!,
+      if (widget.showLeftAlignment!) Attribute.leftAlignment: Attribute.leftAlignment.value!,
+      if (widget.showCenterAlignment!) Attribute.centerAlignment: Attribute.centerAlignment.value!,
+      if (widget.showRightAlignment!) Attribute.rightAlignment: Attribute.rightAlignment.value!,
+      if (widget.showJustifyAlignment!) Attribute.justifyAlignment: Attribute.justifyAlignment.value!,
     };
 
     final _valueAttribute = <Attribute>[
-      Attribute.leftAlignment,
-      Attribute.centerAlignment,
-      Attribute.rightAlignment,
-      Attribute.justifyAlignment
+      if (widget.showLeftAlignment!) Attribute.leftAlignment,
+      if (widget.showCenterAlignment!) Attribute.centerAlignment,
+      if (widget.showRightAlignment!) Attribute.rightAlignment,
+      if (widget.showJustifyAlignment!) Attribute.justifyAlignment
     ];
     final _valueString = <String>[
-      Attribute.leftAlignment.value!,
-      Attribute.centerAlignment.value!,
-      Attribute.rightAlignment.value!,
-      Attribute.justifyAlignment.value!,
+      if (widget.showLeftAlignment!) Attribute.leftAlignment.value!,
+      if (widget.showCenterAlignment!) Attribute.centerAlignment.value!,
+      if (widget.showRightAlignment!) Attribute.rightAlignment.value!,
+      if (widget.showJustifyAlignment!) Attribute.justifyAlignment.value!,
     ];
 
     final theme = Theme.of(context);
+    
+    final buttonCount = ((widget.showLeftAlignment!) ? 1 : 0) + ((widget.showCenterAlignment!) ? 1 : 0) + ((widget.showRightAlignment!) ? 1 : 0) + ((widget.showJustifyAlignment!) ? 1 : 0);
 
     return Row(
       mainAxisSize: MainAxisSize.min,
-      children: List.generate(4, (index) {
+      children: List.generate(buttonCount, (index) {
         return Padding(
           padding: const EdgeInsets.symmetric(horizontal: !kIsWeb ? 1.0 : 5.0),
           child: ConstrainedBox(


### PR DESCRIPTION
New bools added `showLeftAlignment`, `showCenterAlignment`, `showRightAlignment` and `showJustifyAlignment` allow us to turn those specific buttons on or off.

This is in reference to issue #449

Hopefully it works this time!