### PR TITLE
Flutter (Channel beta, 2.12.0-4.1.pre Add Function

### DIFF
--- a/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -14,6 +14,11 @@ mixin RawEditorStateTextInputClientMixin on EditorState
   TextInputConnection? _textInputConnection;
   TextEditingValue? _lastKnownRemoteTextEditingValue;
 
+  /// ----------------------Flutter (Channel beta, 2.12.0-4.1.pre Add Function
+  void insertTextPlaceholder(Size size) {}
+  void removeTextPlaceholder() {}
+  /// ------------------------------------------------------------------------
+
   /// Whether to create an input connection with the platform for text editing
   /// or not.
   ///


### PR DESCRIPTION
Error: The non-abstract class 'RawEditorState' is missing implementations for these members:
 - TextInputClient.insertTextPlaceholder
 - TextInputClient.removeTextPlaceholder