### PR TITLE
Wrap contextMenu with TextFieldTapRegion

### DIFF
--- a/lib/src/widgets/raw_editor.dart
+++ b/lib/src/widgets/raw_editor.dart
@@ -125,9 +125,11 @@ class RawEditor extends StatefulWidget {
     BuildContext context,
     RawEditorState state,
   ) {
-    return AdaptiveTextSelectionToolbar.buttonItems(
-      buttonItems: state.contextMenuButtonItems,
-      anchors: state.contextMenuAnchors,
+    return TextFieldTapRegion(
+      child: AdaptiveTextSelectionToolbar.buttonItems(
+        buttonItems: state.contextMenuButtonItems,
+        anchors: state.contextMenuAnchors,
+      ),
     );
   }
 


### PR DESCRIPTION
After wraping the editor with TextFieldTapRegion,  the context menu also need to be wrapped with TextFieldTapRegion, otherwise the tap event on context menu will not trigger.