### PR TITLE
Option to disable floating cursor

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -242,6 +242,7 @@ class QuillEditor extends StatefulWidget {
       this.onSingleLongTapEnd,
       this.embedBuilder = defaultEmbedBuilder,
       this.customStyleBuilder,
+      this.floatingCursorDisabled = false,
       Key? key});
 
   factory QuillEditor.basic({
@@ -305,6 +306,8 @@ class QuillEditor extends StatefulWidget {
 
   final EmbedBuilder embedBuilder;
   final CustomStyleBuilder? customStyleBuilder;
+
+  final bool floatingCursorDisabled;
 
   @override
   _QuillEditorState createState() => _QuillEditorState();
@@ -408,6 +411,7 @@ class _QuillEditorState extends State<QuillEditor>
       scrollPhysics: widget.scrollPhysics,
       embedBuilder: widget.embedBuilder,
       customStyleBuilder: widget.customStyleBuilder,
+      floatingCursorDisabled: widget.floatingCursorDisabled,
     );
 
     return _selectionGestureDetectorBuilder.build(
@@ -692,7 +696,8 @@ class RenderEditor extends RenderEditableContainerBox
       this._startHandleLayerLink,
       this._endHandleLayerLink,
       EdgeInsets floatingCursorAddedMargin,
-      this._cursorController)
+      this._cursorController,
+      this.floatingCursorDisabled)
       : super(
           children,
           document.root,
@@ -702,6 +707,7 @@ class RenderEditor extends RenderEditableContainerBox
         );
 
   final CursorCont _cursorController;
+  final bool floatingCursorDisabled;
 
   Document document;
   TextSelection selection;
@@ -1214,6 +1220,8 @@ class RenderEditor extends RenderEditableContainerBox
   void setFloatingCursor(FloatingCursorDragState dragState,
       Offset boundedOffset, TextPosition textPosition,
       {double? resetLerpValue}) {
+    if (floatingCursorDisabled) return;
+
     if (dragState == FloatingCursorDragState.Start) {
       _relativeOrigin = Offset.zero;
       _previousOffset = null;

--- a/lib/src/widgets/raw_editor.dart
+++ b/lib/src/widgets/raw_editor.dart
@@ -63,6 +63,7 @@ class RawEditor extends StatefulWidget {
     this.scrollPhysics,
     this.embedBuilder = defaultEmbedBuilder,
     this.customStyleBuilder,
+    this.floatingCursorDisabled = false
   })  : assert(maxHeight == null || maxHeight > 0, 'maxHeight cannot be null'),
         assert(minHeight == null || minHeight >= 0, 'minHeight cannot be null'),
         assert(maxHeight == null || minHeight == null || maxHeight >= minHeight,
@@ -95,6 +96,8 @@ class RawEditor extends StatefulWidget {
   final ScrollPhysics? scrollPhysics;
   final EmbedBuilder embedBuilder;
   final CustomStyleBuilder? customStyleBuilder;
+  final bool floatingCursorDisabled;
+
   @override
   State<StatefulWidget> createState() => RawEditorState();
 }
@@ -167,6 +170,7 @@ class RawEditorState extends EditorState
           onSelectionChanged: _handleSelectionChanged,
           scrollBottomInset: widget.scrollBottomInset,
           padding: widget.padding,
+          floatingCursorDisabled: widget.floatingCursorDisabled,
           children: _buildChildren(_doc, context),
         ),
       ),
@@ -196,6 +200,7 @@ class RawEditorState extends EditorState
               scrollBottomInset: widget.scrollBottomInset,
               padding: widget.padding,
               cursorController: _cursorCont,
+              floatingCursorDisabled: widget.floatingCursorDisabled,
               children: _buildChildren(_doc, context),
             ),
           ),
@@ -812,6 +817,7 @@ class _Editor extends MultiChildRenderObjectWidget {
     required this.onSelectionChanged,
     required this.scrollBottomInset,
     required this.cursorController,
+    required this.floatingCursorDisabled,
     this.padding = EdgeInsets.zero,
     this.offset,
   }) : super(key: key, children: children);
@@ -827,6 +833,7 @@ class _Editor extends MultiChildRenderObjectWidget {
   final double scrollBottomInset;
   final EdgeInsetsGeometry padding;
   final CursorCont cursorController;
+  final bool floatingCursorDisabled;
 
   @override
   RenderEditor createRenderObject(BuildContext context) {
@@ -843,7 +850,8 @@ class _Editor extends MultiChildRenderObjectWidget {
         startHandleLayerLink,
         endHandleLayerLink,
         const EdgeInsets.fromLTRB(4, 4, 4, 5),
-        cursorController);
+        cursorController,
+        floatingCursorDisabled);
   }
 
   @override

--- a/lib/src/widgets/simple_viewer.dart
+++ b/lib/src/widgets/simple_viewer.dart
@@ -158,6 +158,7 @@ class _QuillSimpleViewerState extends State<QuillSimpleViewer>
             scrollBottomInset: widget.scrollBottomInset,
             padding: widget.padding,
             cursorController: _cursorCont,
+            floatingCursorDisabled: true,
             children: _buildChildren(_doc, context)),
       ),
     );
@@ -316,6 +317,7 @@ class _SimpleViewer extends MultiChildRenderObjectWidget {
     required this.onSelectionChanged,
     required this.scrollBottomInset,
     required this.cursorController,
+    required this.floatingCursorDisabled,
     this.offset,
     this.padding = EdgeInsets.zero,
     Key? key,
@@ -330,6 +332,7 @@ class _SimpleViewer extends MultiChildRenderObjectWidget {
   final double scrollBottomInset;
   final EdgeInsetsGeometry padding;
   final CursorCont cursorController;
+  final bool floatingCursorDisabled;
 
   @override
   RenderEditor createRenderObject(BuildContext context) {
@@ -347,7 +350,8 @@ class _SimpleViewer extends MultiChildRenderObjectWidget {
         startHandleLayerLink,
         endHandleLayerLink,
         const EdgeInsets.fromLTRB(4, 4, 4, 5),
-        cursorController);
+        cursorController,
+        floatingCursorDisabled);
   }
 
   @override


### PR DESCRIPTION
Moving cursor using keyboard on iOS is great, but the floating cursor works awful. 
I tried to fix it, spent some time debugging, but unfortunately I have no more time at the moment.

So I decided just to disable the floating cursor. Cursor moving works without a floating cursor.
I added new argument to QuillEditor.