### PR TITLE
Fixes null pointer when setting documents.

### DIFF
--- a/lib/src/widgets/controller.dart
+++ b/lib/src/widgets/controller.dart
@@ -40,6 +40,10 @@ class QuillController extends ChangeNotifier {
   Document get document => _document;
   set document(doc) {
     _document = doc;
+
+    // Prevent the selection from
+    _selection = const TextSelection(baseOffset: 0, extentOffset: 0);
+
     notifyListeners();
   }
 


### PR DESCRIPTION
This fixes a null pointer error that happens when the document is set and the current text selection is past the end of the new document's length.