### PR TITLE
[For ios] Saving image that's filename does not end with it's file ex…

### DIFF
--- a/lib/src/widgets/embeds/default_embed_builder.dart
+++ b/lib/src/widgets/embeds/default_embed_builder.dart
@@ -162,6 +162,26 @@ Widget _menuOptionsForReadonlyImage(
                 color: Colors.greenAccent,
                 text: 'Save'.i18n,
                 onPressed: () {
+                  const List<String> imageFormats = [
+                    '.jpeg',
+                    '.png',
+                    '.jpg',
+                    '.gif',
+                    '.webp',
+                    '.tif',
+                    '.heic'
+                  ];
+
+                  List endsWithFormats = imageFormats.where((imageFormat) => imageUrl.toLowerCase().endsWith(imageFormat)).toList();
+                  if (endsWithFormats.length == 0) {
+                    for(int i = 0; i < imageFormats.length; i++) {
+                      if (imageUrl.toLowerCase().contains(imageFormats[i])) {
+                        imageUrl += imageFormats[i];
+                        break;
+                      }
+                    }
+                  }
+
                   GallerySaver.saveImage(imageUrl).then((_) {
                     ScaffoldMessenger.of(context)
                         .showSnackBar(SnackBar(content: Text('Saved'.i18n)));


### PR DESCRIPTION
This is a bug of  Gallery Saver Package.
https://github.com/CarnegieTechnologies/gallery_saver/issues/66

It can not save image that's filename does not end with it's file extension like below.
"https://firebasestorage.googleapis.com/v0/b/eventat-4ba96.appspot.com/o/2019-Metrology-Events.jpg?alt=media&token=bfc47032-5173-4b3f-86bb-9659f46b362a"

When I tested for android, It can save image. For ios, It show the success snackbar. but not added to gallery.
So I added some logic.

If imageurl does not end with it's file extension, file extension is added to image url for saving.