### PR TITLE
Refactor _QuillEditorState to QuillEditorState

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -374,10 +374,10 @@ class QuillEditor extends StatefulWidget {
   final bool floatingCursorDisabled;
 
   @override
-  _QuillEditorState createState() => _QuillEditorState();
+  QuillEditorState createState() => QuillEditorState();
 }
 
-class _QuillEditorState extends State<QuillEditor>
+class QuillEditorState extends State<QuillEditor>
     implements EditorTextSelectionGestureDetectorBuilderDelegate {
   final GlobalKey<EditorState> _editorKey = GlobalKey<EditorState>();
   late EditorTextSelectionGestureDetectorBuilder
@@ -494,7 +494,7 @@ class _QuillEditorSelectionGestureDetectorBuilder
   _QuillEditorSelectionGestureDetectorBuilder(this._state)
       : super(delegate: _state);
 
-  final _QuillEditorState _state;
+  final QuillEditorState _state;
 
   @override
   void onForcePressStart(ForcePressDetails details) {


### PR DESCRIPTION
To get current caret location, I was using - final textSelectionPoint =
(_quillEditorGlobalKey.currentState as EditorTextSelectionGestureDetectorBuilderDelegate)
.editableTextKey
.currentState
.renderEditor
.getEndpointsForSelection(_quillController.selection)
.last;

Now that EditorTextSelectionGestureDetectorBuilderDelegate is under src getting a warning if I expose it in my code.  Changing the state to public allows me to use the following instead.

(_quillEditorGlobalKey.currentState as QuillEditorState)
.editableTextKey
.currentState
.renderEditor
.getEndpointsForSelection(_quillController.selection)
.last;