### PR TITLE
 Request keyboard focus when no child is found

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -591,44 +591,47 @@ class _QuillEditorSelectionGestureDetectorBuilder
 
     editor!.hideToolbar();
 
-    if (delegate.selectionEnabled && !_isPositionSelected(details)) {
-      final _platform = Theme.of(_state.context).platform;
-      if (isAppleOS(_platform)) {
-        switch (details.kind) {
-          case PointerDeviceKind.mouse:
-          case PointerDeviceKind.stylus:
-          case PointerDeviceKind.invertedStylus:
-            // Precise devices should place the cursor at a precise position.
-            // If `Shift` key is pressed then
-            // extend current selection instead.
-            if (isShiftClick(details.kind)) {
-              renderEditor!
-                ..extendSelection(details.globalPosition,
-                    cause: SelectionChangedCause.tap)
-                ..onSelectionCompleted();
-            } else {
-              renderEditor!
-                ..selectPosition(cause: SelectionChangedCause.tap)
-                ..onSelectionCompleted();
-            }
+    try {
+      if (delegate.selectionEnabled && !_isPositionSelected(details)) {
+        final _platform = Theme.of(_state.context).platform;
+        if (isAppleOS(_platform)) {
+          switch (details.kind) {
+            case PointerDeviceKind.mouse:
+            case PointerDeviceKind.stylus:
+            case PointerDeviceKind.invertedStylus:
+              // Precise devices should place the cursor at a precise position.
+              // If `Shift` key is pressed then
+              // extend current selection instead.
+              if (isShiftClick(details.kind)) {
+                renderEditor!
+                  ..extendSelection(details.globalPosition,
+                      cause: SelectionChangedCause.tap)
+                  ..onSelectionCompleted();
+              } else {
+                renderEditor!
+                  ..selectPosition(cause: SelectionChangedCause.tap)
+                  ..onSelectionCompleted();
+              }
 
-            break;
-          case PointerDeviceKind.touch:
-          case PointerDeviceKind.unknown:
-            // On macOS/iOS/iPadOS a touch tap places the cursor at the edge
-            // of the word.
-            renderEditor!
-              ..selectWordEdge(SelectionChangedCause.tap)
-              ..onSelectionCompleted();
-            break;
+              break;
+            case PointerDeviceKind.touch:
+            case PointerDeviceKind.unknown:
+              // On macOS/iOS/iPadOS a touch tap places the cursor at the edge
+              // of the word.
+              renderEditor!
+                ..selectWordEdge(SelectionChangedCause.tap)
+                ..onSelectionCompleted();
+              break;
+          }
+        } else {
+          renderEditor!
+            ..selectPosition(cause: SelectionChangedCause.tap)
+            ..onSelectionCompleted();
         }
-      } else {
-        renderEditor!
-          ..selectPosition(cause: SelectionChangedCause.tap)
-          ..onSelectionCompleted();
       }
+    } finally {
+      _state._requestKeyboard();
     }
-    _state._requestKeyboard();
   }
 
   @override


### PR DESCRIPTION
`getRenderEditor()!.selectWordEdge` and
`getRenderEditor().selectPosition` currently throw a `'No child'` which
prevents the field from focusing. This happens when `minHeight` is set
and the whole field is not filled with content from the editor (e. g.
it's empty or only one line has some data).

This change catches the `'No child'` exception and lets the code to
continue its execution and request field focus.

This was fixed in #531 but the code got changed and focusing after
exception got removed.

Perhaps there's a better way to fix this bug but it blocked our 
production app release so I did a hotfix and opened this PR :)