### PR TITLE
fix: nextLine getter null where no assertion

### DIFF
--- a/lib/src/models/documents/nodes/line.dart
+++ b/lib/src/models/documents/nodes/line.dart
@@ -381,7 +381,7 @@ class Line extends Container<Leaf?> {
     }
 
     final remaining = len - local;
-    if (remaining > 0) {
+    if (remaining > 0 && nextLine != null) {
       final rest = nextLine!.collectStyle(0, remaining);
       _handle(rest);
     }
@@ -416,7 +416,7 @@ class Line extends Container<Leaf?> {
     // TODO: add line style and parent's block style
 
     final remaining = len - local;
-    if (remaining > 0) {
+    if (remaining > 0 && nextLine != null) {
       final rest =
           nextLine!.collectAllIndividualStyles(0, remaining, beg: local);
       result.addAll(rest);
@@ -450,7 +450,7 @@ class Line extends Container<Leaf?> {
     }
 
     final remaining = len - local;
-    if (remaining > 0) {
+    if (remaining > 0 && nextLine != null) {
       final rest = nextLine!.collectAllStyles(0, remaining);
       result.addAll(rest);
     }
@@ -501,7 +501,7 @@ class Line extends Container<Leaf?> {
         }
       }
 
-      if (_len > 0) {
+      if (_len > 0 && nextLine != null) {
         _len = nextLine!._getPlainText(0, _len, plainText);
       }
     }


### PR DESCRIPTION
Got this error from crashlytics. Only check null safe where there is no `assert(nextLine != null)` which mean it doesn't require nextLine to have value.

```s
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Null check operator used on a null value. Error thrown Instance of 'ErrorDescription'.
       at Line.collectStyle(line.dart:385)
       at Document.collectStyle(document.dart:157)
       at QuillController.getSelectionStyle(controller.dart:101)
       at _ToggleStyleButtonState._selectionStyle(toggle_style_button.dart:57)
       at _ToggleStyleButtonState._didChangeEditingValue.<fn>(toggle_style_button.dart:98)
       at State.setState(framework.dart:1114)
       at _ToggleStyleButtonState._didChangeEditingValue(toggle_style_button.dart:98)
       at ChangeNotifier.notifyListeners(change_notifier.dart:351)
       at QuillController.replaceText(controller.dart:251)
       at DateBlockEmbed.add(date_block_embed.dart:59)
       at SpDateButton.build.<fn>(sp_date_button.dart:35)
       at QuillIconButton.build.<fn>(quill_icon_button.dart:38)
       at _InkResponseState.handleTap(ink_well.dart:1072)
       at GestureRecognizer.invokeCallback(recognizer.dart:253)
       at TapGestureRecognizer.handleTapUp(tap.dart:627)
       at BaseTapGestureRecognizer._checkUp(tap.dart:306)
       at BaseTapGestureRecognizer.acceptGesture(tap.dart:276)
       at GestureArenaManager.sweep(arena.dart:163)
       at GestureBinding.handleEvent(binding.dart:464)
       at GestureBinding.dispatchEvent(binding.dart:440)
       at RendererBinding.dispatchEvent(binding.dart:337)
       at GestureBinding._handlePointerEventImmediately(binding.dart:395)
       at GestureBinding.handlePointerEvent(binding.dart:357)
       at GestureBinding._flushPointerEventQueue(binding.dart:314)
       at GestureBinding._handlePointerDataPacket(binding.dart:295)
```