### PR TITLE
Don't wrap the child in the EditorTextSelectionGestureDetector if selection is disabled

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -493,11 +493,14 @@ class QuillEditorState extends State<QuillEditor>
     );
 
     final editor = I18n(
-        initialLocale: widget.locale,
-        child: _selectionGestureDetectorBuilder.build(
-          behavior: HitTestBehavior.translucent,
-          child: child,
-        ));
+      initialLocale: widget.locale,
+      child: selectionEnabled
+          ? _selectionGestureDetectorBuilder.build(
+              behavior: HitTestBehavior.translucent,
+              child: child,
+            )
+          : child,
+    );
 
     if (kIsWeb) {
       // Intercept RawKeyEvent on Web to prevent it from propagating to parents


### PR DESCRIPTION
When text selection is disabled it doesn't make sense to wrap the `QuillEditor`s child with `EditorTextSelectionGestureDetector`.

This makes handling gestures for read-only, unselectable contents by wrapping the `QuillEditor` in `GestureDetector` more reliable as `EditorTextSelectionGestureDetector` seems to intercept some gestures over the `QuillEditor`.