### PR TITLE
Make QuillController.document mutable.

### DIFF
--- a/lib/src/widgets/controller.dart
+++ b/lib/src/widgets/controller.dart
@@ -17,14 +17,15 @@ typedef DeleteCallback = void Function(int cursorPosition, bool forward);
 
 class QuillController extends ChangeNotifier {
   QuillController({
-    required this.document,
+    required Document document,
     required TextSelection selection,
     bool keepStyleOnNewLine = false,
     this.onReplaceText,
     this.onDelete,
     this.onSelectionCompleted,
     this.onSelectionChanged,
-  })  : _selection = selection,
+  })  : _document = document,
+        _selection = selection,
         _keepStyleOnNewLine = keepStyleOnNewLine;
 
   factory QuillController.basic() {
@@ -35,7 +36,12 @@ class QuillController extends ChangeNotifier {
   }
 
   /// Document managed by this controller.
-  final Document document;
+  Document _document;
+  Document get document => _document;
+  set document(doc) {
+    _document = doc;
+    notifyListeners();
+  }
 
   /// Tells whether to keep or reset the [toggledStyle]
   /// when user adds a new line.


### PR DESCRIPTION
This allows you to update the editor's document, swapping out the contents, while retaining that document's undo/redo buffers etc.