### PR TITLE
Allow alignment of the toolbar icons to match WrapAlignment

### DIFF
--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -439,6 +439,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
+  Map<ToolbarAlignment, WrapAlignment> alignmentMap = {ToolbarAlignment.center: WrapAlignment.center}
 
   @override
   Widget build(BuildContext context) {
@@ -446,12 +447,13 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
       initialLocale: locale,
       child: multiRowsDisplay ?? true
           ? Wrap(
-              alignment: (toolBarIconAlignment==ToolbarAlignment.left)
-                  ? WrapAlignment.left
-                  :(toolBarIconAlignment==ToolbarAlignment.center)
-                  ? WrapAlignment.center
-                  :(toolBarIconAlignment==ToolbarAlignment.right)
-                  ? WrapAlignment.right :  WrapAlignment.center,
+              alignment: alignmentMap,
+//               (toolBarIconAlignment==ToolbarAlignment.left)
+//                   ? WrapAlignment.left
+//                   :(toolBarIconAlignment==ToolbarAlignment.center)
+//                   ? WrapAlignment.center
+//                   :(toolBarIconAlignment==ToolbarAlignment.right)
+//                   ? WrapAlignment.right :  WrapAlignment.center,
               runSpacing: 4,
               spacing: toolBarSectionSpacing ?? 4,
               children: children,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -447,7 +447,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
       child: multiRowsDisplay ?? true
           ? Wrap(
               alignment: 
-              toolBarIconAlignment ?? WrapAlignment.center,
+              (toolBarIconAlignment) ? WrapAlignment.center : WrapAlignment.right,
 //               (toolBarIconAlignment==ToolbarAlignment.left)
 //                   ? WrapAlignment.left
 //                   :(toolBarIconAlignment==ToolbarAlignment.center)

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -417,7 +417,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   final List<Widget> children;
   final double toolBarHeight;
   final double? toolBarSectionSpacing;
-  final toolBarIconAlignment? toolBarIconAlignment;
+  final ToolbarAlignment? toolBarIconAlignment;
   final bool? multiRowsDisplay;
 
   /// The color of the toolbar.

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -439,7 +439,8 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-
+  Size get toolBarIconAlignment2 => toolBarIconAlignment;
+    
   @override
   Widget build(BuildContext context) {
     return I18n(
@@ -447,11 +448,11 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
       child: multiRowsDisplay ?? true
           ? Wrap(
               alignment: 
-              (toolBarIconAlignment==ToolbarAlignment.left)
+              (toolBarIconAlignment2==ToolbarAlignment.left)
                   ? WrapAlignment.left
-                  :(toolBarIconAlignment==ToolbarAlignment.center)
+                  :(toolBarIconAlignment2==ToolbarAlignment.center)
                   ? WrapAlignment.center
-                  :(toolBarIconAlignment==ToolbarAlignment.right)
+                  :(toolBarIconAlignment2==ToolbarAlignment.right)
                   ? WrapAlignment.right :  WrapAlignment.center,
               runSpacing: 4,
               spacing: toolBarSectionSpacing ?? 4,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -446,10 +446,12 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
       initialLocale: locale,
       child: multiRowsDisplay ?? true
           ? Wrap(
-              alignment: (toolBarIconAlignment == ToolbarAlignment.left) 
-                  ? WrapAlignment.left 
-                  : (toolBarIconAlignment == ToolbarAlignment.right) 
-                  ? WrapAlignment.right  : WrapAlignment.center,
+              alignment: (toolBarIconAlignment==ToolbarAlignment.left)
+                  ? WrapAlignment.left
+                  :(toolBarIconAlignment==ToolbarAlignment.center)
+                  ? WrapAlignment.center
+                  :(toolBarIconAlignment==ToolbarAlignment.right)
+                  ? WrapAlignment.right :  WrapAlignment.center,
               runSpacing: 4,
               spacing: toolBarSectionSpacing ?? 4,
               children: children,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -445,7 +445,10 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
       initialLocale: locale,
       child: multiRowsDisplay ?? true
           ? Wrap(
-              alignment: toolBarIconAlignment ?? WrapAlignment.center,
+              alignment: (toolBarIconAlignment == ToolbarAlignment.left) 
+                  ? WrapAlignment.left 
+                  : (toolBarIconAlignment == ToolbarAlignment.right) 
+                  ? WrapAlignment.right  : WrapAlignment.center
               runSpacing: 4,
               spacing: toolBarSectionSpacing ?? 4,
               children: children,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -439,7 +439,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-  Size get toolBarIconAlignment2 => toolBarIconAlignment;
+  ToolbarAlignment get toolBarIconAlignment2 => toolBarIconAlignment;
     
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -72,7 +72,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     required QuillController controller,
     double toolbarIconSize = kDefaultIconSize,
     double toolBarSectionSpacing = 4,
-    WrapAlignment toolBarIconAlignment = WrapAlignment.left,
+    WrapAlignment toolBarIconAlignment = WrapAlignment,
     bool showBoldButton = true,
     bool showItalicButton = true,
     bool showSmallButton = false,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -447,7 +447,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
       child: multiRowsDisplay ?? true
           ? Wrap(
               alignment: 
-              (toolBarIconAlignment) ? WrapAlignment.center : WrapAlignment.right,
+              (toolBarIconAlignment!) ? WrapAlignment.center : WrapAlignment.right,
 //               (toolBarIconAlignment==ToolbarAlignment.left)
 //                   ? WrapAlignment.left
 //                   :(toolBarIconAlignment==ToolbarAlignment.center)

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -154,6 +154,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
       key: key,
       toolBarHeight: toolbarIconSize * 2,
       toolBarSectionSpacing: toolBarSectionSpacing,
+      toolBarIconAlignment: toolBarIconAlignment,
       multiRowsDisplay: multiRowsDisplay,
       locale: locale,
       children: [
@@ -448,7 +449,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
               alignment: (toolBarIconAlignment == ToolbarAlignment.left) 
                   ? WrapAlignment.left 
                   : (toolBarIconAlignment == ToolbarAlignment.right) 
-                  ? WrapAlignment.right  : WrapAlignment.center
+                  ? WrapAlignment.right  : WrapAlignment.center,
               runSpacing: 4,
               spacing: toolBarSectionSpacing ?? 4,
               children: children,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -60,6 +60,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     required this.children,
     this.toolBarHeight = 36,
     this.toolBarSectionSpacing,
+    this.toolBarIconAlignment,
     this.color,
     this.filePickImpl,
     this.multiRowsDisplay,
@@ -71,6 +72,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     required QuillController controller,
     double toolbarIconSize = kDefaultIconSize,
     double toolBarSectionSpacing = 4,
+    WrapAlignment toolBarIconAlignment = WrapAlignment.left,
     bool showBoldButton = true,
     bool showItalicButton = true,
     bool showSmallButton = false,
@@ -413,6 +415,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   final List<Widget> children;
   final double toolBarHeight;
   final double? toolBarSectionSpacing;
+  final WrapAlignment? toolBarIconAlignment;
   final bool? multiRowsDisplay;
 
   /// The color of the toolbar.
@@ -440,7 +443,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
       initialLocale: locale,
       child: multiRowsDisplay ?? true
           ? Wrap(
-              alignment: WrapAlignment.center,
+              alignment: toolBarIconAlignment ?? WrapAlignment.center,
               runSpacing: 4,
               spacing: toolBarSectionSpacing ?? 4,
               children: children,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -439,7 +439,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-  Map<ToolbarAlignment, WrapAlignment> alignmentMap = {ToolbarAlignment.center: WrapAlignment.center}
+  Map<ToolbarAlignment, WrapAlignment> alignmentMap = {ToolbarAlignment.center: WrapAlignment.center};
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -446,8 +446,8 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
       initialLocale: locale,
       child: multiRowsDisplay ?? true
           ? Wrap(
-              alignment: 
-              (toolBarIconAlignment!) ? WrapAlignment.center : WrapAlignment.right,
+              alignment: WrapAlignment.right,
+//               (toolBarIconAlignment!) ? WrapAlignment.center : WrapAlignment.right,
 //               (toolBarIconAlignment==ToolbarAlignment.left)
 //                   ? WrapAlignment.left
 //                   :(toolBarIconAlignment==ToolbarAlignment.center)

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -418,7 +418,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   final List<Widget> children;
   final double toolBarHeight;
   final double? toolBarSectionSpacing;
-  final ToolbarAlignment toolBarIconAlignment;
+  final ToolbarAlignment? toolBarIconAlignment;
   final bool? multiRowsDisplay;
 
   /// The color of the toolbar.
@@ -447,12 +447,13 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
       child: multiRowsDisplay ?? true
           ? Wrap(
               alignment: 
-              (toolBarIconAlignment==ToolbarAlignment.left)
-                  ? WrapAlignment.left
-                  :(toolBarIconAlignment==ToolbarAlignment.center)
-                  ? WrapAlignment.center
-                  :(toolBarIconAlignment==ToolbarAlignment.right)
-                  ? WrapAlignment.right :  WrapAlignment.center,
+              toolBarIconAlignment ?? WrapAlignment.center,
+//               (toolBarIconAlignment==ToolbarAlignment.left)
+//                   ? WrapAlignment.left
+//                   :(toolBarIconAlignment==ToolbarAlignment.center)
+//                   ? WrapAlignment.center
+//                   :(toolBarIconAlignment==ToolbarAlignment.right)
+//                   ? WrapAlignment.right :  WrapAlignment.center,
               runSpacing: 4,
               spacing: toolBarSectionSpacing ?? 4,
               children: children,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -446,14 +446,13 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
       initialLocale: locale,
       child: multiRowsDisplay ?? true
           ? Wrap(
-              alignment: WrapAlignment.right,
-//               (toolBarIconAlignment!) ? WrapAlignment.center : WrapAlignment.right,
-//               (toolBarIconAlignment==ToolbarAlignment.left)
-//                   ? WrapAlignment.left
-//                   :(toolBarIconAlignment==ToolbarAlignment.center)
-//                   ? WrapAlignment.center
-//                   :(toolBarIconAlignment==ToolbarAlignment.right)
-//                   ? WrapAlignment.right :  WrapAlignment.center,
+              alignment: 
+              (toolBarIconAlignment==ToolbarAlignment.left)
+                  ? WrapAlignment.start
+                  :(toolBarIconAlignment==ToolbarAlignment.center)
+                  ? WrapAlignment.center
+                  :(toolBarIconAlignment==ToolbarAlignment.right)
+                  ? WrapAlignment.end :  WrapAlignment.center,
               runSpacing: 4,
               spacing: toolBarSectionSpacing ?? 4,
               children: children,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -49,7 +49,7 @@ typedef WebVideoPickImpl = Future<String?> Function(
 typedef MediaPickSettingSelector = Future<MediaPickSetting?> Function(
     BuildContext context);
 
-enum ToolbarAlignment{ left, center, right }
+enum ToolbarAlignment{ start, center, end }
 
 // The default size of the icon of a button.
 const double kDefaultIconSize = 18;
@@ -447,11 +447,11 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
       child: multiRowsDisplay ?? true
           ? Wrap(
               alignment: 
-              (toolBarIconAlignment==ToolbarAlignment.left)
+              (toolBarIconAlignment==ToolbarAlignment.start)
                   ? WrapAlignment.start
                   :(toolBarIconAlignment==ToolbarAlignment.center)
                   ? WrapAlignment.center
-                  :(toolBarIconAlignment==ToolbarAlignment.right)
+                  :(toolBarIconAlignment==ToolbarAlignment.end)
                   ? WrapAlignment.end :  WrapAlignment.center,
               runSpacing: 4,
               spacing: toolBarSectionSpacing ?? 4,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -439,7 +439,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-    
+
   @override
   Widget build(BuildContext context) {
     return I18n(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -418,7 +418,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   final List<Widget> children;
   final double toolBarHeight;
   final double? toolBarSectionSpacing;
-  final ToolbarAlignment? toolBarIconAlignment;
+  final ToolbarAlignment toolBarIconAlignment;
   final bool? multiRowsDisplay;
 
   /// The color of the toolbar.
@@ -439,7 +439,6 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-  ToolbarAlignment get toolBarIconAlignment2 => toolBarIconAlignment;
     
   @override
   Widget build(BuildContext context) {
@@ -448,11 +447,11 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
       child: multiRowsDisplay ?? true
           ? Wrap(
               alignment: 
-              (toolBarIconAlignment2==ToolbarAlignment.left)
+              (toolBarIconAlignment==ToolbarAlignment.left)
                   ? WrapAlignment.left
-                  :(toolBarIconAlignment2==ToolbarAlignment.center)
+                  :(toolBarIconAlignment==ToolbarAlignment.center)
                   ? WrapAlignment.center
-                  :(toolBarIconAlignment2==ToolbarAlignment.right)
+                  :(toolBarIconAlignment==ToolbarAlignment.right)
                   ? WrapAlignment.right :  WrapAlignment.center,
               runSpacing: 4,
               spacing: toolBarSectionSpacing ?? 4,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -439,7 +439,6 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => Size.fromHeight(toolBarHeight);
-  Map<ToolbarAlignment, WrapAlignment> alignmentMap = {ToolbarAlignment.center: WrapAlignment.center};
 
   @override
   Widget build(BuildContext context) {
@@ -447,13 +446,13 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
       initialLocale: locale,
       child: multiRowsDisplay ?? true
           ? Wrap(
-              alignment: alignmentMap,
-//               (toolBarIconAlignment==ToolbarAlignment.left)
-//                   ? WrapAlignment.left
-//                   :(toolBarIconAlignment==ToolbarAlignment.center)
-//                   ? WrapAlignment.center
-//                   :(toolBarIconAlignment==ToolbarAlignment.right)
-//                   ? WrapAlignment.right :  WrapAlignment.center,
+              alignment: 
+              (toolBarIconAlignment==ToolbarAlignment.left)
+                  ? WrapAlignment.left
+                  :(toolBarIconAlignment==ToolbarAlignment.center)
+                  ? WrapAlignment.center
+                  :(toolBarIconAlignment==ToolbarAlignment.right)
+                  ? WrapAlignment.right :  WrapAlignment.center,
               runSpacing: 4,
               spacing: toolBarSectionSpacing ?? 4,
               children: children,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -49,6 +49,8 @@ typedef WebVideoPickImpl = Future<String?> Function(
 typedef MediaPickSettingSelector = Future<MediaPickSetting?> Function(
     BuildContext context);
 
+enum ToolbarAlignment{ left, center, right }
+
 // The default size of the icon of a button.
 const double kDefaultIconSize = 18;
 
@@ -72,7 +74,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     required QuillController controller,
     double toolbarIconSize = kDefaultIconSize,
     double toolBarSectionSpacing = 4,
-    WrapAlignment toolBarIconAlignment = WrapAlignment,
+    ToolbarAlignment toolBarIconAlignment = ToolbarAlignment.center,
     bool showBoldButton = true,
     bool showItalicButton = true,
     bool showSmallButton = false,
@@ -415,7 +417,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   final List<Widget> children;
   final double toolBarHeight;
   final double? toolBarSectionSpacing;
-  final WrapAlignment? toolBarIconAlignment;
+  final toolBarIconAlignment? toolBarIconAlignment;
   final bool? multiRowsDisplay;
 
   /// The color of the toolbar.


### PR DESCRIPTION
Currently, the toolbar is inside a `Wrap` which is set to `WrapAlignment.center`, this opens up `WrapAlignment.start` and `WrapAlignment.end` by creating a new enum: `ToolbarAlignment` via `toolBarIconAlignment`

We now have `ToolbarAlignment.start`, `ToolbarAlignment.center` and `ToolbarAlignment.end` with `ToolbarAlignment.center` as the default so it looks the same as it was before

```
QuillToolbar.basic(
...
toolBarIconAlignment:ToolbarAlignment.start,
)
```

Let me know if I hosed anything up!