### PR TITLE
Changes to support custom attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,81 @@ QuillToolbar.basic(
     ]
 ```
 
+### Custom Attributes
+Often times we want to apply a style that is not available by default with the use of existing toolbar buttons. For such cases, we can simply add a custom toolbar button to apply a custom attribute to the selected text.
+
+We can create a custom attribute by defining the class as such:
+```dart
+class CustomAttribute extends Attribute<bool?> {
+  const CustomAttribute(bool? val)
+      : super(KEY, AttributeScope.INLINE, val);
+
+  static const String KEY = 'my-custom-attr';
+}
+```
+
+We should then register the attribute when the app is started.
+
+```dart
+void main() {
+  Attribute.addCustomAttribute(const CustomAttribute(null));
+  runApp(MyApp());
+}
+```
+
+After that we can define a custom style builder and handle the text style that will be applied for the given attribute. For example, the below code will apply a blue color and yellow background if a text contains this attribute.
+```dart
+  TextStyle _customStyleBuilder(Attribute attr) {
+    if (attr.key == CustomAttribute.KEY) {
+      return TextStyle(
+          color: Colors.blue, backgroundColor: Colors.yellow);
+    }
+
+    return const TextStyle();
+  }
+
+  Widget build(BuildContext context) {
+    var quillEditor = QuillEditor(
+    ...
+    customStyleBuilder: _customStyleBuilder,
+    );
+    ...
+  }
+```
+
+You can then add a custom toolbar button that will apply this attribute to the selected text.
+```dart
+  var toolbar = QuillToolbar.basic(
+    controller: controller,
+    customButtons: [
+      QuillCustomButton(
+          icon: Icons.smart_toy_sharp,
+          onTap: () {
+            if (controller
+                .getSelectionStyle()
+                .attributes
+                .keys
+                .contains(CustomAttribute.KEY)) {
+              // remove the attribute if it's already applied
+              controller
+                  .formatSelection(const CustomAttribute(null));
+            } else {
+              // add the attribute
+              controller
+                  .formatSelection(const CustomAttribute(true));
+            }
+          },
+          isToggled: () {
+            // determine whether the button should be in a toggled state
+            return controller
+                .getSelectionStyle()
+                .attributes
+                .containsKey(CustomAttribute.KEY);
+          })
+    ],
+);
+```
+
 
 ## Embed Blocks
 

--- a/example/lib/pages/custom_attr_page.dart
+++ b/example/lib/pages/custom_attr_page.dart
@@ -1,0 +1,128 @@
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_quill/flutter_quill.dart' hide Text;
+import 'package:flutter_quill_extensions/flutter_quill_extensions.dart';
+
+import '../universal_ui/universal_ui.dart';
+import '../widgets/demo_scaffold.dart';
+
+class CustomAttrPage extends StatefulWidget {
+  CustomAttrPage() {
+    // should probably be called when the app first starts but since the
+    // registry is a hashmap then it won't really matter for this example
+    Attribute.addCustomAttribute(const RandomColorAttribute(true));
+  }
+
+  @override
+  _CustomAttrPageState createState() => _CustomAttrPageState();
+}
+
+class _CustomAttrPageState extends State<CustomAttrPage> {
+  final FocusNode _focusNode = FocusNode();
+  QuillController? _controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return DemoScaffold(
+      documentFilename: 'sample_data_nomedia.json',
+      builder: _buildContent,
+      customButtons: [
+        QuillCustomButton(
+            icon: Icons.smart_toy_sharp,
+            onTap: () {
+              if (_controller != null) {
+                if (_controller!
+                    .getSelectionStyle()
+                    .attributes
+                    .keys
+                    .contains(RandomColorAttribute.KEY)) {
+                  _controller!
+                      .formatSelection(const RandomColorAttribute(null));
+                } else {
+                  _controller!
+                      .formatSelection(const RandomColorAttribute(true));
+                }
+              }
+            },
+            isToggled: () {
+              return _controller != null &&
+                  _controller!
+                      .getSelectionStyle()
+                      .attributes
+                      .containsKey(RandomColorAttribute.KEY);
+            })
+      ],
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          setState(() {
+            // update ui and randomize the colors
+          });
+        },
+        child: const Icon(Icons.refresh),
+      ),
+      title: 'Custom attribute demo',
+    );
+  }
+
+  Widget _buildContent(BuildContext context, QuillController? controller) {
+    _controller = controller;
+    var quillEditor = QuillEditor(
+      controller: controller!,
+      scrollController: ScrollController(),
+      scrollable: true,
+      focusNode: _focusNode,
+      autoFocus: true,
+      readOnly: false,
+      expands: false,
+      padding: EdgeInsets.zero,
+      embedBuilders: FlutterQuillEmbeds.builders(),
+      customStyleBuilder: _customStyleBuilder,
+    );
+    if (kIsWeb) {
+      quillEditor = QuillEditor(
+        controller: controller,
+        scrollController: ScrollController(),
+        scrollable: true,
+        focusNode: _focusNode,
+        autoFocus: true,
+        readOnly: false,
+        expands: false,
+        padding: EdgeInsets.zero,
+        embedBuilders: defaultEmbedBuildersWeb,
+        customStyleBuilder: _customStyleBuilder,
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.all(8),
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          border: Border.all(color: Colors.grey.shade200),
+        ),
+        child: quillEditor,
+      ),
+    );
+  }
+
+  TextStyle _customStyleBuilder(Attribute attr) {
+    if (attr.key == RandomColorAttribute.KEY) {
+      // generate a random text color
+      return TextStyle(
+          color:
+              Color((Random().nextDouble() * 0xFFFFFF).toInt()).withOpacity(1));
+    }
+
+    return const TextStyle();
+  }
+}
+
+// custom inline attribute
+class RandomColorAttribute extends Attribute<bool?> {
+  const RandomColorAttribute(bool? val)
+      : super(KEY, AttributeScope.INLINE, val);
+
+  static const String KEY = 'random-color';
+}

--- a/example/lib/pages/home_page.dart
+++ b/example/lib/pages/home_page.dart
@@ -15,6 +15,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:tuple/tuple.dart';
 
 import '../universal_ui/universal_ui.dart';
+import 'custom_attr_page.dart';
 import 'read_only_page.dart';
 
 class HomePage extends StatefulWidget {
@@ -342,15 +343,33 @@ class _HomePageState extends State<HomePage> {
           indent: size.width * 0.1,
           endIndent: size.width * 0.1,
         ),
+        ListTile(
+          title:
+              const Center(child: Text('Custom attr demo', style: itemStyle)),
+          dense: true,
+          visualDensity: VisualDensity.compact,
+          onTap: _openCustomAttrPage,
+        ),
       ],
     );
   }
 
   void _readOnly() {
+    Navigator.pop(super.context);
     Navigator.push(
       super.context,
       MaterialPageRoute(
         builder: (context) => ReadOnlyPage(),
+      ),
+    );
+  }
+
+  void _openCustomAttrPage() {
+    Navigator.pop(super.context);
+    Navigator.push(
+      super.context,
+      MaterialPageRoute(
+        builder: (context) => CustomAttrPage(),
       ),
     );
   }

--- a/example/lib/pages/read_only_page.dart
+++ b/example/lib/pages/read_only_page.dart
@@ -20,15 +20,14 @@ class _ReadOnlyPageState extends State<ReadOnlyPage> {
   @override
   Widget build(BuildContext context) {
     return DemoScaffold(
-      documentFilename: isDesktop()
-          ? 'assets/sample_data_nomedia.json'
-          : 'sample_data_nomedia.json',
+      documentFilename: 'sample_data_nomedia.json',
       builder: _buildContent,
       showToolbar: _edit == true,
       floatingActionButton: FloatingActionButton.extended(
           label: Text(_edit == true ? 'Done' : 'Edit'),
           onPressed: _toggleEdit,
           icon: Icon(_edit == true ? Icons.check : Icons.edit)),
+      title: 'Read only demo',
     );
   }
 

--- a/example/lib/widgets/demo_scaffold.dart
+++ b/example/lib/widgets/demo_scaffold.dart
@@ -20,6 +20,8 @@ class DemoScaffold extends StatefulWidget {
     this.actions,
     this.showToolbar = true,
     this.floatingActionButton,
+    this.customButtons,
+    this.title = '',
     Key? key,
   }) : super(key: key);
 
@@ -29,24 +31,23 @@ class DemoScaffold extends StatefulWidget {
   final List<Widget>? actions;
   final Widget? floatingActionButton;
   final bool showToolbar;
+  final List<QuillCustomButton>? customButtons;
+  final String title;
 
   @override
   _DemoScaffoldState createState() => _DemoScaffoldState();
 }
 
 class _DemoScaffoldState extends State<DemoScaffold> {
-  final _scaffoldKey = GlobalKey<ScaffoldState>();
   QuillController? _controller;
 
   bool _loading = false;
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_controller == null && !_loading) {
-      _loading = true;
-      _loadFromAssets();
-    }
+  void initState() {
+    super.initState();
+    _loading = true;
+    _loadFromAssets();
   }
 
   @override
@@ -93,36 +94,34 @@ class _DemoScaffoldState extends State<DemoScaffold> {
     var toolbar = QuillToolbar.basic(
       controller: _controller!,
       embedButtons: FlutterQuillEmbeds.buttons(),
+      customButtons: widget.customButtons ?? [],
     );
     if (_isDesktop()) {
       toolbar = QuillToolbar.basic(
         controller: _controller!,
         embedButtons: FlutterQuillEmbeds.buttons(
             filePickImpl: openFileSystemPickerForDesktop),
+        customButtons: widget.customButtons ?? [],
       );
     }
     return Scaffold(
-      key: _scaffoldKey,
       appBar: AppBar(
         elevation: 0,
-        backgroundColor: Theme.of(context).canvasColor,
+        backgroundColor: Colors.grey.shade800,
+        title: Text(widget.title),
         centerTitle: false,
         titleSpacing: 0,
-        leading: IconButton(
-          icon: Icon(
-            Icons.chevron_left,
-            color: Colors.grey.shade800,
-            size: 18,
-          ),
-          onPressed: () => Navigator.pop(context),
-        ),
-        title: _loading || !widget.showToolbar ? null : toolbar,
         actions: actions,
       ),
       floatingActionButton: widget.floatingActionButton,
       body: _loading
           ? const Center(child: Text('Loading...'))
           : widget.builder(context, _controller),
+      bottomNavigationBar: _loading || !widget.showToolbar
+          ? null
+          : BottomAppBar(
+              child: toolbar,
+            ),
     );
   }
 

--- a/lib/flutter_quill.dart
+++ b/lib/flutter_quill.dart
@@ -7,6 +7,7 @@ export 'src/models/documents/nodes/leaf.dart';
 export 'src/models/documents/nodes/node.dart';
 export 'src/models/documents/style.dart';
 export 'src/models/quill_delta.dart';
+export 'src/models/rules/rule.dart';
 export 'src/models/themes/quill_custom_button.dart';
 export 'src/models/themes/quill_dialog_theme.dart';
 export 'src/models/themes/quill_icon_theme.dart';

--- a/lib/src/models/documents/attribute.dart
+++ b/lib/src/models/documents/attribute.dart
@@ -17,6 +17,10 @@ class Attribute<T> {
   final AttributeScope scope;
   final T value;
 
+  static void addCustomAttribute(Attribute attr) {
+    _registry[attr.key] = attr;
+  }
+
   static final Map<String, Attribute> _registry = LinkedHashMap.of({
     Attribute.bold.key: Attribute.bold,
     Attribute.italic.key: Attribute.italic,

--- a/lib/src/models/themes/quill_custom_button.dart
+++ b/lib/src/models/themes/quill_custom_button.dart
@@ -1,11 +1,136 @@
 import 'package:flutter/material.dart';
 
-class QuillCustomButton {
-  const QuillCustomButton({this.icon, this.onTap});
+import '../../../flutter_quill.dart';
 
-  ///The icon widget
+class QuillCustomButton {
+  const QuillCustomButton(
+      {this.icon,
+      this.onTap,
+      this.isToggled,
+      this.builder = defaultCustomButtonBuilder});
+
+  // The icon widget
   final IconData? icon;
 
-  ///The function when the icon is tapped
+  // The function when the icon is tapped
   final VoidCallback? onTap;
+
+  // The function to determine whether the button is toggled
+  final CustomButtonToggled? isToggled;
+
+  // Can specify a custom builder to build the widget
+  final CustomButtonBuilder builder;
 }
+
+class QuillCustomButtonWidget extends StatefulWidget {
+  const QuillCustomButtonWidget(
+      {required this.button,
+      required this.controller,
+      required this.iconSize,
+      this.iconTheme,
+      this.afterPressed});
+
+  final QuillCustomButton button;
+  final QuillController controller;
+  final double iconSize;
+  final QuillIconTheme? iconTheme;
+  final VoidCallback? afterPressed;
+
+  @override
+  State<QuillCustomButtonWidget> createState() =>
+      _QuillCustomButtonWidgetState();
+}
+
+class _QuillCustomButtonWidgetState extends State<QuillCustomButtonWidget> {
+  bool _toggled = false;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // set the initial toggled state
+    _toggled =
+        widget.button.isToggled != null ? widget.button.isToggled!() : false;
+
+    // add listener to update the toggled state
+    widget.controller.addListener(_didChangeEditingValue);
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_didChangeEditingValue);
+    super.dispose();
+  }
+
+  void _didChangeEditingValue() {
+    final toggled =
+        widget.button.isToggled != null ? widget.button.isToggled!() : false;
+
+    if (toggled != _toggled) {
+      setState(() {
+        _toggled = toggled;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.button.builder(
+        context,
+        widget.controller,
+        widget.button.icon,
+        widget.iconSize,
+        widget.iconTheme,
+        _toggled,
+        widget.button.onTap,
+        widget.afterPressed);
+  }
+}
+
+typedef CustomButtonBuilder = Widget Function(
+  BuildContext context,
+  QuillController controller,
+  IconData? icon,
+  double iconSize,
+  QuillIconTheme? iconTheme,
+  bool isToggled,
+  VoidCallback? onPressed,
+  VoidCallback? afterPressed,
+);
+
+Widget defaultCustomButtonBuilder(
+  BuildContext context,
+  QuillController controller,
+  IconData? icon,
+  double iconSize,
+  QuillIconTheme? iconTheme,
+  bool isToggled,
+  VoidCallback? onPressed,
+  VoidCallback? afterPressed,
+) {
+  final theme = Theme.of(context);
+  final isEnabled = onPressed != null;
+  final iconColor = isEnabled
+      ? isToggled
+          ? (iconTheme?.iconSelectedColor ?? theme.primaryIconTheme.color)
+          : (iconTheme?.iconUnselectedColor ?? theme.iconTheme.color)
+      : (iconTheme?.disabledIconColor ?? theme.disabledColor);
+  final fill = isEnabled
+      ? isToggled
+          ? (iconTheme?.iconSelectedFillColor ?? theme.toggleableActiveColor)
+          : (iconTheme?.iconUnselectedFillColor ?? theme.canvasColor)
+      : (iconTheme?.disabledIconFillColor ?? theme.canvasColor);
+
+  return QuillIconButton(
+    highlightElevation: 0,
+    hoverElevation: 0,
+    size: iconSize * kIconButtonFactor,
+    icon: Icon(icon, size: iconSize, color: iconColor),
+    fillColor: fill,
+    onPressed: onPressed,
+    afterPressed: afterPressed,
+    borderRadius: iconTheme?.borderRadius ?? 2,
+  );
+}
+
+typedef CustomButtonToggled = bool Function();

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -486,13 +486,11 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
               color: Colors.grey.shade400,
             ),
         for (var customButton in customButtons)
-          QuillIconButton(
-            highlightElevation: 0,
-            hoverElevation: 0,
-            size: toolbarIconSize * kIconButtonFactor,
-            icon: Icon(customButton.icon, size: toolbarIconSize),
-            borderRadius: iconTheme?.borderRadius ?? 2,
-            onPressed: customButton.onTap,
+          QuillCustomButtonWidget(
+            button: customButton,
+            controller: controller,
+            iconSize: toolbarIconSize,
+            iconTheme: iconTheme,
             afterPressed: afterButtonPressed,
           ),
       ],


### PR DESCRIPTION
Even though there is existing code to support custom attributes/rules there doesn't seem to be a way to actually use them without running into some type of issue. This PR addresses these issues along with some other related fixes.

1. Custom attribute with scope != IGNORE. (#582)
For example, if you attempt to add an INLINE custom attribute then you might see the following error:
```
Assertion failed: file:///lib/src/models/documents/nodes/leaf.dart:30:12
value.isInline || value.isIgnored || value.isEmpty
"Unable to apply Style to leaf: {Attribute{key: custom-attr, scope: AttributeScope.IGNORE, value: custom}}"
```

This is caused by remapping any attribute that is not found in the Attribute registry to scope IGNORE. So even though you might have defined your attribute as INLINE it will get changed to IGNORE when reading the document from json. The following code in lib/src/models/documents/style.dart:14 is causing this:

 ```dart
 static Style fromJson(Map<String, dynamic>? attributes) {
    if (attributes == null) {
      return Style();
    }

    final result = attributes.map((key, dynamic value) {
      final attr = Attribute.fromKeyValue(key, value);
      return MapEntry<String, Attribute>(
          key, attr ?? Attribute(key, AttributeScope.IGNORE, value));
    });
    return Style.attr(result);
  }
```

The easy way to handle this would be to allow adding custom attributes to the registry which is what this PR does. Ideally you just add the custom attribute to the registry when the app starts. This in turn allows you to add custom attributes that take advantage of existing rules.

```dart
void main() {
  Attribute.addCustomAttribute(const CustomAttribute());
  runApp(MyApp());
}
```

2. Custom attribute with scope == IGNORE
If you try to add a custom attribute with scope IGNORE then you will run into another issue, mainly not being able to add custom rules to handle the custom attribute. The Rule class not being exported means that new rules cannot be added. See issue #617. This PR exports the Rule class.

3. Custom button styling
Custom button styling is limited and currently doesn't apply the styles defined in icon theme. Made the necessary changes to fix that.

4. Fixed the read only demo page and added a demo page for custom attributes.