### PR TITLE
Add typing shortcuts

### DIFF
--- a/lib/src/utils/cast.dart
+++ b/lib/src/utils/cast.dart
@@ -1,0 +1,1 @@
+T? castOrNull<T>(dynamic x) => x is T ? x : null;

--- a/lib/src/widgets/controller.dart
+++ b/lib/src/widgets/controller.dart
@@ -102,6 +102,26 @@ class QuillController extends ChangeNotifier {
         .mergeAll(toggledStyle);
   }
 
+  // Increases or decreases the indent of the current selection by 1.
+  void indentSelection(bool isIncrease) {
+    final indent = getSelectionStyle().attributes[Attribute.indent.key];
+    if (indent == null) {
+      if (isIncrease) {
+        formatSelection(Attribute.indentL1);
+      }
+      return;
+    }
+    if (indent.value == 1 && !isIncrease) {
+      formatSelection(Attribute.clone(Attribute.indentL1, null));
+      return;
+    }
+    if (isIncrease) {
+      formatSelection(Attribute.getIndentLevel(indent.value + 1));
+      return;
+    }
+    formatSelection(Attribute.getIndentLevel(indent.value - 1));
+  }
+
   /// Returns all styles for each node within selection
   List<Tuple2<int, Style>> getAllIndividualSelectionStyles() {
     final styles = document.collectAllIndividualStyles(

--- a/lib/src/widgets/toolbar/indent_button.dart
+++ b/lib/src/widgets/toolbar/indent_button.dart
@@ -42,27 +42,7 @@ class _IndentButtonState extends State<IndentButton> {
       fillColor: iconFillColor,
       borderRadius: widget.iconTheme?.borderRadius ?? 2,
       onPressed: () {
-        final indent = widget.controller
-            .getSelectionStyle()
-            .attributes[Attribute.indent.key];
-        if (indent == null) {
-          if (widget.isIncrease) {
-            widget.controller.formatSelection(Attribute.indentL1);
-          }
-          return;
-        }
-        if (indent.value == 1 && !widget.isIncrease) {
-          widget.controller
-              .formatSelection(Attribute.clone(Attribute.indentL1, null));
-          return;
-        }
-        if (widget.isIncrease) {
-          widget.controller
-              .formatSelection(Attribute.getIndentLevel(indent.value + 1));
-          return;
-        }
-        widget.controller
-            .formatSelection(Attribute.getIndentLevel(indent.value - 1));
+        widget.controller.indentSelection(widget.isIncrease);
       },
       afterPressed: widget.afterButtonPressed,
     );


### PR DESCRIPTION
This adds typing shortcuts that are similar to quill-js and apple's notes application.

Start lists with "1." or "-". When you press space after either of these strings, it will automatically format them as actual lists.

Indent / Dedent lists with <Tab> and <Shift+Tab>.