### PR TITLE
Do not show caret on screen when the editor is not focused

### DIFF
--- a/lib/src/widgets/raw_editor.dart
+++ b/lib/src/widgets/raw_editor.dart
@@ -422,7 +422,7 @@ class RawEditorState extends EditorState
           _keyboardVisibilityController?.onChange.listen((visible) {
         _keyboardVisible = visible;
         if (visible) {
-          _onChangeTextEditingValue();
+          _onChangeTextEditingValue(!_hasFocus);
         }
       });
     }


### PR DESCRIPTION
For some reason, `RawEditorState.initState` is called every time I focus
a `TextField` inside a scrollable view which uses the `ScrollController`
that is passed to `QuillEditor.scrollController`. And, `RawEditorState.initState`
calls `RawEditorState._onChangeTextEditingValue` which make sure that
caret is visible on the screen if `ignoreCaret` is not `true`.
In this commit I set `ignoreCaret` to opposite of `_hasFocus` so that
caret is displayed only when the text field is focused. These changes
make it easier to use `QuillEditor` in a list with other text fields.