### PR TITLE
fix error style when input chinese japanese or korean

### DIFF
--- a/lib/src/models/rules/insert.dart
+++ b/lib/src/models/rules/insert.dart
@@ -477,7 +477,7 @@ class PreserveInlineStylesRule extends InsertRule {
     }
 
     final itr = DeltaIterator(document);
-    final prev = itr.skip(index);
+    final prev = itr.skip(len == 0 ? index : index + 1);
     if (prev == null ||
         prev.data is! String ||
         (prev.data as String).contains('\n')) {


### PR DESCRIPTION
when input chinese,confirm the inputing word will replace the word's spelling,so that the text style will be inherit the text style before it.To fix it,set replace paragraph text style as what's instead first word's style.