### PR TITLE
Update toolbar.dart

### DIFF
--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -198,7 +198,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
                       style: TextStyle(
                           color: fontSize.value == '0'
                               ? Colors.red
-                              : Colors.black)),
+                              : null)),
                 ),
             ],
             onSelected: (newSize) {


### PR DESCRIPTION
The text color of the PopupMenuItem should not be fixed to black. It looks bad in DarkMode and you can't style it via the theme. Changed to null to use the style from the theme.