### PR TITLE
export style class

### DIFF
--- a/lib/flutter_quill.dart
+++ b/lib/flutter_quill.dart
@@ -4,6 +4,7 @@ export 'src/models/documents/attribute.dart';
 export 'src/models/documents/document.dart';
 export 'src/models/documents/nodes/embeddable.dart';
 export 'src/models/documents/nodes/leaf.dart';
+export 'src/models/documents/style.dart';
 export 'src/models/quill_delta.dart';
 export 'src/models/themes/quill_dialog_theme.dart';
 export 'src/models/themes/quill_icon_theme.dart';


### PR DESCRIPTION
flutter quill does not export Style class. i.e. the controller method getSelectionStyle() returns an instance of this class. This is needed in my app to determine the style of the current selection.