### PR TITLE
fixed casting null to Tuple2 

### DIFF
--- a/lib/src/widgets/toolbar/link_style_button.dart
+++ b/lib/src/widgets/toolbar/link_style_button.dart
@@ -120,7 +120,11 @@ class _LinkStyleButtonState extends State<LinkStyleButton> {
         return _LinkDialog(
             dialogTheme: widget.dialogTheme, link: link, text: text);
       },
-    ).then(_linkSubmitted);
+    ).then(
+      (value) {
+        if (value != null) _linkSubmitted(value);
+      },
+    );
   }
 
   String? _getLinkAttributeValue() {


### PR DESCRIPTION
fix: fixed casting null to Tuple2 when link dialog is dismissed without any input (e.g. barrier dismissed)