### PR TITLE
This adds a new CustomIcons option to add your own icons to the QuillToolBar

### DIFF
--- a/lib/flutter_quill.dart
+++ b/lib/flutter_quill.dart
@@ -8,6 +8,7 @@ export 'src/models/documents/style.dart';
 export 'src/models/quill_delta.dart';
 export 'src/models/themes/quill_dialog_theme.dart';
 export 'src/models/themes/quill_icon_theme.dart';
+export 'src/models/themes/quill_custom_icon.dart';
 export 'src/widgets/controller.dart';
 export 'src/widgets/default_styles.dart';
 export 'src/widgets/editor.dart';

--- a/lib/src/models/themes/quill_custom_icon.dart
+++ b/lib/src/models/themes/quill_custom_icon.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class QuillCustomIcon {
+  const QuillCustomIcon(
+      {this.icon,
+        this.onTap});
+
+  ///The icon widget
+  final Widget? icon;
+
+  ///The function when the icon is tapped
+  final VoidCallback? onTap;
+}

--- a/lib/src/models/themes/quill_custom_icon.dart
+++ b/lib/src/models/themes/quill_custom_icon.dart
@@ -6,7 +6,7 @@ class QuillCustomIcon {
         this.onTap});
 
   ///The icon widget
-  final Widget? icon;
+  final IconData? icon;
 
   ///The function when the icon is tapped
   final VoidCallback? onTap;

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -64,6 +64,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     this.multiRowsDisplay = true,
     this.color,
     this.filePickImpl,
+    this.customIcons = const [],
     this.locale,
     Key? key,
   }) : super(key: key);
@@ -110,6 +111,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     FilePickImpl? filePickImpl,
     WebImagePickImpl? webImagePickImpl,
     WebVideoPickImpl? webVideoPickImpl,
+    List<QuillCustomIcon> customIcons = const [],
 
     ///Map of font sizes in [int]
     Map<String, int>? fontSizeValues,
@@ -173,6 +175,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
       toolbarSectionSpacing: toolbarSectionSpacing,
       toolbarIconAlignment: toolbarIconAlignment,
       multiRowsDisplay: multiRowsDisplay,
+      customIcons: customIcons,  
       locale: locale,
       children: [
         if (showUndo)
@@ -486,6 +489,9 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   /// More https://github.com/singerdmx/flutter-quill#translation
   final Locale? locale;
 
+  /// List of custom icons
+  final List<QuillCustomIcon> customIcons;
+    
   @override
   Size get preferredSize => Size.fromHeight(toolbarHeight);
 

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -23,6 +23,7 @@ import 'toolbar/toggle_check_list_button.dart';
 import 'toolbar/toggle_style_button.dart';
 import 'toolbar/video_button.dart';
 import 'toolbar/quill_dropdown_button.dart';
+import 'toolbar/quill_icon_button.dart';
 
 export 'toolbar/clear_format_button.dart';
 export 'toolbar/color_button.dart';
@@ -467,6 +468,22 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             iconTheme: iconTheme,
             dialogTheme: dialogTheme,
           ),
+        if (customIcons.isNotEmpty)
+          if (showDividers)
+            VerticalDivider(
+              indent: 12,
+              endIndent: 12,
+              color: Colors.grey.shade400,
+            ),
+          for (var customIcon in customIcons)
+            QuillIconButton(
+                highlightElevation: 0,
+                hoverElevation: 0,
+                size: toolbarIconSize * kIconButtonFactor,
+                icon: Icon(customIcon.icon, size: toolbarIconSize),
+                borderRadius:iconTheme?.borderRadius ?? 2,
+                onPressed: customIcon.onTap
+            ),
       ],
     );
   }

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -6,6 +6,7 @@ import 'package:i18n_extension/i18n_widget.dart';
 import '../models/documents/attribute.dart';
 import '../models/themes/quill_dialog_theme.dart';
 import '../models/themes/quill_icon_theme.dart';
+import '../models/themes/quill_custom_icon.dart';
 import 'controller.dart';
 import 'toolbar/arrow_indicated_button_list.dart';
 import 'toolbar/camera_button.dart';


### PR DESCRIPTION
New customIcons option that lets users add their own `icon` and icon `onTap` function to the toolbar.  New icons will goto the end of the toolbar

To add an Icon, we should use a new `QuillCustomIcon` class
```
                                QuillCustomIcon(
                                    icon:Icons.ac_unit,
                                    onTap: (){
                                      debugPrint('snowflake');
                                    }
                                ),
```

Each `QuillCustomIcon`  is used as part of the `customIcons` option as follows:

```
QuillToolbar.basic(
   (...),
    customIcons: [
                                QuillCustomIcon(
                                    icon:Icons.ac_unit,
                                    onTap: (){
                                      debugPrint('snowflake1');
                                    }
                                ),

                                QuillCustomIcon(
                                    icon:Icons.ac_unit,
                                    onTap: (){
                                      debugPrint('snowflake2');
                                    }
                                ),

                                QuillCustomIcon(
                                    icon:Icons.ac_unit,
                                    onTap: (){
                                      debugPrint('snowflake3');
                                    }
                                ),
    ]
```