### PR TITLE
Bug fix for copying text with new lines

### DIFF
--- a/lib/src/models/documents/nodes/line.dart
+++ b/lib/src/models/documents/nodes/line.dart
@@ -477,14 +477,16 @@ class Line extends Container<Leaf?> {
       total.add(text.substring(text.length - firstNodeLen));
     }
 
+    var middleNodesLen = 0;
     for (var i = 1; i < res.length - 1; i++) {
       if (res[i].item2 != Embed.kObjectReplacementCharacter) {
+        middleNodesLen += res[i].item1;
         total.add(res[i].item2);
       }
     }
 
     // Adjust last node
-    final lastNodeLen = len - res[res.length - 1].item1;
+    final lastNodeLen = len - middleNodesLen - res[res.length - 1].item1;
     text = res[res.length - 1].item2;
     if (text != Embed.kObjectReplacementCharacter) {
       total.add(text.substring(0, lastNodeLen));


### PR DESCRIPTION
https://github.com/singerdmx/flutter-quill/issues/667

The length of nodes between the first and last was not being taken into account when getting plain text.