### PR TITLE
Fixed Flutter Quill Not Working With Xcode 14 Beta or iOS 16 Beta

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   characters: ^1.2.0
   youtube_player_flutter:
     git:
-      url: git://github.com/garv-shah/youtube_player_flutter
+      url: https://github.com/garv-shah/youtube_player_flutter
       ref: master
       path: packages/youtube_player_flutter/
   diff_match_patch: ^0.4.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,11 @@ dependencies:
   pedantic: ^1.11.1
   video_player: ^2.4.2
   characters: ^1.2.0
-  youtube_player_flutter: ^8.1.0
+  youtube_player_flutter:
+    git:
+      url: git://github.com/garv-shah/youtube_player_flutter
+      ref: master
+      path: packages/youtube_player_flutter/
   diff_match_patch: ^0.4.1
   i18n_extension: ^5.0.0
   gallery_saver: ^2.3.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,11 +24,7 @@ dependencies:
   pedantic: ^1.11.1
   video_player: ^2.4.2
   characters: ^1.2.0
-  youtube_player_flutter:
-    git:
-      url: https://github.com/garv-shah/youtube_player_flutter
-      ref: master
-      path: packages/youtube_player_flutter/
+  youtube_player_flutter_quill: ^8.2.0
   diff_match_patch: ^0.4.1
   i18n_extension: ^5.0.0
   gallery_saver: ^2.3.2


### PR DESCRIPTION
@singerdmx i got the package uploaded to pub [here](https://pub.dev/packages/youtube_player_flutter_quill/versions/8.2.0) :)
Sorry it took so long, was figuring out how pub worked, hopefully this can be published successfully