### PR TITLE
Feature: add selection completed callback

### DIFF
--- a/lib/src/widgets/controller.dart
+++ b/lib/src/widgets/controller.dart
@@ -20,6 +20,7 @@ class QuillController extends ChangeNotifier {
     bool keepStyleOnNewLine = false,
     this.onReplaceText,
     this.onDelete,
+    this.onSelectionCompleted,
   })  : _selection = selection,
         _keepStyleOnNewLine = keepStyleOnNewLine;
 
@@ -47,6 +48,8 @@ class QuillController extends ChangeNotifier {
 
   /// Custom delete handler
   DeleteCallback? onDelete;
+
+  void Function()? onSelectionCompleted;
 
   /// Store any styles attribute that got toggled by the tap of a button
   /// and that has not been applied yet.
@@ -241,10 +244,6 @@ class QuillController extends ChangeNotifier {
     _updateSelection(textSelection, source);
     notifyListeners();
   }
-
-  // callback sub classes can override to implement actions when a selection is
-  // completed.
-  void selectionCompleted() {}
 
   void compose(Delta delta, TextSelection textSelection, ChangeSource source) {
     if (delta.isNotEmpty) {

--- a/lib/src/widgets/controller.dart
+++ b/lib/src/widgets/controller.dart
@@ -242,6 +242,10 @@ class QuillController extends ChangeNotifier {
     notifyListeners();
   }
 
+  // callback sub classes can override to implement actions when a selection is
+  // completed.
+  void selectionCompleted() {}
+
   void compose(Delta delta, TextSelection textSelection, ChangeSource source) {
     if (delta.isNotEmpty) {
       document.compose(delta, source);

--- a/lib/src/widgets/raw_editor.dart
+++ b/lib/src/widgets/raw_editor.dart
@@ -377,7 +377,7 @@ class RawEditorState extends EditorState
   }
 
   void _handleSelectionCompleted() {
-    widget.controller.selectionCompleted();
+    widget.controller.onSelectionCompleted?.call();
   }
 
   /// Updates the checkbox positioned at [offset] in document

--- a/lib/src/widgets/raw_editor.dart
+++ b/lib/src/widgets/raw_editor.dart
@@ -288,6 +288,7 @@ class RawEditorState extends EditorState
           startHandleLayerLink: _startHandleLayerLink,
           endHandleLayerLink: _endHandleLayerLink,
           onSelectionChanged: _handleSelectionChanged,
+          onSelectionCompleted: _handleSelectionCompleted,
           scrollBottomInset: widget.scrollBottomInset,
           padding: widget.padding,
           maxContentWidth: widget.maxContentWidth,
@@ -318,6 +319,7 @@ class RawEditorState extends EditorState
               startHandleLayerLink: _startHandleLayerLink,
               endHandleLayerLink: _endHandleLayerLink,
               onSelectionChanged: _handleSelectionChanged,
+              onSelectionCompleted: _handleSelectionCompleted,
               scrollBottomInset: widget.scrollBottomInset,
               padding: widget.padding,
               maxContentWidth: widget.maxContentWidth,
@@ -372,6 +374,10 @@ class RawEditorState extends EditorState
         bringIntoView(selection.extent);
       }
     }
+  }
+
+  void _handleSelectionCompleted() {
+    widget.controller.selectionCompleted();
   }
 
   /// Updates the checkbox positioned at [offset] in document
@@ -793,6 +799,9 @@ class RawEditorState extends EditorState
     }
     textEditingValue = value;
     userUpdateTextEditingValue(value, cause);
+
+    // keyboard and text input force a selection completion
+    _handleSelectionCompleted();
   }
 
   @override
@@ -914,6 +923,7 @@ class _Editor extends MultiChildRenderObjectWidget {
     required this.startHandleLayerLink,
     required this.endHandleLayerLink,
     required this.onSelectionChanged,
+    required this.onSelectionCompleted,
     required this.scrollBottomInset,
     required this.cursorController,
     required this.floatingCursorDisabled,
@@ -930,6 +940,7 @@ class _Editor extends MultiChildRenderObjectWidget {
   final LayerLink startHandleLayerLink;
   final LayerLink endHandleLayerLink;
   final TextSelectionChangedHandler onSelectionChanged;
+  final TextSelectionCompletedHandler onSelectionCompleted;
   final double scrollBottomInset;
   final EdgeInsetsGeometry padding;
   final double? maxContentWidth;
@@ -947,6 +958,7 @@ class _Editor extends MultiChildRenderObjectWidget {
         startHandleLayerLink: startHandleLayerLink,
         endHandleLayerLink: endHandleLayerLink,
         onSelectionChanged: onSelectionChanged,
+        onSelectionCompleted: onSelectionCompleted,
         cursorController: cursorController,
         padding: padding,
         maxContentWidth: maxContentWidth,


### PR DESCRIPTION
This PR is to implement a feature to allow the `QuillController` to notify when a selection process has completed. In the use case I'm facing, I need to update the UI when discrete selection events have concluded (such as a drag), but right now it's impossible to differentiate between drag update and drag end events. Thus the proposal for this feature. As described in the comments of the PR:

> Selection completion is defined as when the user input has concluded for an entire selection action. For simple taps and keyboard input events that change the selection, this callback is invoked immediately following the `TextSelectionChangedHandler`. For long taps, the selection is considered complete at the up event of a long tap. For drag selections, the selection completes once the drag/pan event ends or is interrupted.

Thanks for considering this PR.
