### PR TITLE
Flutter Quill Doesn't Work On iOS 16 or Xcode 14 Betas (Stored properties cannot be marked potentially unavailable with '@available')

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   characters: ^1.2.0
   youtube_player_flutter:
     git:
-      url: git://github.com/garv-shah/youtube_player_flutter
+      url: https://github.com/garv-shah/youtube_player_flutter
       ref: master
       path: packages/youtube_player_flutter/
   diff_match_patch: ^0.4.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,11 @@ dependencies:
   pedantic: ^1.11.1
   video_player: ^2.4.2
   characters: ^1.2.0
-  youtube_player_flutter: ^8.1.0
+  youtube_player_flutter:
+    git:
+      url: git://github.com/garv-shah/youtube_player_flutter
+      ref: master
+      path: packages/youtube_player_flutter/
   diff_match_patch: ^0.4.1
   i18n_extension: ^5.0.0
   gallery_saver: ^2.3.2


### PR DESCRIPTION
As documented in this issue here (https://github.com/pichillilorenzo/flutter_inappwebview/issues/1251), one of Flutter Quill's dependencies, Flutter In App Webview, causes the following issue on the new apple betas:

```bash
Could not build the precompiled application for the device.
Swift Compiler Error (Xcode): Stored properties cannot be marked potentially unavailable with '@available'
/Users/garv/development/flutter/.pub-cache/hosted/pub.dartlang.org/flutter_inappwebview-5.4.3+7/ios/Classes/Types/UserScript.swift:12:5

Uncategorized (Xcode): Command SwiftCompile failed with a nonzero exit code
```

As such, the following PR to Flutter In App Webview could be used to circumvent the issue: https://github.com/pichillilorenzo/flutter_inappwebview/pull/1238

The problem is, for Flutter Quill, this is a dependency of a dependency, going Flutter Quill -> YouTube Player Flutter -> Flutter In App Webview, and YouTube Player Flutter doesn't seem very frequently updated, so it may be quite a few months before this is fixed.

As such, this PR changes the dependency to a fork of these repos, to fix the above issue :D