### PR TITLE
fix ordered list numeration with several lists in document

### DIFF
--- a/lib/src/widgets/raw_editor.dart
+++ b/lib/src/widgets/raw_editor.dart
@@ -756,13 +756,28 @@ class RawEditorState extends EditorState
   List<Widget> _buildChildren(Document doc, BuildContext context) {
     final result = <Widget>[];
     final indentLevelCounts = <int, int>{};
+    // this need for several ordered list in document
+    // we need to reset indents Map, if list finished
+    // List finished when there is node without Attribute.ol in styles
+    // So in this case we set clearIndents=true and send it
+    // to the next EditableTextBlock
+    var prevNodeOl = false;
+    var clearIndents = false;
+
     for (final node in doc.root.children) {
+      final attrs = node.style.attributes;
+
+      if (prevNodeOl && attrs[Attribute.list.key] != Attribute.ol) {
+        clearIndents = true;
+      }
+
+      prevNodeOl = attrs[Attribute.list.key] == Attribute.ol;
+
       if (node is Line) {
         final editableTextLine = _getEditableTextLineFromNode(node, context);
         result.add(Directionality(
             textDirection: getDirectionOfNode(node), child: editableTextLine));
       } else if (node is Block) {
-        final attrs = node.style.attributes;
         final editableTextBlock = EditableTextBlock(
             block: node,
             controller: controller,
@@ -782,11 +797,14 @@ class RawEditorState extends EditorState
             onLaunchUrl: widget.onLaunchUrl,
             cursorCont: _cursorCont,
             indentLevelCounts: indentLevelCounts,
+            clearIndents: clearIndents,
             onCheckboxTap: _handleCheckboxTap,
             readOnly: widget.readOnly,
             customStyleBuilder: widget.customStyleBuilder);
         result.add(Directionality(
             textDirection: getDirectionOfNode(node), child: editableTextBlock));
+
+        clearIndents = false;
       } else {
         throw StateError('Unreachable.');
       }

--- a/lib/src/widgets/style_widgets/number_point.dart
+++ b/lib/src/widgets/style_widgets/number_point.dart
@@ -31,6 +31,7 @@ class QuillNumberPoint extends StatelessWidget {
     int? level = 0;
     if (!attrs.containsKey(Attribute.indent.key) && indentLevelCounts.isEmpty) {
       indentLevelCounts.clear();
+      indentLevelCounts[0] = 1;
       return Container(
         alignment: AlignmentDirectional.topEnd,
         width: width,

--- a/lib/src/widgets/text_block.dart
+++ b/lib/src/widgets/text_block.dart
@@ -68,6 +68,7 @@ class EditableTextBlock extends StatelessWidget {
       required this.linkActionPicker,
       required this.cursorCont,
       required this.indentLevelCounts,
+      required this.clearIndents,
       required this.onCheckboxTap,
       required this.readOnly,
       this.onLaunchUrl,
@@ -91,6 +92,7 @@ class EditableTextBlock extends StatelessWidget {
   final CustomStyleBuilder? customStyleBuilder;
   final CursorCont cursorCont;
   final Map<int, int> indentLevelCounts;
+  final bool clearIndents;
   final Function(int, bool) onCheckboxTap;
   final bool readOnly;
 
@@ -107,7 +109,7 @@ class EditableTextBlock extends StatelessWidget {
         decoration: _getDecorationForBlock(block, defaultStyles) ??
             const BoxDecoration(),
         contentPadding: contentPadding,
-        children: _buildChildren(context, indentLevelCounts));
+        children: _buildChildren(context, indentLevelCounts, clearIndents));
   }
 
   BoxDecoration? _getDecorationForBlock(
@@ -122,11 +124,14 @@ class EditableTextBlock extends StatelessWidget {
     return null;
   }
 
-  List<Widget> _buildChildren(
-      BuildContext context, Map<int, int> indentLevelCounts) {
+  List<Widget> _buildChildren(BuildContext context,
+      Map<int, int> indentLevelCounts, bool clearIndents) {
     final defaultStyles = QuillStyles.getStyles(context, false);
     final count = block.children.length;
     final children = <Widget>[];
+    if (clearIndents) {
+      indentLevelCounts.clear();
+    }
     var index = 0;
     for (final line in Iterable.castFrom<dynamic, Line>(block.children)) {
       index++;


### PR DESCRIPTION
Fix for cases, when there is several separated ordered lists in documents
For now, it continues counter from first list, even if between first list and next list several block or lines.