### PR TITLE
Request keyboard focus when no child is found

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -599,16 +599,22 @@ class _QuillEditorSelectionGestureDetectorBuilder
               break;
             case PointerDeviceKind.touch:
             case PointerDeviceKind.unknown:
-              getRenderEditor()!.selectWordEdge(SelectionChangedCause.tap);
-              break;
+              try {
+                getRenderEditor()!.selectWordEdge(SelectionChangedCause.tap);
+              } finally {
+                break;
+              }
           }
           break;
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
-          getRenderEditor()!.selectPosition(SelectionChangedCause.tap);
-          break;
+          try {
+            getRenderEditor()!.selectPosition(SelectionChangedCause.tap);
+          } finally {
+            break;
+          }
       }
     }
     _state._requestKeyboard();


### PR DESCRIPTION
`getRenderEditor()!.selectWordEdge` and
`getRenderEditor().selectPosition` currently throw a `'No child'` which
prevents the field from focusing. This happens when `minHeight` is set
and the whole field is not filled with content from the editor (e. g.
it's empty or only one line has some data).

This change catches the `'No child'` exception and lets the code to
continue its execution and request field focus.