### PR TITLE
fix wrong custom embed key

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -485,14 +485,15 @@ class QuillEditorState extends State<QuillEditor>
 
         if (builders != null) {
           var _node = node;
+          final type = node.value.type;
 
           // Creates correct node for custom embed
-          if (node.value.type == BlockEmbed.customType) {
+          if (type == BlockEmbed.customType) {
             _node = Embed(CustomBlockEmbed.fromJsonString(node.value.data));
           }
 
           for (final builder in builders) {
-            if (builder.key == _node.value.type) {
+            if (builder.key == type) {
               return builder.build(context, controller, _node, readOnly);
             }
           }


### PR DESCRIPTION
_node.value.type & node.value.type has different value in custom embed case which lead to error, should always use `node.value.type`.

See how it error In `editor.dart`:
```dart
if (builders != null) {
  var _node = node;

  // Creates correct node for custom embed
  if (node.value.type == BlockEmbed.customType) {
    _node = Embed(CustomBlockEmbed.fromJsonString(node.value.data));
  }

  // error here since it can't find that key
  for (final builder in builders) {
    if (builder.key == _node.value.type) {
      return builder.build(context, controller, _node, readOnly);
    }
  }
}

throw UnimplementedError(
  'Embeddable type "${node.value.type}" is not supported by supplied '
  'embed builders. You must pass your own builder function to '
  'embedBuilders property of QuillEditor or QuillField widgets.',
);
```