### PR TITLE
Add a new parameter toolBarSectionSpacing to control the toolbar icon Wrap spacing

### DIFF
--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -444,7 +444,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
               alignment: WrapAlignment.center,
               runSpacing: 4,
               //spacing: toolbarSectionSpacing,
-              spacing:10,
+              spacing:9.0,
               children: children,
             )
           : Container(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -55,7 +55,6 @@ const double kDefaultIconSize = 18;
 // The factor of how much larger the button is in relation to the icon.
 const double kIconButtonFactor = 1.77;
 
-
 class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   const QuillToolbar({
     required this.children,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -56,7 +56,7 @@ const double kDefaultIconSize = 18;
 const double kIconButtonFactor = 1.77;
 
 // The default horizontal spacing between toolbar icon sections (Wrap spacing)
-const double _defaultToolbarSectionSpacing = 4;
+const int _defaultToolbarSectionSpacing = 4;
 
 class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   const QuillToolbar({

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -60,6 +60,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   const QuillToolbar({
     required this.children,
     this.toolBarHeight = 36,
+    this.toolBarSectionSpacing,
     this.color,
     this.filePickImpl,
     this.multiRowsDisplay,
@@ -70,7 +71,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   factory QuillToolbar.basic({
     required QuillController controller,
     double toolbarIconSize = kDefaultIconSize,
-    double toolBarSectionSpacing = 4,
+    double toolBarSectionSpacing,
     bool showBoldButton = true,
     bool showItalicButton = true,
     bool showSmallButton = false,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -71,6 +71,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   factory QuillToolbar.basic({
     required QuillController controller,
     double toolbarIconSize = kDefaultIconSize,
+    double toolBarSectionSpacing,
     bool showBoldButton = true,
     bool showItalicButton = true,
     bool showSmallButton = false,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -413,7 +413,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   final List<Widget> children;
   final double toolBarHeight;
-  final double toolBarSectionSpacing;
+  final double? toolBarSectionSpacing;
   final bool? multiRowsDisplay;
 
   /// The color of the toolbar.

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -56,7 +56,7 @@ const double kDefaultIconSize = 18;
 const double kIconButtonFactor = 1.77;
 
 // The default horizontal spacing between toolbar icon sections (Wrap spacing)
-const int _defaultToolbarSectionSpacing = 4;
+const int kDefaultToolbarSectionSpacing = 4;
 
 class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   const QuillToolbar({
@@ -72,7 +72,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   factory QuillToolbar.basic({
     required QuillController controller,
     double toolbarIconSize = kDefaultIconSize,
-    int toolbarSectionSpacing = _defaultToolbarSectionSpacing,
+    int toolbarSectionSpacing = kDefaultToolbarSectionSpacing,
     bool showBoldButton = true,
     bool showItalicButton = true,
     bool showSmallButton = false,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -443,7 +443,8 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           ? Wrap(
               alignment: WrapAlignment.center,
               runSpacing: 4,
-              spacing: toolbarSectionSpacing,
+              //spacing: toolbarSectionSpacing,
+              spacing:10,
               children: children,
             )
           : Container(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -433,7 +433,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-  //double get _toolBarSectionSpacing => toolBarSectionSpacing;
+  double get _toolBarSectionSpacing => toolBarSectionSpacing;
     
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -443,7 +443,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           ? Wrap(
               alignment: WrapAlignment.center,
               runSpacing: 4,
-              spacing:toolBarSectionSpacing,
+              spacing:_toolBarSectionSpacing,
               //spacing: _toolBarSectionSpacing,
               children: children,
             )

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -411,6 +411,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   final List<Widget> children;
   final double toolBarHeight;
+  final double toolBarSectionSpacing;
   final bool? multiRowsDisplay;
 
   /// The color of the toolbar.

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -443,7 +443,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           ? Wrap(
               alignment: WrapAlignment.center,
               runSpacing: 4,
-              spacing: toolBarSectionSpacing,
+              spacing: toolBarSectionSpacing ?? 4,
               children: children,
             )
           : Container(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -56,7 +56,7 @@ const double kDefaultIconSize = 18;
 const double kIconButtonFactor = 1.77;
 
 // The default horizontal spacing between toolbar icon sections (Wrap spacing)
-const int kDefaultToolbarSectionSpacing = 4;
+const double kDefaultToolbarSectionSpacing = 4.0;
 
 class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   const QuillToolbar({
@@ -72,7 +72,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   factory QuillToolbar.basic({
     required QuillController controller,
     double toolbarIconSize = kDefaultIconSize,
-    int toolbarSectionSpacing = kDefaultToolbarSectionSpacing,
+    double toolbarSectionSpacing = kDefaultToolbarSectionSpacing,
     bool showBoldButton = true,
     bool showItalicButton = true,
     bool showSmallButton = false,
@@ -433,7 +433,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-  int get _toolbarSectionSpacing => toolbarSectionSpacing;
+  int get toolbarSectionSpacing => _toolbarSectionSpacing;
     
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -60,7 +60,6 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   const QuillToolbar({
     required this.children,
     this.toolBarHeight = 36,
-    this.toolBarSectionSpacing = 4,
     this.color,
     this.filePickImpl,
     this.multiRowsDisplay,
@@ -443,8 +442,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           ? Wrap(
               alignment: WrapAlignment.center,
               runSpacing: 4,
-              spacing:_toolBarSectionSpacing,
-              //spacing: _toolBarSectionSpacing,
+              spacing: _toolBarSectionSpacing,
               children: children,
             )
           : Container(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -443,7 +443,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           ? Wrap(
               alignment: WrapAlignment.center,
               runSpacing: 4,
-              spacing: _toolbarSectionSpacing,
+              spacing: toolbarSectionSpacing,
               children: children,
             )
           : Container(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -60,7 +60,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   const QuillToolbar({
     required this.children,
     this.toolBarHeight = 36,
-    this.toolBarSectionSpacing,
+    this.toolBarSectionSpacing = 4,
     this.color,
     this.filePickImpl,
     this.multiRowsDisplay,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -60,6 +60,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   const QuillToolbar({
     required this.children,
     this.toolBarHeight = 36,
+    this.toolBarSectionSpacing,
     this.color,
     this.filePickImpl,
     this.multiRowsDisplay,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -60,6 +60,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   const QuillToolbar({
     required this.children,
     this.toolBarHeight = 36,
+    this.toolBarSectionSpacing,
     this.color,
     this.filePickImpl,
     this.multiRowsDisplay,
@@ -70,7 +71,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   factory QuillToolbar.basic({
     required QuillController controller,
     double toolbarIconSize = kDefaultIconSize,
-    double toolbarSectionSpacing = 4,
+    double toolBarSectionSpacing = 4,
     bool showBoldButton = true,
     bool showItalicButton = true,
     bool showSmallButton = false,
@@ -149,6 +150,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     return QuillToolbar(
       key: key,
       toolBarHeight: toolbarIconSize * 2,
+      toolBarSectionSpacing: toolBarSectionSpacing,
       multiRowsDisplay: multiRowsDisplay,
       locale: locale,
       children: [
@@ -411,7 +413,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   final List<Widget> children;
   final double toolBarHeight;
-  final double toolbarSectionSpacing;
+  final double? toolBarSectionSpacing;
   final bool? multiRowsDisplay;
 
   /// The color of the toolbar.
@@ -432,7 +434,6 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-  double get toolBarSectionSpacing2 => toolbarSectionSpacing;
     
   @override
   Widget build(BuildContext context) {
@@ -442,7 +443,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           ? Wrap(
               alignment: WrapAlignment.center,
               runSpacing: 4,
-              spacing: toolBarSectionSpacing2,
+              spacing: toolBarSectionSpacing,
               children: children,
             )
           : Container(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -55,6 +55,9 @@ const double kDefaultIconSize = 18;
 // The factor of how much larger the button is in relation to the icon.
 const double kIconButtonFactor = 1.77;
 
+// The default horizontal spacing between toolbar icon sections (Wrap spacing)
+const double _defaultToolbarSectionSpacing = 4;
+
 class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   const QuillToolbar({
     required this.children,
@@ -69,6 +72,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   factory QuillToolbar.basic({
     required QuillController controller,
     double toolbarIconSize = kDefaultIconSize,
+    int toolbarSectionSpacing = _defaultToolbarSectionSpacing,
     bool showBoldButton = true,
     bool showItalicButton = true,
     bool showSmallButton = false,
@@ -438,7 +442,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           ? Wrap(
               alignment: WrapAlignment.center,
               runSpacing: 4,
-              spacing: 4,
+              spacing: toolbarSectionSpacing,
               children: children,
             )
           : Container(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -411,7 +411,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   final List<Widget> children;
   final double toolBarHeight;
-  final double toolBarSectionSpacing;
+  final double toolbarSectionSpacing;
   final bool? multiRowsDisplay;
 
   /// The color of the toolbar.

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -433,7 +433,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-    
+
   @override
   Widget build(BuildContext context) {
     return I18n(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -60,7 +60,6 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   const QuillToolbar({
     required this.children,
     this.toolBarHeight = 36,
-    this.toolBarSectionSpacing = 4,
     this.color,
     this.filePickImpl,
     this.multiRowsDisplay,
@@ -71,7 +70,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   factory QuillToolbar.basic({
     required QuillController controller,
     double toolbarIconSize = kDefaultIconSize,
-    double toolBarSectionSpacing,
+    double toolbarSectionSpacing = 4,
     bool showBoldButton = true,
     bool showItalicButton = true,
     bool showSmallButton = false,
@@ -433,7 +432,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-  double get _toolBarSectionSpacing => toolBarSectionSpacing;
+  double get _toolBarSectionSpacing => toolbarSectionSpacing;
     
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -60,7 +60,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   const QuillToolbar({
     required this.children,
     this.toolBarHeight = 36,
-    this.toolBarSectionSpacing = 4,
+    this.toolBarSectionSpacing,
     this.color,
     this.filePickImpl,
     this.multiRowsDisplay,
@@ -443,6 +443,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           ? Wrap(
               alignment: WrapAlignment.center,
               runSpacing: 4,
+              spacing:toolBarSectionSpacing,
               //spacing: _toolBarSectionSpacing,
               children: children,
             )

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -432,7 +432,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-  double get _toolBarSectionSpacing => toolbarSectionSpacing;
+  double get toolBarSectionSpacing2 => toolbarSectionSpacing;
     
   @override
   Widget build(BuildContext context) {
@@ -442,7 +442,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           ? Wrap(
               alignment: WrapAlignment.center,
               runSpacing: 4,
-              spacing: _toolBarSectionSpacing,
+              spacing: toolBarSectionSpacing2,
               children: children,
             )
           : Container(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -433,7 +433,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-  int get toolbarSectionSpacing => _toolbarSectionSpacing;
+  int get toolbarSectionSpacing => toolbarSectionSpacing;
     
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -413,7 +413,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   final List<Widget> children;
   final double toolBarHeight;
-  final double? toolBarSectionSpacing;
+  final double toolBarSectionSpacing;
   final bool? multiRowsDisplay;
 
   /// The color of the toolbar.

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -433,7 +433,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-  double get toolbarSectionSpacing => toolbarSectionSpacing;
+  double get _toolbarSectionSpacing => toolbarSectionSpacing;
     
   @override
   Widget build(BuildContext context) {
@@ -443,8 +443,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           ? Wrap(
               alignment: WrapAlignment.center,
               runSpacing: 4,
-              //spacing: toolbarSectionSpacing,
-              spacing:9.0,
+              spacing: _toolbarSectionSpacing,
               children: children,
             )
           : Container(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -55,13 +55,12 @@ const double kDefaultIconSize = 18;
 // The factor of how much larger the button is in relation to the icon.
 const double kIconButtonFactor = 1.77;
 
-// The default horizontal spacing between toolbar icon sections (Wrap spacing)
-const double kDefaultToolbarSectionSpacing = 4.0;
 
 class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   const QuillToolbar({
     required this.children,
     this.toolBarHeight = 36,
+    this.toolBarSectionSpacing = 4,
     this.color,
     this.filePickImpl,
     this.multiRowsDisplay,
@@ -72,7 +71,6 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   factory QuillToolbar.basic({
     required QuillController controller,
     double toolbarIconSize = kDefaultIconSize,
-    double toolbarSectionSpacing = kDefaultToolbarSectionSpacing,
     bool showBoldButton = true,
     bool showItalicButton = true,
     bool showSmallButton = false,
@@ -433,7 +431,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-  double get _toolbarSectionSpacing => toolbarSectionSpacing;
+  double get _toolBarSectionSpacing => toolBarSectionSpacing;
     
   @override
   Widget build(BuildContext context) {
@@ -443,7 +441,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           ? Wrap(
               alignment: WrapAlignment.center,
               runSpacing: 4,
-              spacing: _toolbarSectionSpacing,
+              spacing: _toolBarSectionSpacing,
               children: children,
             )
           : Container(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -433,7 +433,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-  int get toolbarSectionSpacing => toolbarSectionSpacing;
+  double get toolbarSectionSpacing => toolbarSectionSpacing;
     
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -433,7 +433,8 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-
+  int get _toolbarSectionSpacing => toolbarSectionSpacing;
+    
   @override
   Widget build(BuildContext context) {
     return I18n(
@@ -442,7 +443,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           ? Wrap(
               alignment: WrapAlignment.center,
               runSpacing: 4,
-              spacing: toolbarSectionSpacing,
+              spacing: _toolbarSectionSpacing,
               children: children,
             )
           : Container(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -60,7 +60,6 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   const QuillToolbar({
     required this.children,
     this.toolBarHeight = 36,
-    this.toolBarSectionSpacing = 4,
     this.color,
     this.filePickImpl,
     this.multiRowsDisplay,
@@ -71,7 +70,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   factory QuillToolbar.basic({
     required QuillController controller,
     double toolbarIconSize = kDefaultIconSize,
-    double toolBarSectionSpacing,
+    double toolBarSectionSpacing = 4,
     bool showBoldButton = true,
     bool showItalicButton = true,
     bool showSmallButton = false,
@@ -432,7 +431,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-  double get _toolBarSectionSpacing => toolBarSectionSpacing;
+  //double get _toolBarSectionSpacing => toolBarSectionSpacing;
     
   @override
   Widget build(BuildContext context) {
@@ -442,7 +441,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           ? Wrap(
               alignment: WrapAlignment.center,
               runSpacing: 4,
-              spacing: _toolBarSectionSpacing,
+              //spacing: _toolBarSectionSpacing,
               children: children,
             )
           : Container(


### PR DESCRIPTION
The toolbar icons are in a Wrap, with the sections separated by the `spacing` parameter.   This opens the parameter up for us to modify via `toolBarSectionSpacing`

If possible please review my code, I might have made some noob mistakes in how its written, but it does work well