### PR TITLE
Remove showAutocorrectionPromptRect isn't implemented exception

### DIFF
--- a/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -283,7 +283,8 @@ mixin RawEditorStateTextInputClientMixin on EditorState
 
   @override
   void showAutocorrectionPromptRect(int start, int end) {
-    throw UnimplementedError();
+    // this is called VERY OFTEN when editing a document, no longer throw an exception
+    // throw UnimplementedError();
   }
 
   @override


### PR DESCRIPTION
showAutocorrectionPromptRect isn't implemented, however, don't throw not implemented exception.

The function is called with every keystroke as a user is typing on iOS.