### PR TITLE
Remove default small color

### DIFF
--- a/lib/src/widgets/default_styles.dart
+++ b/lib/src/widgets/default_styles.dart
@@ -245,7 +245,7 @@ class DefaultStyles {
             baseStyle, const Tuple2(0, 0), const Tuple2(0, 0), null),
         bold: const TextStyle(fontWeight: FontWeight.bold),
         italic: const TextStyle(fontStyle: FontStyle.italic),
-        small: const TextStyle(fontSize: 12, color: Colors.black45),
+        small: const TextStyle(fontSize: 12),
         underline: const TextStyle(decoration: TextDecoration.underline),
         strikeThrough: const TextStyle(decoration: TextDecoration.lineThrough),
         inlineCode: InlineCodeStyle(


### PR DESCRIPTION
Black color works well with light mode but will be broken in dark mode.