### PR TITLE
Hiding dialog after selecting action for image

### DIFF
--- a/lib/src/widgets/embeds/default_embed_builder.dart
+++ b/lib/src/widgets/embeds/default_embed_builder.dart
@@ -183,9 +183,11 @@ Widget _menuOptionsForReadonlyImage(
                 color: Colors.greenAccent,
                 text: 'Save'.i18n,
                 onPressed: () {
-                  GallerySaver.saveImage(imageUrl).then((_) =>
-                      ScaffoldMessenger.of(context)
-                          .showSnackBar(SnackBar(content: Text('Saved'.i18n))));
+                  GallerySaver.saveImage(imageUrl).then((_) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('Saved'.i18n)));
+                      Navigator.pop(context);
+                  });
                 },
               );
               final zoomOption = _SimpleDialogItem(
@@ -193,7 +195,7 @@ Widget _menuOptionsForReadonlyImage(
                 color: Colors.cyanAccent,
                 text: 'Zoom'.i18n,
                 onPressed: () {
-                  Navigator.push(
+                  Navigator.pushReplacement(
                       context,
                       MaterialPageRoute(
                           builder: (context) =>


### PR DESCRIPTION
It is unnatural to have a dialog left after choosing an action. In particular, when save is selected, the dialog is maintained, making it difficult to see the bottom snack bar, so the user may press the save button several times.