### PR TITLE
Update quill_dropdown_button.dart to fix static analysis on pub.dev

### DIFF
--- a/lib/src/widgets/toolbar/quill_dropdown_button.dart
+++ b/lib/src/widgets/toolbar/quill_dropdown_button.dart
@@ -33,6 +33,7 @@ class _QuillDropdownButtonState<T> extends State<QuillDropdownButton<T>> {
 
   @override
   void initState() {
+    super.initState();
     _currentValue = widget.initialValue as int;
   }
 


### PR DESCRIPTION
On pub.dev there is a score loss of pub points because of `static analysis` 
```
INFO: This method overrides a method annotated as '@mustCallSuper' in 'State', but doesn't invoke the overridden method.
```
I believe this would fix that