### PR TITLE
Added korean translation 'Size'

### DIFF
--- a/lib/src/translations/toolbar.i18n.dart
+++ b/lib/src/translations/toolbar.i18n.dart
@@ -287,6 +287,7 @@ extension Localization on String {
           'Resize': '크기조정',
           'Width': '넓이',
           'Height': '높이',
+          'Size': '크기',
           'Small': '작게',
           'Large': '크게',
           'Huge': '매우크게',


### PR DESCRIPTION
Error log when using korean.
flutter: ➜ There are no translations in 'ko' for "Size".

So I added korean translation 'size' 