### PR TITLE
Add Font Size dropdown to the toolbar

### DIFF
--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -184,6 +184,23 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             undo: false,
             iconTheme: iconTheme,
           ),
+        QuillDropdownButton(
+          iconTheme: iconTheme,
+          items:[
+            for (var fontSizeValue in fontSizeValues)
+            PopupMenuItem<int>(
+              value: fontSizeValue,
+              child: Text(fontSizeValue.toString()),
+            ),
+          ],
+          onSelected:(newSize){
+            if (newSize != null)
+              {
+                controller.formatSelection(Attribute.fromKeyValue('size', newSize));
+              }
+            },
+          initialValue: 0,
+        ),          
         if (showBoldButton)
           ToggleStyleButton(
             attribute: Attribute.bold,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -189,23 +189,24 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             iconTheme: iconTheme,
           ),
         if (showFontSize)
-        QuillDropdownButton(
-          iconTheme: iconTheme,
-          items:[
-            for (var fontSize in fontSizes)
-            PopupMenuItem<int>(
-              value: fontSize,
-              child: Text(fontSize.toString()),
-            ),
-          ],
-          onSelected:(newSize){
-            if (newSize != null)
-              {
-                controller.formatSelection(Attribute.fromKeyValue('size', newSize));
-              }
-            },
-          initialValue: fontSizes[initialFontSizeValue ?? 0],
-        ),          
+            QuillDropdownButton(
+              iconTheme: iconTheme,
+              height:toolbarIconSize*2,
+              items:[
+                for (var fontSize in fontSizes)
+                PopupMenuItem<int>(
+                  value: fontSize,
+                  child: Text(fontSize.toString()),
+                ),
+              ],
+              onSelected:(newSize){
+                if (newSize != null)
+                  {
+                    controller.formatSelection(Attribute.fromKeyValue('size', newSize));
+                  }
+                },
+              initialValue: fontSizes[initialFontSizeValue ?? 0],
+            ),          
         if (showBoldButton)
           ToggleStyleButton(
             attribute: Attribute.bold,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -112,6 +112,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
     ///List of font sizes in [int]
     List? fontSizeValues,
+    int? initialFontSizeValue,
       
     ///The theme to use for the icons in the toolbar, uses type [QuillIconTheme]
     QuillIconTheme? iconTheme,
@@ -205,7 +206,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
                 controller.formatSelection(Attribute.fromKeyValue('size', newSize));
               }
             },
-          initialValue: 0,
+          initialValue: initialFontSizeValue,
         ),          
         if (showBoldButton)
           ToggleStyleButton(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -21,6 +21,7 @@ import 'toolbar/select_header_style_button.dart';
 import 'toolbar/toggle_check_list_button.dart';
 import 'toolbar/toggle_style_button.dart';
 import 'toolbar/video_button.dart';
+import 'toolbar/quill_dropdown_button.dart';
 
 export 'toolbar/clear_format_button.dart';
 export 'toolbar/color_button.dart';

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -73,6 +73,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     double toolbarSectionSpacing = 4,
     WrapAlignment toolbarIconAlignment = WrapAlignment.center,
     bool showDividers = true,
+    bool showFontSize = true,
     bool showBoldButton = true,
     bool showItalicButton = true,
     bool showSmallButton = false,
@@ -122,6 +123,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     Key? key,
   }) {
     final isButtonGroupShown = [
+      showFontSize ||  
       showBoldButton ||
           showItalicButton ||
           showSmallButton ||
@@ -184,6 +186,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             undo: false,
             iconTheme: iconTheme,
           ),
+        if (showFontSize)
         QuillDropdownButton(
           iconTheme: iconTheme,
           items:[

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -144,6 +144,22 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
       showLink
     ];
 
+    //default font size values
+    final fontSizeValues = [
+      10,
+      12,
+      14,
+      16,
+      18,
+      20,
+      24,
+      28,
+      32,
+      48
+    ];
+
+    int _currentFontSize = 16;
+      
     return QuillToolbar(
       key: key,
       toolbarHeight: toolbarIconSize * 2,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -163,8 +163,6 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
       32,
       48
     ];
-
-    int _currentFontSize = 16;
       
     return QuillToolbar(
       key: key,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -204,7 +204,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
                 controller.formatSelection(Attribute.fromKeyValue('size', newSize));
               }
             },
-          initialValue: initialFontSizeValue,
+          initialValue: fontSizes[initialFontSizeValue ?? 0],
         ),          
         if (showBoldButton)
           ToggleStyleButton(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -110,6 +110,9 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     WebImagePickImpl? webImagePickImpl,
     WebVideoPickImpl? webVideoPickImpl,
 
+    ///List of font sizes in [int]
+    List? fontSizeValues,
+      
     ///The theme to use for the icons in the toolbar, uses type [QuillIconTheme]
     QuillIconTheme? iconTheme,
 
@@ -147,7 +150,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     ];
 
     //default font size values
