### PR TITLE
New borderRadius for iconTheme

### DIFF
--- a/lib/src/models/themes/quill_icon_theme.dart
+++ b/lib/src/models/themes/quill_icon_theme.dart
@@ -8,6 +8,7 @@ class QuillIconTheme {
     this.iconUnselectedFillColor,
     this.disabledIconColor,
     this.disabledIconFillColor,
+    this.borderRadius
   });
 
   ///The color to use for selected icons in the toolbar

--- a/lib/src/models/themes/quill_icon_theme.dart
+++ b/lib/src/models/themes/quill_icon_theme.dart
@@ -27,4 +27,7 @@ class QuillIconTheme {
 
   ///The fill color to use for disabled icons in the toolbar
   final Color? disabledIconFillColor;
+  
+  ///The borderRadius for icons
+  final double? borderRadius;
 }

--- a/lib/src/widgets/toolbar/camera_button.dart
+++ b/lib/src/widgets/toolbar/camera_button.dart
@@ -53,6 +53,7 @@ class CameraButton extends StatelessWidget {
       hoverElevation: 0,
       size: iconSize * 1.77,
       fillColor: iconFillColor,
+      borderRadius: iconTheme?.borderRadius ?? 2,
       onPressed: () => _handleCameraButtonTap(context, controller,
           onImagePickCallback: onImagePickCallback,
           onVideoPickCallback: onVideoPickCallback,

--- a/lib/src/widgets/toolbar/clear_format_button.dart
+++ b/lib/src/widgets/toolbar/clear_format_button.dart
@@ -36,6 +36,7 @@ class _ClearFormatButtonState extends State<ClearFormatButton> {
         size: widget.iconSize * kIconButtonFactor,
         icon: Icon(widget.icon, size: widget.iconSize, color: iconColor),
         fillColor: fillColor,
+        borderRadius: widget.iconTheme?.borderRadius ?? 2,
         onPressed: () {
           final attrs = <Attribute>{};
           for (final style in widget.controller.getAllSelectionStyles()) {

--- a/lib/src/widgets/toolbar/color_button.dart
+++ b/lib/src/widgets/toolbar/color_button.dart
@@ -124,6 +124,7 @@ class _ColorButtonState extends State<ColorButton> {
           size: widget.iconSize,
           color: widget.background ? iconColorBackground : iconColor),
       fillColor: widget.background ? fillColorBackground : fillColor,
+      borderRadius: widget.iconTheme?.borderRadius ?? 2,
       onPressed: _showColorPicker,
     );
   }

--- a/lib/src/widgets/toolbar/history_button.dart
+++ b/lib/src/widgets/toolbar/history_button.dart
@@ -42,6 +42,7 @@ class _HistoryButtonState extends State<HistoryButton> {
       size: widget.iconSize * 1.77,
       icon: Icon(widget.icon, size: widget.iconSize, color: _iconColor),
       fillColor: fillColor,
+      borderRadius: widget.iconTheme?.borderRadius ?? 2,
       onPressed: _changeHistory,
     );
   }

--- a/lib/src/widgets/toolbar/image_button.dart
+++ b/lib/src/widgets/toolbar/image_button.dart
@@ -55,6 +55,7 @@ class ImageButton extends StatelessWidget {
       hoverElevation: 0,
       size: iconSize * 1.77,
       fillColor: iconFillColor,
+      borderRadius: iconTheme?.borderRadius ?? 2,
       onPressed: () => _onPressedHandler(context),
     );
   }

--- a/lib/src/widgets/toolbar/indent_button.dart
+++ b/lib/src/widgets/toolbar/indent_button.dart
@@ -38,6 +38,7 @@ class _IndentButtonState extends State<IndentButton> {
       size: widget.iconSize * 1.77,
       icon: Icon(widget.icon, size: widget.iconSize, color: iconColor),
       fillColor: iconFillColor,
+      borderRadius: widget.iconTheme?.borderRadius ?? 2,
       onPressed: () {
         final indent = widget.controller
             .getSelectionStyle()

--- a/lib/src/widgets/toolbar/link_style_button.dart
+++ b/lib/src/widgets/toolbar/link_style_button.dart
@@ -91,6 +91,7 @@ class _LinkStyleButtonState extends State<LinkStyleButton> {
           ),
           fillColor:
               widget.iconTheme?.iconUnselectedFillColor ?? theme.canvasColor,
+          borderRadius: widget.iconTheme?.borderRadius ?? 2,
           onPressed: pressedHandler,
         ),
       ),

--- a/lib/src/widgets/toolbar/quill_dropdown_button.dart
+++ b/lib/src/widgets/toolbar/quill_dropdown_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../models/themes/quill_icon_theme.dart';
 
 @Deprecated('Not being used')
 class QuillDropdownButton<T> extends StatefulWidget {
@@ -11,6 +12,7 @@ class QuillDropdownButton<T> extends StatefulWidget {
     this.fillColor,
     this.hoverElevation = 1,
     this.highlightElevation = 1,
+    this.iconTheme,
     Key? key,
   }) : super(key: key);
 
@@ -22,6 +24,7 @@ class QuillDropdownButton<T> extends StatefulWidget {
   final T initialValue;
   final List<PopupMenuEntry<T>> items;
   final ValueChanged<T> onSelected;
+  final QuillIconTheme? iconTheme;
 
   @override
   _QuillDropdownButtonState<T> createState() => _QuillDropdownButtonState<T>();

--- a/lib/src/widgets/toolbar/quill_dropdown_button.dart
+++ b/lib/src/widgets/toolbar/quill_dropdown_button.dart
@@ -35,7 +35,7 @@ class _QuillDropdownButtonState<T> extends State<QuillDropdownButton<T>> {
       constraints: BoxConstraints.tightFor(height: widget.height),
       child: RawMaterialButton(
         visualDensity: VisualDensity.compact,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(2)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(widget.iconTheme?.borderRadius ?? 2)),
         fillColor: widget.fillColor,
         elevation: 0,
         hoverElevation: widget.hoverElevation,

--- a/lib/src/widgets/toolbar/quill_icon_button.dart
+++ b/lib/src/widgets/toolbar/quill_icon_button.dart
@@ -8,6 +8,7 @@ class QuillIconButton extends StatelessWidget {
     this.fillColor,
     this.hoverElevation = 1,
     this.highlightElevation = 1,
+    this.borderRadius = 2,
     Key? key,
   }) : super(key: key);
 
@@ -17,6 +18,7 @@ class QuillIconButton extends StatelessWidget {
   final Color? fillColor;
   final double hoverElevation;
   final double highlightElevation;
+  final double borderRadius;
 
   @override
   Widget build(BuildContext context) {
@@ -24,7 +26,7 @@ class QuillIconButton extends StatelessWidget {
       constraints: BoxConstraints.tightFor(width: size, height: size),
       child: RawMaterialButton(
         visualDensity: VisualDensity.compact,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(2)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(borderRadius)),
         fillColor: fillColor,
         elevation: 0,
         hoverElevation: hoverElevation,

--- a/lib/src/widgets/toolbar/quill_icon_button.dart
+++ b/lib/src/widgets/toolbar/quill_icon_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../models/themes/quill_icon_theme.dart';
 
 class QuillIconButton extends StatelessWidget {
   const QuillIconButton({
@@ -8,6 +9,7 @@ class QuillIconButton extends StatelessWidget {
     this.fillColor,
     this.hoverElevation = 1,
     this.highlightElevation = 1,
+    this.iconTheme,
     Key? key,
   }) : super(key: key);
 
@@ -17,6 +19,7 @@ class QuillIconButton extends StatelessWidget {
   final Color? fillColor;
   final double hoverElevation;
   final double highlightElevation;
+  final QuillIconTheme? iconTheme;
 
   @override
   Widget build(BuildContext context) {
@@ -24,7 +27,7 @@ class QuillIconButton extends StatelessWidget {
       constraints: BoxConstraints.tightFor(width: size, height: size),
       child: RawMaterialButton(
         visualDensity: VisualDensity.compact,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(2)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(widget.iconTheme?.borderRadius ?? 2)),
         fillColor: fillColor,
         elevation: 0,
         hoverElevation: hoverElevation,

--- a/lib/src/widgets/toolbar/quill_icon_button.dart
+++ b/lib/src/widgets/toolbar/quill_icon_button.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import '../../models/themes/quill_icon_theme.dart';
 
 class QuillIconButton extends StatelessWidget {
   const QuillIconButton({
@@ -9,7 +8,6 @@ class QuillIconButton extends StatelessWidget {
     this.fillColor,
     this.hoverElevation = 1,
     this.highlightElevation = 1,
-    this.iconTheme,
     Key? key,
   }) : super(key: key);
 
@@ -19,7 +17,6 @@ class QuillIconButton extends StatelessWidget {
   final Color? fillColor;
   final double hoverElevation;
   final double highlightElevation;
-  final QuillIconTheme? iconTheme;
 
   @override
   Widget build(BuildContext context) {
@@ -27,7 +24,7 @@ class QuillIconButton extends StatelessWidget {
       constraints: BoxConstraints.tightFor(width: size, height: size),
       child: RawMaterialButton(
         visualDensity: VisualDensity.compact,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(iconTheme?.borderRadius ?? 2)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(2)),
         fillColor: fillColor,
         elevation: 0,
         hoverElevation: hoverElevation,

--- a/lib/src/widgets/toolbar/quill_icon_button.dart
+++ b/lib/src/widgets/toolbar/quill_icon_button.dart
@@ -27,7 +27,7 @@ class QuillIconButton extends StatelessWidget {
       constraints: BoxConstraints.tightFor(width: size, height: size),
       child: RawMaterialButton(
         visualDensity: VisualDensity.compact,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(widget.iconTheme?.borderRadius ?? 2)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(iconTheme?.borderRadius ?? 2)),
         fillColor: fillColor,
         elevation: 0,
         hoverElevation: hoverElevation,

--- a/lib/src/widgets/toolbar/select_alignment_button.dart
+++ b/lib/src/widgets/toolbar/select_alignment_button.dart
@@ -97,7 +97,7 @@ class _SelectAlignmentButtonState extends State<SelectAlignmentButton> {
               elevation: 0,
               visualDensity: VisualDensity.compact,
               shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(2)),
+                  borderRadius: BorderRadius.circular(widget.iconTheme?.borderRadius ?? 2)),
               fillColor: _valueToText[_value] == _valueString[index]
                   ? (widget.iconTheme?.iconSelectedFillColor ??
                       theme.toggleableActiveColor)

--- a/lib/src/widgets/toolbar/select_header_style_button.dart
+++ b/lib/src/widgets/toolbar/select_header_style_button.dart
@@ -79,7 +79,7 @@ class _SelectHeaderStyleButtonState extends State<SelectHeaderStyleButton> {
               elevation: 0,
               visualDensity: VisualDensity.compact,
               shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(2)),
+                  borderRadius: BorderRadius.circular(widget.iconTheme?.borderRadius ?? 2)),
               fillColor: _valueToText[_value] == _valueString[index]
                   ? (widget.iconTheme?.iconSelectedFillColor ??
                       theme.toggleableActiveColor)

--- a/lib/src/widgets/toolbar/toggle_style_button.dart
+++ b/lib/src/widgets/toolbar/toggle_style_button.dart
@@ -145,5 +145,6 @@ Widget defaultToggleStyleButtonBuilder(
     icon: Icon(icon, size: iconSize, color: iconColor),
     fillColor: fill,
     onPressed: onPressed,
+    borderRadius: iconTheme?.borderRadius ?? 2,
   );
 }

--- a/lib/src/widgets/toolbar/video_button.dart
+++ b/lib/src/widgets/toolbar/video_button.dart
@@ -55,6 +55,7 @@ class VideoButton extends StatelessWidget {
       hoverElevation: 0,
       size: iconSize * 1.77,
       fillColor: iconFillColor,
+      borderRadius: iconTheme?.borderRadius ?? 2,
       onPressed: () => _onPressedHandler(context),
     );
   }


### PR DESCRIPTION
Add ability to modify the `borderRadius` double for toolbar icons, via the `iconTheme`