### PR TITLE
Fix the demo page so adding custom notes works on the web version.

### DIFF
--- a/example/lib/pages/home_page.dart
+++ b/example/lib/pages/home_page.dart
@@ -198,33 +198,35 @@ class _HomePageState extends State<HomePage> {
       quillEditor = MouseRegion(
         cursor: SystemMouseCursors.text,
         child: QuillEditor(
-          controller: _controller!,
-          scrollController: ScrollController(),
-          scrollable: true,
-          focusNode: _focusNode,
-          autoFocus: false,
-          readOnly: false,
-          placeholder: 'Add content',
-          expands: false,
-          padding: EdgeInsets.zero,
-          onTapUp: (details, p1) {
-            return _onTripleClickSelection();
-          },
-          customStyles: DefaultStyles(
-            h1: DefaultTextBlockStyle(
-                const TextStyle(
-                  fontSize: 32,
-                  color: Colors.black,
-                  height: 1.15,
-                  fontWeight: FontWeight.w300,
-                ),
-                const VerticalSpacing(16, 0),
-                const VerticalSpacing(0, 0),
-                null),
-            sizeSmall: const TextStyle(fontSize: 9),
-          ),
-          embedBuilders: defaultEmbedBuildersWeb,
-        ),
+            controller: _controller!,
+            scrollController: ScrollController(),
+            scrollable: true,
+            focusNode: _focusNode,
+            autoFocus: false,
+            readOnly: false,
+            placeholder: 'Add content',
+            expands: false,
+            padding: EdgeInsets.zero,
+            onTapUp: (details, p1) {
+              return _onTripleClickSelection();
+            },
+            customStyles: DefaultStyles(
+              h1: DefaultTextBlockStyle(
+                  const TextStyle(
+                    fontSize: 32,
+                    color: Colors.black,
+                    height: 1.15,
+                    fontWeight: FontWeight.w300,
+                  ),
+                  const VerticalSpacing(16, 0),
+                  const VerticalSpacing(0, 0),
+                  null),
+              sizeSmall: const TextStyle(fontSize: 9),
+            ),
+            embedBuilders: [
+              ...defaultEmbedBuildersWeb,
+              NotesEmbedBuilder(addEditNote: _addEditNote),
+            ]),
       );
     }
     var toolbar = QuillToolbar.basic(


### PR DESCRIPTION
I was getting an error when using the web version and trying to add the custom notes block.  
Turns out the NotesEmbedBuilder was not being passed in when the platform is web.  This fixes that that issue.  Most of the changed lines are white space changes because flutter and android studio are opinionated about formatting.  If you hide whitespace changes you'll see the real substance of the changes is to add NotesEmbedBuilder to the list passed to embedBuilders.

https://github.com/singerdmx/flutter-quill/pull/1134/files?diff=unified&w=1