-    final fontSizeValues = [
+    final fontSizes = fontSizeValues ?? [
       10,
       12,
       14,
@@ -190,10 +193,10 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
         QuillDropdownButton(
           iconTheme: iconTheme,
           items:[
-            for (var fontSizeValue in fontSizeValues)
+            for (var fontSize in fontSizes)
             PopupMenuItem<int>(
-              value: fontSizeValue,
-              child: Text(fontSizeValue.toString()),
+              value: fontSize,
+              child: Text(fontSize.toString()),
             ),
           ],
           onSelected:(newSize){

--- a/lib/src/widgets/toolbar/quill_dropdown_button.dart
+++ b/lib/src/widgets/toolbar/quill_dropdown_button.dart
@@ -95,7 +95,7 @@ class _QuillDropdownButtonState<T> extends State<QuillDropdownButton<T>> {
 
   Widget _buildContent(BuildContext context) {
     return ConstrainedBox(
-      constraints: const BoxConstraints.tightFor(width: 110),
+      constraints: const BoxConstraints.tightFor(width: 60),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8),
         child: Row(

--- a/lib/src/widgets/toolbar/quill_dropdown_button.dart
+++ b/lib/src/widgets/toolbar/quill_dropdown_button.dart
@@ -1,14 +1,11 @@
 import 'package:flutter/material.dart';
 import '../../models/themes/quill_icon_theme.dart';
-import '../controller.dart';
-import '../../models/documents/attribute.dart';
 
 class QuillDropdownButton<T> extends StatefulWidget {
   const QuillDropdownButton({
     required this.initialValue,
     required this.items,
     required this.onSelected,
-    required this.controller,
     this.startValue = 16,
     this.height = 40,
     this.fillColor,
@@ -26,7 +23,6 @@ class QuillDropdownButton<T> extends StatefulWidget {
   final T initialValue;
   final List<PopupMenuEntry<T>> items;
   final ValueChanged<T> onSelected;
-  final QuillController controller;
   final QuillIconTheme? iconTheme;
 
   @override
@@ -95,7 +91,6 @@ class _QuillDropdownButtonState<T> extends State<QuillDropdownButton<T>> {
       setState(() {
         _currentValue = newValue as int;
         widget.onSelected(newValue);
-        widget.controller.formatSelection(Attribute.fromKeyValue('size', newValue));
       });
     });
   }

--- a/lib/src/widgets/toolbar/quill_dropdown_button.dart
+++ b/lib/src/widgets/toolbar/quill_dropdown_button.dart
@@ -6,7 +6,6 @@ class QuillDropdownButton<T> extends StatefulWidget {
     required this.initialValue,
     required this.items,
     required this.onSelected,
-    this.startValue = 16,
     this.height = 40,
     this.fillColor,
     this.hoverElevation = 1,
@@ -15,7 +14,6 @@ class QuillDropdownButton<T> extends StatefulWidget {
     Key? key,
   }) : super(key: key);
 
-  final int startValue;
   final double height;
   final Color? fillColor;
   final double hoverElevation;
@@ -32,11 +30,11 @@ class QuillDropdownButton<T> extends StatefulWidget {
 // ignore: deprecated_member_use_from_same_package
 class _QuillDropdownButtonState<T> extends State<QuillDropdownButton<T>> {
   
-  int _currentValue = 16;
+  int _currentValue = 0;
 
   @override
   void initState(){
-      _currentValue = widget.startValue;
+      _currentValue = widget.initialValue as int;
   }
   
   @override

--- a/lib/src/widgets/toolbar/quill_dropdown_button.dart
+++ b/lib/src/widgets/toolbar/quill_dropdown_button.dart
@@ -3,10 +3,10 @@ import '../../models/themes/quill_icon_theme.dart';
 
 class QuillDropdownButton<T> extends StatefulWidget {
   const QuillDropdownButton({
-    required this.child,
     required this.initialValue,
     required this.items,
     required this.onSelected,
+    this.startValue = 16,
     this.height = 40,
     this.fillColor,
     this.hoverElevation = 1,
@@ -15,11 +15,11 @@ class QuillDropdownButton<T> extends StatefulWidget {
     Key? key,
   }) : super(key: key);
 
+  final int startValue;
   final double height;
   final Color? fillColor;
   final double hoverElevation;
   final double highlightElevation;
-  final Widget child;
   final T initialValue;
   final List<PopupMenuEntry<T>> items;
   final ValueChanged<T> onSelected;
@@ -31,6 +31,14 @@ class QuillDropdownButton<T> extends StatefulWidget {
 
 // ignore: deprecated_member_use_from_same_package
 class _QuillDropdownButtonState<T> extends State<QuillDropdownButton<T>> {
+  
+  int _currentValue = 16;
+
+  @override
+  void initState(){
+      _currentValue = widget.startValue;
+  }
+  
   @override
   Widget build(BuildContext context) {
     return ConstrainedBox(
@@ -80,7 +88,10 @@ class _QuillDropdownButtonState<T> extends State<QuillDropdownButton<T>> {
         // if (widget.onCanceled != null) widget.onCanceled();
         return null;
       }
-      widget.onSelected(newValue);
+      setState(() {
+        _currentValue = newValue as int;
+        widget.onSelected(newValue);
+      });
     });
   }
 
@@ -91,7 +102,7 @@ class _QuillDropdownButtonState<T> extends State<QuillDropdownButton<T>> {
         padding: const EdgeInsets.symmetric(horizontal: 8),
         child: Row(
           children: [
-            widget.child,
+            Text(_currentValue.toString()),
             Expanded(child: Container()),
             const Icon(Icons.arrow_drop_down, size: 15)
           ],

--- a/lib/src/widgets/toolbar/quill_dropdown_button.dart
+++ b/lib/src/widgets/toolbar/quill_dropdown_button.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../models/themes/quill_icon_theme.dart';
 
-@Deprecated('Not being used')
 class QuillDropdownButton<T> extends StatefulWidget {
   const QuillDropdownButton({
     required this.child,

--- a/lib/src/widgets/toolbar/quill_dropdown_button.dart
+++ b/lib/src/widgets/toolbar/quill_dropdown_button.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
 import '../../models/themes/quill_icon_theme.dart';
+import '../controller.dart';
+import '../../models/documents/attribute.dart';
 
 class QuillDropdownButton<T> extends StatefulWidget {
   const QuillDropdownButton({
     required this.initialValue,
     required this.items,
     required this.onSelected,
+    required this.controller,
     this.startValue = 16,
     this.height = 40,
     this.fillColor,
@@ -23,6 +26,7 @@ class QuillDropdownButton<T> extends StatefulWidget {
   final T initialValue;
   final List<PopupMenuEntry<T>> items;
   final ValueChanged<T> onSelected;
+  final QuillController controller;
   final QuillIconTheme? iconTheme;
 
   @override
@@ -91,6 +95,7 @@ class _QuillDropdownButtonState<T> extends State<QuillDropdownButton<T>> {
       setState(() {
         _currentValue = newValue as int;
         widget.onSelected(newValue);
+        widget.controller.formatSelection(Attribute.fromKeyValue('size', newValue));
       });
     });
   }


### PR DESCRIPTION
This will add a new `fontSize` function using the existing quill drop down widget (previously depreciated).

Font size options can be set via a list:
```
QuillToolbar.basic(
     (...),
     fontSizeValues: [10,30,50]
```

and an initial value can be chosen among that list
```
QuillToolbar.basic(
     (...),
     fontSizeValues: [10,30,50],
     initialFontSizeValue: 2, //will use font size 50 as the initial value
```

Whatever the base font size of your widget is will be considered the 'initial value' (no style change will be applied on first launch to prevent a font size from being applied for people who don't want it), but any choice to change it will then apply

If no `fontSizeValues` is given, then a default initial value set will be used: 
```
      10,
      12,
      14,
      16,
      18,
      20,
      24,
      28,
      32,
      48
```

This has been working very well for me in my tests and use case, but please try it out and see if its working for you as you like!