### PR TITLE
Convert FontSize to a Map to allow for named Font Size

### DIFF
--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -185,6 +185,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             items: [
               for(MapEntry<String, int> fontSize in fontSizes.entries)
                 PopupMenuItem<int>(
+                  key: ValueKey(fontSize.key),
                   value: fontSize.value,
                   child: Text(fontSize.key.toString()),
                 ),

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -110,8 +110,8 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     WebImagePickImpl? webImagePickImpl,
     WebVideoPickImpl? webVideoPickImpl,
 
-    ///List of font sizes in [int]
-    List? fontSizeValues,
+    ///Map of font sizes in [int]
+    Map<String, int>? fontSizeValues,
     int? initialFontSizeValue,
 
     ///The theme to use for the icons in the toolbar, uses type [QuillIconTheme]
@@ -152,7 +152,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
     //default font size values
     final fontSizes =
-        fontSizeValues ?? [10, 12, 14, 16, 18, 20, 24, 28, 32, 48];
+        fontSizeValues ?? {'10':10, '12':12, '14':14, '16':16, '18':18, '20':20, '24':24, '28':28, '32':32, '48':48};
 
     return QuillToolbar(
       key: key,
@@ -183,10 +183,10 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             iconTheme: iconTheme,
             height: (toolbarIconSize * 2)-(toolbarIconSize / 3),
             items: [
-              for (var fontSize in fontSizes)
+              for(MapEntry<String, int> fontSize in fontSizes.entries)
                 PopupMenuItem<int>(
-                  value: fontSize,
-                  child: Text(fontSize.toString()),
+                  value: fontSize.value,
+                  child: Text(fontSize.key.toString()),
                 ),
             ],
             onSelected: (newSize) {
@@ -195,7 +195,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
                     .formatSelection(Attribute.fromKeyValue('size', newSize));
               }
             },
-            initialValue: fontSizes[initialFontSizeValue ?? 0],
+            initialValue: fontSizes.values.toList()[initialFontSizeValue ?? 0]
           ),
         if (showBoldButton)
           ToggleStyleButton(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -196,7 +196,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
                     .formatSelection(Attribute.fromKeyValue('size', newSize));
               }
             },
-            rawitemslist: fontSizes,
+            rawitemsmap: fontSizes,
             initialValue: (initialFontSizeValue != null) && (initialFontSizeValue <= fontSizes.length - 1) ? initialFontSizeValue : 0,
           ),
         if (showBoldButton)

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -181,7 +181,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
         if (showFontSize)
           QuillDropdownButton(
             iconTheme: iconTheme,
-            height: toolbarIconSize * 2,
+            height: (toolbarIconSize * 2)-(toolbarIconSize / 3),
             items: [
               for (var fontSize in fontSizes)
                 PopupMenuItem<int>(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -196,8 +196,8 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
                     .formatSelection(Attribute.fromKeyValue('size', newSize));
               }
             },
-            initialValue: fontSizes.values.toList()[initialFontSizeValue ?? 0],
-            initialValueTitle: fontSizes.keys.toList()[initialFontSizeValue ?? 0]  
+            rawitemslist: fontSizes,
+            initialValue: (initialFontSizeValue != null) && (initialFontSizeValue <= fontSizes.length - 1) ? initialFontSizeValue : 0,
           ),
         if (showBoldButton)
           ToggleStyleButton(

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -196,7 +196,8 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
                     .formatSelection(Attribute.fromKeyValue('size', newSize));
               }
             },
-            initialValue: fontSizes.values.toList()[initialFontSizeValue ?? 0]
+            initialValue: fontSizes.values.toList()[initialFontSizeValue ?? 0],
+            initialValueTitle: fontSizes.keys.toList()[initialFontSizeValue ?? 0]  
           ),
         if (showBoldButton)
           ToggleStyleButton(

--- a/lib/src/widgets/toolbar/quill_dropdown_button.dart
+++ b/lib/src/widgets/toolbar/quill_dropdown_button.dart
@@ -94,18 +94,16 @@ class _QuillDropdownButtonState<T> extends State<QuillDropdownButton<T>> {
   }
 
   Widget _buildContent(BuildContext context) {
-    return ConstrainedBox(
-      constraints: const BoxConstraints.tightFor(width: 60),
-      child: Padding(
+    return Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8),
         child: Row(
+          mainAxisSize: MainAxisSize.min,
           children: [
             Text(_currentValue.toString()),
-            Expanded(child: Container()),
-            const Icon(Icons.arrow_drop_down, size: 15)
+            SizedBox(width:6),
+            const Icon(Icons.arrow_drop_down, size: 17)
           ],
         ),
-      ),
-    );
+      );
   }
 }

