### PR TITLE
Fixes bug where the divider is doubled if showheaderstyle is turned off

### DIFF
--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -318,7 +318,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             iconSize: toolbarIconSize,
             iconTheme: iconTheme,
           ),
-        if (showDividers && isButtonGroupShown[2] &&
+        if (showDividers && showHeaderStyle && isButtonGroupShown[2] &&
             (isButtonGroupShown[3] ||
                 isButtonGroupShown[4] ||
                 isButtonGroupShown[5]))


### PR DESCRIPTION
When showheaderstyle is turned off then you result with two dividers back to back, this turns off the trailing divider if showheaderstyle is false