### PR TITLE
exports more nodes to the public API

### DIFF
--- a/lib/flutter_quill.dart
+++ b/lib/flutter_quill.dart
@@ -2,8 +2,10 @@ library flutter_quill;
 
 export 'src/models/documents/attribute.dart';
 export 'src/models/documents/document.dart';
+export 'src/models/documents/nodes/block.dart';
 export 'src/models/documents/nodes/embeddable.dart';
 export 'src/models/documents/nodes/leaf.dart';
+export 'src/models/documents/nodes/line.dart';
 export 'src/models/documents/nodes/node.dart';
 export 'src/models/documents/style.dart';
 export 'src/models/quill_delta.dart';


### PR DESCRIPTION
For a project I'm working on (a HTML to quill parser), I need to expose more nodes, for now it's just `line` and `block`. That could be cleaner to wrap what to be exposed within a `nodes/nodes.dart` & I could create a new PR addressing this.