### PR TITLE
Fixed handling of mac intents

### DIFF
--- a/lib/src/widgets/raw_editor.dart
+++ b/lib/src/widgets/raw_editor.dart
@@ -1431,7 +1431,14 @@ class RawEditorState extends EditorState
 
   @override
   void performSelector(String selectorName) {
-    // TODO: implement performSelector
+    final intent = intentForMacOSSelector(selectorName);
+
+    if (intent != null) {
+      final primaryContext = primaryFocus?.context;
+      if (primaryContext != null) {
+        Actions.invoke(primaryContext, intent);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Without this method implemented, the quill editor is dropping platform-specific intents.  This may be happening on other platforms, but I know this fix works for macos