### PR TITLE
Pass any specified key in QuillEditor constructor to super

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -270,7 +270,7 @@ class QuillEditor extends StatefulWidget {
       this.linkActionPickerDelegate = defaultLinkActionPickerDelegate,
       this.customStyleBuilder,
       this.floatingCursorDisabled = false,
-      Key? key});
+      Key? key}) : super(key: key);
 
   factory QuillEditor.basic({
     required QuillController controller,


### PR DESCRIPTION
I'm passing in a GlobalKey to QuillEditor so I can later determine cursor/last selection handle position.


// pass the following into QuillEditor constructor
  GlobalKey flutterQuillKey;
  ScrollController _scrollController = ScrollController();
  QuillController _controller =  QuillController(document: doc, selection: const TextSelection.collapsed(offset: 0));
  ...
  // elsewhere in callback
  final textSelectionPoint =
          (flutterQuillKey.currentState as EditorTextSelectionGestureDetectorBuilderDelegate)
              .editableTextKey
              .currentState
              .renderEditor
              .getEndpointsForSelection(_controller.selection)
              .last;

      final renderObject = flutterQuillKey.currentContext.findRenderObject();

      if (renderObject is RenderPointerListener) {
        final x = textSelectionPoint.point.dx;
        final y = textSelectionPoint.point.dy - _scrollController.offset;

        // cursor is located at x,y
     }