### PR TITLE
Fix certain keys not working on web when editor is in a scroll view (#304)

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -469,10 +469,26 @@ class QuillEditorState extends State<QuillEditor>
       floatingCursorDisabled: widget.floatingCursorDisabled,
     );
 
-    return _selectionGestureDetectorBuilder.build(
+    final editor = _selectionGestureDetectorBuilder.build(
       behavior: HitTestBehavior.translucent,
       child: child,
     );
+
+    if (kIsWeb) {
+      // Intercept RawKeyEvent on Web to prevent it from propagating to parents
+      // that might interfere with the editor key behavior, such as
+      // SingleChildScrollView. Thanks to @wliumelb for the workaround.
+      // See issue https://github.com/singerdmx/flutter-quill/issues/304
+      return RawKeyboardListener(
+        onKey: (_) {},
+        focusNode: FocusNode(
+          onKey: (node, event) => KeyEventResult.skipRemainingHandlers,
+        ),
+        child: editor,
+      );
+    }
+
+    return editor;
   }
 
   @override


### PR DESCRIPTION
Implements the fix proposed by @wliumelb from issue #304 