### PR TITLE
Improve ImageEmbedBuilderWeb in example

### DIFF
--- a/example/lib/universal_ui/universal_ui.dart
+++ b/example/lib/universal_ui/universal_ui.dart
@@ -44,8 +44,12 @@ class ImageEmbedBuilderWeb implements EmbedBuilder {
       return const SizedBox();
     }
     final size = MediaQuery.of(context).size;
-    UniversalUI().platformViewRegistry.registerViewFactory(
-        imageUrl, (viewId) => html.ImageElement()..src = imageUrl);
+    UniversalUI().platformViewRegistry.registerViewFactory(imageUrl, (viewId) {
+      return html.ImageElement()
+        ..src = imageUrl
+        ..style.height = 'auto'
+        ..style.width = 'auto';
+    });
     return Padding(
       padding: EdgeInsets.only(
         right: ResponsiveWidget.isMediumScreen(context)


### PR DESCRIPTION
When using the example in Web browsers, the image is displayed abnormally or not displayed.

The browser debug console outputs: 
```
Height of Platform View type: [https://some.com/some.jpg] may not be set. Defaulting to `height: 100%`.
Set `style.height` to any appropriate value to stop this message.

Width of Platform View type: [https://some.com/some.jpg] may not be set. Defaulting to `width: 100%`.
Set `style.width` to any appropriate value to stop this message.
```

So I added the `width` and `height` style for the image, setting it to 'auto', to make it show properly.