### PR TITLE
feat: added Note to linkActionPickerDelegate

### DIFF
--- a/lib/src/widgets/link.dart
+++ b/lib/src/widgets/link.dart
@@ -42,10 +42,10 @@ enum LinkMenuAction {
 typedef LinkActionPicker = Future<LinkMenuAction> Function(Node linkNode);
 
 typedef LinkActionPickerDelegate = Future<LinkMenuAction> Function(
-    BuildContext context, String link);
+    BuildContext context, String link, Node node);
 
 Future<LinkMenuAction> defaultLinkActionPickerDelegate(
-    BuildContext context, String link) async {
+    BuildContext context, String link, Node node) async {
   switch (defaultTargetPlatform) {
     case TargetPlatform.iOS:
       return _showCupertinoLinkMenu(context, link);

--- a/lib/src/widgets/raw_editor.dart
+++ b/lib/src/widgets/raw_editor.dart
@@ -783,7 +783,7 @@ class RawEditorState extends EditorState
 
   Future<LinkMenuAction> _linkActionPicker(Node linkNode) async {
     final link = linkNode.style.attributes[Attribute.link.key]!.value!;
-    return widget.linkActionPickerDelegate(context, link);
+    return widget.linkActionPickerDelegate(context, link, linkNode);
   }
 
   bool _showCaretOnScreenScheduled = false;


### PR DESCRIPTION
This PR adds the `Node` parameter to the `linkActionPickerDelegate`. 
Example usage: 
1. Get the position of the link relative to the document.
2. Get access to attributes.

This PR is a breaking change