### PR TITLE
Small doc change to avoid json parse error

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can then write this to storage.
 To open a FlutterQuill editor with an existing JSON representation that you've previously stored, you can do something like this:
 
 ```dart
-var myJSON = jsonDecode(incomingJSONText);
+var myJSON = jsonDecode(r'$incomingJSONText');
 _controller = QuillController(
           document: Document.fromJson(myJSON),
           selection: TextSelection.collapsed(offset: 0),

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can then write this to storage.
 To open a FlutterQuill editor with an existing JSON representation that you've previously stored, you can do something like this:
 
 ```dart
-var myJSON = jsonDecode(r'$incomingJSONText');
+var myJSON = jsonDecode(r'{"insert":"hello\n"}');
 _controller = QuillController(
           document: Document.fromJson(myJSON),
           selection: TextSelection.collapsed(offset: 0),


### PR DESCRIPTION
Dart will throw ```Control character in string (at character x)``` if the string contains control flow character like ```\n```.
In order to avoid it, just add ```r``` at the start of string to tell the compiler to ignore the special characters. 