### PR TITLE
Remove transparent color of ImageVideoUtils dialog

### DIFF
--- a/flutter_quill_extensions/lib/embeds/toolbar/image_video_utils.dart
+++ b/flutter_quill_extensions/lib/embeds/toolbar/image_video_utils.dart
@@ -80,7 +80,6 @@ class ImageVideoUtils {
         context: context,
         builder: (ctx) => AlertDialog(
           contentPadding: EdgeInsets.zero,
-          backgroundColor: Colors.transparent,
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: [


### PR DESCRIPTION
This change makes the Gallery and Link text clearly visible on the `ImageVideoUtils` dialog.