--- a/lib/src/widgets/toolbar/quill_dropdown_button.dart
+++ b/lib/src/widgets/toolbar/quill_dropdown_button.dart
@@ -4,6 +4,7 @@ import '../../models/themes/quill_icon_theme.dart';
 class QuillDropdownButton<T> extends StatefulWidget {
   const QuillDropdownButton({
     required this.initialValue,
+    required this.initialValueTitle,
     required this.items,
     required this.onSelected,
     this.height = 40,
@@ -19,6 +20,7 @@ class QuillDropdownButton<T> extends StatefulWidget {
   final double hoverElevation;
   final double highlightElevation;
   final T initialValue;
+  final String initialValueTitle;
   final List<PopupMenuEntry<T>> items;
   final ValueChanged<T> onSelected;
   final QuillIconTheme? iconTheme;
@@ -29,12 +31,12 @@ class QuillDropdownButton<T> extends StatefulWidget {
 
 // ignore: deprecated_member_use_from_same_package
 class _QuillDropdownButtonState<T> extends State<QuillDropdownButton<T>> {
-  int _currentValue = 0;
+  String _currentValue = '';
 
   @override
   void initState() {
     super.initState();
-    _currentValue = widget.initialValue as int;
+    _currentValue = widget.initialValueTitle;
   }
 
   @override
@@ -87,7 +89,7 @@ class _QuillDropdownButtonState<T> extends State<QuillDropdownButton<T>> {
         return null;
       }
       setState(() {
-        _currentValue = newValue as int;
+        _currentValue = ((widget.items[1].key) as ValueKey<String>).value;
         widget.onSelected(newValue);
       });
     });

--- a/lib/src/widgets/toolbar/quill_dropdown_button.dart
+++ b/lib/src/widgets/toolbar/quill_dropdown_button.dart
@@ -4,8 +4,8 @@ import '../../models/themes/quill_icon_theme.dart';
 class QuillDropdownButton<T> extends StatefulWidget {
   const QuillDropdownButton({
     required this.initialValue,
-    required this.initialValueTitle,
     required this.items,
+    required this.rawitemsmap,
     required this.onSelected,
     this.height = 40,
     this.fillColor,
@@ -20,8 +20,8 @@ class QuillDropdownButton<T> extends StatefulWidget {
   final double hoverElevation;
   final double highlightElevation;
   final T initialValue;
-  final String initialValueTitle;
   final List<PopupMenuEntry<T>> items;
+  final Map<String,int> rawitemsmap;
   final ValueChanged<T> onSelected;
   final QuillIconTheme? iconTheme;
 
@@ -36,7 +36,7 @@ class _QuillDropdownButtonState<T> extends State<QuillDropdownButton<T>> {
   @override
   void initState() {
     super.initState();
-    _currentValue = widget.initialValueTitle;
+    _currentValue = widget.rawitemsmap.keys.elementAt(widget.initialValue as int);
   }
 
   @override
@@ -89,7 +89,7 @@ class _QuillDropdownButtonState<T> extends State<QuillDropdownButton<T>> {
         return null;
       }
       setState(() {
-        _currentValue = ((widget.items[1].key) as ValueKey<String>).value;
+        _currentValue = widget.rawitemsmap.entries.firstWhere((element) => element.value==newValue, orElse: () => widget.rawitemsmap.entries.first).key;
         widget.onSelected(newValue);
       });
     });
@@ -97,7 +97,7 @@ class _QuillDropdownButtonState<T> extends State<QuillDropdownButton<T>> {
 
   Widget _buildContent(BuildContext context) {
     return Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 8),
+        padding: const EdgeInsets.symmetric(horizontal: 10),
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [


### PR DESCRIPTION
`fontSizeValues` is now converted from a List to a `Map<String,int>' to allow for names for each font size, for example:

```
fontSizeValues: const {'Small':8, 'Medium':24, 'Large':46},
```

But if you want to keep using actual font size numbers, simply do:

```
fontSizeValues: const {'8':8, '24':24, '46':46},
```

Stylistically the font size drop down width is now variable to accommodate different named font size parameters, so any name you use should fit within the dropdown box