### PR TITLE
Have text selection span full line height for uneven sized text.

### DIFF
--- a/lib/src/widgets/proxy.dart
+++ b/lib/src/widgets/proxy.dart
@@ -290,7 +290,7 @@ class RenderParagraphProxy extends RenderProxyBox
 
   @override
   List<TextBox> getBoxesForSelection(TextSelection selection) => child!
-      .getBoxesForSelection(selection, boxHeightStyle: BoxHeightStyle.strut);
+      .getBoxesForSelection(selection, boxHeightStyle: BoxHeightStyle.max);
 
   @override
   void performLayout() {


### PR DESCRIPTION
This:

![image](https://user-images.githubusercontent.com/6005812/229224930-5166e328-b635-414e-ae4d-83b8764f905f.png)

Instead of this:

![image](https://user-images.githubusercontent.com/6005812/229224991-9db57320-3632-4e7a-866b-3903872a018c.png)
