### PR TITLE
add .moveCursorToPosition(integer)

### DIFF
--- a/lib/src/widgets/controller.dart
+++ b/lib/src/widgets/controller.dart
@@ -259,6 +259,11 @@ class QuillController extends ChangeNotifier {
         const TextSelection.collapsed(offset: 0), ChangeSource.LOCAL);
   }
 
+  void moveCursorToPosition(int position) {
+    updateSelection(
+        TextSelection.collapsed(offset: position), ChangeSource.LOCAL);
+  }
+  
   void moveCursorToEnd() {
     updateSelection(
         TextSelection.collapsed(offset: plainTextEditingValue.text.length),


### PR DESCRIPTION
added `.moveCursorToPosition(integer)` to allow us to move the cursor to a specific position

If too low or too high a number is provided, it seems to correctly land at the start and end of the document