### PR TITLE
Allow removing font size attribute from text

### DIFF
--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -199,7 +199,15 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             ],
             onSelected: (newSize) {
               controller.formatSelection(
-                  Attribute.fromKeyValue('size', getFontSize(newSize)));
+              if (newSize == '0') {
+                controller.formatSelection(
+                    Attribute.fromKeyValue('size', null));
+              }
+              else
+                {
+                  controller.formatSelection(
+                      Attribute.fromKeyValue('size', getFontSize(newSize)));
+                }
             },
             rawItemsMap: fontSizes,
           ),

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -198,7 +198,6 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
                 ),
             ],
             onSelected: (newSize) {
-              controller.formatSelection(
               if (newSize == '0') {
                 controller.formatSelection(
                     Attribute.fromKeyValue('size', null));

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -199,14 +199,12 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             ],
             onSelected: (newSize) {
               if (newSize == '0') {
+                controller
+                    .formatSelection(Attribute.fromKeyValue('size', null));
+              } else {
                 controller.formatSelection(
-                    Attribute.fromKeyValue('size', null));
+                    Attribute.fromKeyValue('size', getFontSize(newSize)));
               }
-              else
-                {
-                  controller.formatSelection(
-                      Attribute.fromKeyValue('size', getFontSize(newSize)));
-                }
             },
             rawItemsMap: fontSizes,
           ),


### PR DESCRIPTION
New changes have been great, but the problem is once you set a font size, you cannot unset the font size to no font size attribute in the delta.  

With this change, if a font size of `0` is used, then the font size attribute is remove from the text.  This would be a totally optional usage, as the default list of font sizes does not include an option of `0`, but a user can add it to a custom font size list if they wish