### PR TITLE
Aligns numerical and bullet lists with text content

### DIFF
--- a/lib/src/widgets/text_block.dart
+++ b/lib/src/widgets/text_block.dart
@@ -135,6 +135,7 @@ class EditableTextBlock extends StatelessWidget {
           _buildLeading(context, line, index, indentLevelCounts, count),
           TextLine(
             line: line,
+            index: index,
             textDirection: textDirection,
             embedBuilder: embedBuilder,
             customStyleBuilder: customStyleBuilder,
@@ -164,25 +165,6 @@ class EditableTextBlock extends StatelessWidget {
       Map<int, int> indentLevelCounts, int count) {
     final defaultStyles = QuillStyles.getStyles(context, false);
     final attrs = line.style.attributes;
-    if (attrs[Attribute.list.key] == Attribute.ol) {
-      return QuillNumberPoint(
-        index: index,
-        indentLevelCounts: indentLevelCounts,
-        count: count,
-        style: defaultStyles!.leading!.style,
-        attrs: attrs,
-        width: 32,
-        padding: 8,
-      );
-    }
-
-    if (attrs[Attribute.list.key] == Attribute.ul) {
-      return QuillBulletPoint(
-        style:
-            defaultStyles!.leading!.style.copyWith(fontWeight: FontWeight.bold),
-        width: 32,
-      );
-    }
 
     if (attrs[Attribute.list.key] == Attribute.checked) {
       return CheckboxPoint(
@@ -235,8 +217,7 @@ class EditableTextBlock extends StatelessWidget {
 
     var baseIndent = 0.0;
 
-    if (attrs.containsKey(Attribute.list.key) ||
-        attrs.containsKey(Attribute.codeBlock.key)) {
+    if (attrs.containsKey(Attribute.codeBlock.key)) {
       baseIndent = 32.0;
     }
 

--- a/lib/src/widgets/text_line.dart
+++ b/lib/src/widgets/text_line.dart
@@ -38,12 +38,14 @@ class TextLine extends StatefulWidget {
     required this.controller,
     required this.onLaunchUrl,
     required this.linkActionPicker,
+    this.index,
     this.textDirection,
     this.customStyleBuilder,
     Key? key,
   }) : super(key: key);
 
   final Line line;
+  final int? index;
   final TextDirection? textDirection;
   final EmbedsBuilder embedBuilder;
   final DefaultStyles styles;
@@ -294,9 +296,22 @@ class _TextLineState extends State<TextLine> {
     final nodeStyle = textNode.style;
     final isLink = nodeStyle.containsKey(Attribute.link.key) &&
         nodeStyle.attributes[Attribute.link.key]!.value != null;
+    final attrs = widget.line.style.attributes;
+    const whiteSpace = TextSpan(text: ' ');
+
+    var leading = const TextSpan();
+    if (attrs[Attribute.list.key] == Attribute.ol) {
+      leading = TextSpan(text: '${widget.index.toString()}.');
+    } else if (attrs[Attribute.list.key] == Attribute.ul) {
+      leading = TextSpan(
+        text: '•',
+        style:
+            defaultStyles.leading!.style.copyWith(fontWeight: FontWeight.bold),
+      );
+    }
 
     return TextSpan(
-      text: textNode.value,
+      children: [leading, whiteSpace, TextSpan(text: textNode.value)],
       style: _getInlineTextStyle(
           textNode, defaultStyles, nodeStyle, lineStyle, isLink),
       recognizer: isLink && canLaunchLinks ? _getRecognizer(node) : null,


### PR DESCRIPTION
This PR fixes the issue with numerical and bullet points always being aligned to the left even when the text is center or right aligned. Quill.js has support for numerical and bullet points being aligned with the text content and this PR adds that support for Flutter Quill.

This PR solves issue #1053

Look at the screenshots below to see the differences.

**Flutter Quill: Current**

![Simulator Screen Shot - iPhone 13 - 2023-01-10 at 09 54 40](https://user-images.githubusercontent.com/39175434/211584273-129c8614-765f-477f-8f1a-a0c64e9f71a8.png)

**Flutter Quill: Updated**

![Simulator Screen Shot - iPhone 13 - 2023-01-09 at 17 24 05](https://user-images.githubusercontent.com/39175434/211420466-347dce8c-bdd1-4fd5-9166-13c9831ab578.png)

**Quill JS** - https://quilljs.com/docs/formats/

<img width="838" alt="Screen Shot 2023-01-09 at 5 22 12 PM" src="https://user-images.githubusercontent.com/39175434/211420219-37815bfa-dee6-4cb1-9e32-a2c26101ee83.png">
