### PR TITLE
Ability to add custom shortcuts and actions

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -180,6 +180,8 @@ class QuillEditor extends StatefulWidget {
       this.floatingCursorDisabled = false,
       this.textSelectionControls,
       this.onImagePaste,
+      this.customShortcuts,
+      this.customActions,
       Key? key})
       : super(key: key);
 
@@ -394,6 +396,9 @@ class QuillEditor extends StatefulWidget {
   /// Returns the url of the image if the image should be inserted.
   final Future<String?> Function(Uint8List imageBytes)? onImagePaste;
 
+  final Map<LogicalKeySet, Intent>? customShortcuts;
+  final Map<Type, Action<Intent>>? customActions;
+
   @override
   QuillEditorState createState() => QuillEditorState();
 }
@@ -504,6 +509,8 @@ class QuillEditorState extends State<QuillEditor>
       customStyleBuilder: widget.customStyleBuilder,
       floatingCursorDisabled: widget.floatingCursorDisabled,
       onImagePaste: widget.onImagePaste,
+      customShortcuts: widget.customShortcuts,
+      customActions: widget.customActions,
     );
 
     final editor = I18n(

--- a/lib/src/widgets/raw_editor.dart
+++ b/lib/src/widgets/raw_editor.dart
@@ -70,6 +70,8 @@ class RawEditor extends StatefulWidget {
       this.minHeight,
       this.maxContentWidth,
       this.customStyles,
+      this.customShortcuts,
+      this.customActions,
       this.expands = false,
       this.autoFocus = false,
       this.keyboardAppearance = Brightness.light,
@@ -226,6 +228,9 @@ class RawEditor extends StatefulWidget {
   final ScrollPhysics? scrollPhysics;
 
   final Future<String?> Function(Uint8List imageBytes)? onImagePaste;
+
+  final Map<LogicalKeySet, Intent>? customShortcuts;
+  final Map<Type, Action<Intent>>? customActions;
 
   /// Builder function for embeddable objects.
   final EmbedsBuilder embedBuilder;
@@ -428,9 +433,14 @@ class RawEditorState extends EditorState
 
           LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.shift,
               LogicalKeyboardKey.keyL): const ApplyCheckListIntent(),
+
+          if (widget.customShortcuts != null) ...widget.customShortcuts!,
         },
         child: Actions(
-          actions: _actions,
+          actions: {
+            ..._actions,
+            if (widget.customActions != null) ...widget.customActions!,
+          },
           child: Focus(
             focusNode: widget.focusNode,
             onKey: _onKey,


### PR DESCRIPTION
I can not use my own shortcuts whenever the quill editor is focused (web), so I thought that this change is a good idea