### PR TITLE
Create a 'Default' category for Font Size which results in no font size styling

### DIFF
--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -202,7 +202,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
                 ),
             ],
             onSelected: (newSize) {
-              if (newSize != null) {
+              if (newSize != null) && (newSize > 0) {
                 controller
                     .formatSelection(Attribute.fromKeyValue('size', newSize));
               }

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -202,7 +202,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
                 ),
             ],
             onSelected: (newSize) {
-              if (newSize != null) && (newSize > 0) {
+              if ((newSize != null) && (newSize > 0)) {
                 controller
                     .formatSelection(Attribute.fromKeyValue('size', newSize));
               }

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -153,6 +153,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     //default font size values
     final fontSizes = fontSizeValues ??
         {
+          'Default':0,
           '10': 10,
           '12': 12,
           '14': 14,
@@ -202,10 +203,15 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
                 ),
             ],
             onSelected: (newSize) {
-              if ((newSize != null) && (newSize > 0)) {
+              if ((newSize != null) && (newSize as int > 0)) {
                 controller
                     .formatSelection(Attribute.fromKeyValue('size', newSize));
               }
+              if (newSize as int == 0)
+                {
+                controller
+                    .formatSelection(Attribute.fromKeyValue('size', null));
+                }
             },
             rawitemsmap: fontSizes,
             initialValue: (initialFontSizeValue != null) &&


### PR DESCRIPTION
If font-size 0 is used as an item in the `fontSizeValues` and is chosen, then all font-size attributes will be removed from delta.   

The standard list of default font sizes is updated with a `Default` option, that will try to apply a font-size of `0` that will end all font-size style for the given selection