### PR TITLE
feat: support multiple links insertion on the go

### DIFF
--- a/lib/src/models/rules/insert.dart
+++ b/lib/src/models/rules/insert.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_quill/flutter_quill.dart';
 import 'package:tuple/tuple.dart';
 
 import '../documents/attribute.dart';
@@ -286,44 +287,107 @@ class InsertEmbedsRule extends InsertRule {
   }
 }
 
-/// Applies link format to text segment (which looks like a link) when user
-/// inserts space character after it.
+/// Applies link format to text segments within the inserted text that matches
+/// the URL pattern.
+///
+/// The link attribute is applied as the user types.
 class AutoFormatLinksRule extends InsertRule {
   const AutoFormatLinksRule();
 
+  /// Link pattern.
+  ///
+  /// This pattern is used to match a links within a text segment.
+  static const _linkPattern =
+      r'(https?:\/\/|www\.)[\w-\.]+\.[\w-\.]+(\/([\S]+)?)?';
+  static final _linkRegExp = RegExp(_linkPattern);
+
   @override
-  Delta? applyRule(Delta document, int index,
-      {int? len, Object? data, Attribute? attribute}) {
-    if (data is! String || data != ' ') {
-      return null;
+  Delta? applyRule(
+    Delta document,
+    int index, {
+    int? len,
+    Object? data,
+    Attribute? attribute,
+  }) {
+    // Only format when inserting text.
+    if (data is! String) return null;
+
+    // Get current text.
+    final entireText = Document.fromDelta(document).toPlainText();
+
+    // Get word before insertion.
+    final leftWordPart = entireText
+        // Keep all text before insertion.
+        .substring(0, index)
+        // Keep last paragraph.
+        .split('\n')
+        .last
+        // Keep last word.
+        .split(' ')
+        .last
+        .trimLeft();
+
+    // Get word after insertion.
+    final rightWordPart = entireText
+        // Keep all text after insertion.
+        .substring(index)
+        // Keep first paragraph.
+        .split('\n')
+        .first
+        // Keep first word.
+        .split(' ')
+        .first
+        .trimRight();
+
+    // Build the segment of affected words.
+    final affectedWords = '$leftWordPart$data$rightWordPart';
+
+    // Check for URL pattern.
+    final matches = _linkRegExp.allMatches(affectedWords);
+
+    // If there are no matches, do not apply any format.
+    if (matches.isEmpty) return null;
+
+    // Build base delta.
+    // The base delta is a simple insertion delta.
+    final baseDelta = Delta()
+      ..retain(index)
+      ..insert(data);
+
+    // Get unchanged text length.
+    final unmodifiedLength = index - leftWordPart.length;
+
+    // Create formatter delta.
+    // The formatter delta will only include links formatting when needed.
+    final formatterDelta = Delta()..retain(unmodifiedLength);
+
+    var previousLinkEndRelativeIndex = 0;
+    for (final match in matches) {
+      // Get the size of the leading segment of text that is not part of the
+      // link.
+      final separationLength = match.start - previousLinkEndRelativeIndex;
+
+      // Get the identified link.
+      final link = affectedWords.substring(match.start, match.end);
+
+      // Keep the leading segment of text and add link with its proper
+      // attribute.
+      formatterDelta
+        ..retain(separationLength, LinkAttribute(null).toJson())
+        ..retain(link.length, LinkAttribute(link).toJson());
+
+      // Update reference index.
+      previousLinkEndRelativeIndex = match.end;
     }
 
-    final itr = DeltaIterator(document);
-    final prev = itr.skip(index);
-    if (prev == null || prev.data is! String) {
-      return null;
-    }
+    // Get remaining text length.
+    final remainingLength = affectedWords.length - previousLinkEndRelativeIndex;
 
-    try {
-      final cand = (prev.data as String).split('\n').last.split(' ').last;
-      final link = Uri.parse(cand);
-      if (!['https', 'http'].contains(link.scheme)) {
-        return null;
-      }
-      final attributes = prev.attributes ?? <String, dynamic>{};
+    // Remove links from remaining non-link text.
+    formatterDelta.retain(remainingLength, LinkAttribute(null).toJson());
 
-      if (attributes.containsKey(Attribute.link.key)) {
-        return null;
-      }
-
-      attributes.addAll(LinkAttribute(link.toString()).toJson());
-      return Delta()
-        ..retain(index + (len ?? 0) - cand.length)
-        ..retain(cand.length, attributes)
-        ..insert(data, prev.attributes);
-    } on FormatException {
-      return null;
-    }
+    // Build and return resulting change delta.
+    return baseDelta.compose(formatterDelta);
   }
 }
 

--- a/lib/src/models/rules/rule.dart
+++ b/lib/src/models/rules/rule.dart
@@ -43,6 +43,7 @@ class Rules {
     const PreserveLineStyleOnSplitRule(),
     const ResetLineFormatOnNewLineRule(),
     const AutoFormatLinksRule(),
+    const AutoFormatMultipleLinksRule(),
     const PreserveInlineStylesRule(),
     const CatchAllInsertRule(),
     const EnsureEmbedLineRule(),


### PR DESCRIPTION
## Details

- Apply link attribute as the user types.
- Support link attributes assignation when pasting a block of text.
- Apply or remove the link attribute to the words around the insertion, considering the resulting affected text segments.
- Use regular expressions to check if a URL is acceptable or valid. The pattern in use is `r'(https?:\/\/|www\.)[\w-\.]+\.[\w-\.]+(\/([\S]+)?)?'` but a better one might replace it.

## Manual testing

1. Run the `example` demo app.
2. Insert the following text:
	```
	Lorem ipsum dolor sit amet, consectetur www.google.com adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation http://google.com ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse https://www.google.com cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
	```
The included URLs should be formatted with the link attribute.

## Related issues

- Might close #578 