### PR TITLE
Added a property to control the detect word boundary behaviour

### DIFF
--- a/lib/src/widgets/delegate.dart
+++ b/lib/src/widgets/delegate.dart
@@ -66,7 +66,9 @@ class EditorTextSelectionGestureDetectorBuilder {
   /// Creates a [EditorTextSelectionGestureDetectorBuilder].
   ///
   /// The [delegate] must not be null.
-  EditorTextSelectionGestureDetectorBuilder({required this.delegate});
+  EditorTextSelectionGestureDetectorBuilder({
+    required this.delegate,
+    this.detectWordBoundary = true});
 
   /// The delegate for this [EditorTextSelectionGestureDetectorBuilder].
   ///
@@ -82,6 +84,8 @@ class EditorTextSelectionGestureDetectorBuilder {
   /// will return true if current [onTapDown] event is triggered by a touch or
   /// a stylus.
   bool shouldShowSelectionToolbar = true;
+
+  bool detectWordBoundary = true;
 
   /// The [State] of the [EditableText] for which the builder will provide a
   /// [EditorTextSelectionGestureDetector].
@@ -354,7 +358,8 @@ class EditorTextSelectionGestureDetectorBuilder {
       onDragSelectionUpdate: onDragSelectionUpdate,
       onDragSelectionEnd: onDragSelectionEnd,
       behavior: behavior,
-      child: child,
+      detectWordBoundary: detectWordBoundary,
+      child: child
     );
   }
 }

--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -182,6 +182,7 @@ class QuillEditor extends StatefulWidget {
       this.onImagePaste,
       this.customShortcuts,
       this.customActions,
+      this.detectWordBoundary = true,
       Key? key})
       : super(key: key);
 
@@ -399,6 +400,8 @@ class QuillEditor extends StatefulWidget {
   final Map<LogicalKeySet, Intent>? customShortcuts;
   final Map<Type, Action<Intent>>? customActions;
 
+  final bool detectWordBoundary;
+
   @override
   QuillEditorState createState() => QuillEditorState();
 }
@@ -413,7 +416,8 @@ class QuillEditorState extends State<QuillEditor>
   void initState() {
     super.initState();
     _selectionGestureDetectorBuilder =
-        _QuillEditorSelectionGestureDetectorBuilder(this);
+        _QuillEditorSelectionGestureDetectorBuilder(this,
+            widget.detectWordBoundary);
   }
 
   @override
@@ -591,10 +595,11 @@ class QuillEditorState extends State<QuillEditor>
 
 class _QuillEditorSelectionGestureDetectorBuilder
     extends EditorTextSelectionGestureDetectorBuilder {
-  _QuillEditorSelectionGestureDetectorBuilder(this._state)
+  _QuillEditorSelectionGestureDetectorBuilder(this._state, this._detectWordBoundary)
       : super(delegate: _state);
 
   final QuillEditorState _state;
+  final bool _detectWordBoundary;
 
   @override
   void onForcePressStart(ForcePressDetails details) {
@@ -712,9 +717,15 @@ class _QuillEditorSelectionGestureDetectorBuilder
             case PointerDeviceKind.unknown:
               // On macOS/iOS/iPadOS a touch tap places the cursor at the edge
               // of the word.
-              renderEditor!
-                ..selectWordEdge(SelectionChangedCause.tap)
-                ..onSelectionCompleted();
+              if (_detectWordBoundary) {
+                renderEditor!
+                  ..selectWordEdge(SelectionChangedCause.tap)
+                  ..onSelectionCompleted();
+              } else {
+                renderEditor!
+                  ..selectPosition(cause: SelectionChangedCause.tap)
+                  ..onSelectionCompleted();
+              }
               break;
             case PointerDeviceKind.trackpad:
               // TODO: Handle this case.

--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -596,7 +596,7 @@ class QuillEditorState extends State<QuillEditor>
 class _QuillEditorSelectionGestureDetectorBuilder
     extends EditorTextSelectionGestureDetectorBuilder {
   _QuillEditorSelectionGestureDetectorBuilder(this._state, this._detectWordBoundary)
-      : super(delegate: _state);
+      : super(delegate: _state, detectWordBoundary: _detectWordBoundary);
 
   final QuillEditorState _state;
   final bool _detectWordBoundary;

--- a/lib/src/widgets/text_selection.dart
+++ b/lib/src/widgets/text_selection.dart
@@ -714,6 +714,7 @@ class EditorTextSelectionGestureDetector extends StatefulWidget {
     this.onDragSelectionUpdate,
     this.onDragSelectionEnd,
     this.behavior,
+    this.detectWordBoundary = true,
     Key? key,
   }) : super(key: key);
 
@@ -788,6 +789,8 @@ class EditorTextSelectionGestureDetector extends StatefulWidget {
 
   /// Child below this widget.
   final Widget child;
+
+  final bool detectWordBoundary;
 
   @override
   State<StatefulWidget> createState() =>


### PR DESCRIPTION
On iOS/macOS/iPadOS, library by default detects word boundary and position the cursor accordingly. It would be good to add ability to customize this behaviour to allow precise cursor selection on apple OS