### PR TITLE
Highlight the beginning selected, empty lines.

### DIFF
--- a/lib/src/widgets/text_line.dart
+++ b/lib/src/widgets/text_line.dart
@@ -1107,6 +1107,19 @@ class RenderEditableTextLine extends RenderEditableBox {
         _selectedRects ??= _body!.getBoxesForSelection(
           local,
         );
+
+        // Paint a small rect at the start of empty lines that
+        // are contained by the selection.
+        if (line.isEmpty &&
+          textSelection.baseOffset <= line.offset &&
+          textSelection.extentOffset > line.offset
+        ) {
+          final lineHeight =
+            preferredLineHeight(TextPosition(offset: line.offset));
+          _selectedRects?.add(
+            TextBox.fromLTRBD(0, 0, 3, lineHeight, textDirection));
+        }
+
         _paintSelection(context, effectiveOffset);
       }
     }


### PR DESCRIPTION
Highlights the beginning few pixels of empty lines. This makes it much easier to see that you're successfully selecting when trying to select empty regions of the document.

![image](https://user-images.githubusercontent.com/6005812/229223296-2c3b0edd-9f89-4c93-bc91-5b9d5c36b9c3.png)
