### PR TITLE
clear toggled style on selection change

### DIFF
--- a/lib/src/widgets/controller.dart
+++ b/lib/src/widgets/controller.dart
@@ -327,6 +327,7 @@ class QuillController extends ChangeNotifier {
     _selection = selection.copyWith(
         baseOffset: math.min(selection.baseOffset, end),
         extentOffset: math.min(selection.extentOffset, end));
+    toggledStyle = Style();
   }
 
   /// Given offset, find its leaf node in document


### PR DESCRIPTION
The issue:
- Toggle some attributes (set `toggledStyle`), don't type anything
- Select some text with different attributes
Toolbar buttons are showing not selection style but `toggledStyle`

Solution:
Drop `toggledStyle` on selection change

https://user-images.githubusercontent.com/5296407/154703229-c72d1749-114b-42c8-9ff6-f59a6f0a45d2.mp4


