### PR TITLE
upgrades device info plus to ^7.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   characters: ^1.2.0
   diff_match_patch: ^0.4.1
   i18n_extension: ^5.0.1
-  device_info_plus: ^4.0.0
+  device_info_plus: ^7.0.0
   platform: ^3.1.0
   pasteboard: ^0.2.0
 


### PR DESCRIPTION
Pretty simple. We are unable to upgrade a number of dependencies in our application due to dependency issues with this package.