### PR TITLE
fix selection overlay for collapsed selection

### DIFF
--- a/lib/src/widgets/raw_editor.dart
+++ b/lib/src/widgets/raw_editor.dart
@@ -695,15 +695,13 @@ class RawEditorState extends EditorState
 
   void _updateOrDisposeSelectionOverlayIfNeeded() {
     if (_selectionOverlay != null) {
-      if (_hasFocus && !textEditingValue.selection.isCollapsed) {
-        _selectionOverlay!.update(textEditingValue);
-      } else {
+      if (!_hasFocus) {
         _selectionOverlay!.dispose();
         _selectionOverlay = null;
+      } else if (!textEditingValue.selection.isCollapsed) {
+        _selectionOverlay!.update(textEditingValue);
       }
     } else if (_hasFocus) {
-      _selectionOverlay?.hide();
-
       _selectionOverlay = EditorTextSelectionOverlay(
         value: textEditingValue,
         context: context,

--- a/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -306,7 +306,7 @@ mixin RawEditorStateTextInputClientMixin on EditorState
         }
         final size = renderEditor.size;
         final transform = renderEditor.getTransformTo(null);
-        _textInputConnection!.setEditableSizeAndTransform(size, transform);
+        _textInputConnection?.setEditableSizeAndTransform(size, transform);
       });
     }
   }


### PR DESCRIPTION
If _hasFocus and selection is collapsed then overlay is disposed and toolbar doesn't show.
Fixed that issue.