### PR TITLE
toolbar & selection handle update

### DIFF
--- a/lib/src/widgets/delegate.dart
+++ b/lib/src/widgets/delegate.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 
 import '../../flutter_quill.dart';
 import 'text_selection.dart';
@@ -252,9 +253,17 @@ class EditorTextSelectionGestureDetectorBuilder {
   void onDoubleTapDown(TapDownDetails details) {
     if (delegate.selectionEnabled) {
       renderEditor!.selectWord(SelectionChangedCause.tap);
-      if (shouldShowSelectionToolbar) {
-        editor!.showToolbar();
-      }
+      // allow the selection to get updated before trying to bring up
+      // toolbars.
+      //
+      // if double tap happens on an editor that doesn't
+      // have focus, selection hasn't been set when the toolbars
+      // get added
+      SchedulerBinding.instance!.addPostFrameCallback((_) {
+        if (shouldShowSelectionToolbar) {
+          editor!.showToolbar();
+        }
+      });
     }
   }
 

--- a/lib/src/widgets/raw_editor/raw_editor_state_selection_delegate_mixin.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state_selection_delegate_mixin.dart
@@ -136,7 +136,7 @@ mixin RawEditorStateSelectionDelegateMixin on EditorState
   void hideToolbar([bool hideHandles = true]) {
     // If the toolbar is currently visible.
     if (selectionOverlay?.toolbar != null) {
-      selectionOverlay?.hideToolbar();
+      hideHandles ? selectionOverlay?.hide() : selectionOverlay?.hideToolbar();
     }
   }
 

--- a/lib/src/widgets/text_selection.dart
+++ b/lib/src/widgets/text_selection.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 
 import '../models/documents/nodes/node.dart';
@@ -224,6 +225,11 @@ class EditorTextSelectionOverlay {
     Overlay.of(context, rootOverlay: true, debugRequiredFor: debugRequiredFor)!
         .insert(toolbar!);
     _toolbarController.forward(from: 0);
+
+    // make sure handles are visible as well
+    if (_handles == null) {
+      showHandles();
+    }
   }
 
   Widget _buildHandle(
@@ -308,7 +314,16 @@ class EditorTextSelectionOverlay {
 
   Widget _buildToolbar(BuildContext context) {
     // Find the horizontal midpoint, just above the selected text.
-    final endpoints = renderObject.getEndpointsForSelection(_selection);
+    List<TextSelectionPoint> endpoints;
+
+    try {
+      // building with an invalid selection with throw an exception
+      // This happens where the selection has changed, but the toolbar
+      // hasn't been dismissed yet.
+      endpoints = renderObject.getEndpointsForSelection(_selection);
+    } catch (_) {
+      return Container();
+    }
 
     final editingRegion = Rect.fromPoints(
       renderObject.localToGlobal(Offset.zero),


### PR DESCRIPTION
    - Fix crash when toolbar is still visible and selection is removed (i.e. drag select, scroll entire document, hit backspace key)
    - Fix selection handles & toolbar visibility after paste, backspace, copy