### PR TITLE
Added a property to control the detect word boundary behaviour

### DIFF
--- a/lib/src/widgets/delegate.dart
+++ b/lib/src/widgets/delegate.dart
@@ -341,7 +341,8 @@ class EditorTextSelectionGestureDetectorBuilder {
   ///
   /// The [child] or its subtree should contain [EditableText].
   Widget build(
-      {required HitTestBehavior behavior, required Widget child, Key? key}) {
+      {required HitTestBehavior behavior, required Widget child, Key? key,
+        bool detectWordBoundary = true}) {
     return EditorTextSelectionGestureDetector(
       key: key,
       onTapDown: onTapDown,

--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -522,6 +522,7 @@ class QuillEditorState extends State<QuillEditor>
       child: selectionEnabled
           ? _selectionGestureDetectorBuilder.build(
               behavior: HitTestBehavior.translucent,
+              detectWordBoundary: widget.detectWordBoundary,
               child: child,
             )
           : child,


### PR DESCRIPTION
On iOS/macOS/iPadOS, library by default detects word boundary and position the cursor accordingly. It would be good to add ability to customize this behaviour to allow precise cursor selection on apple OS