### PR TITLE
fix non scrollable editor exception, when tapped under content

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -1794,7 +1794,10 @@ class RenderEditableContainerBox extends RenderBox
       dy += child.size.height;
       child = childAfter(child);
     }
-    throw StateError('No child at offset $offset.');
+
+    // this case possible, when editor not scrollable,
+    // but minHeight > content height and tap was under content
+    return lastChild!;
   }
 
   @override


### PR DESCRIPTION
Not sure is it right, but working as expected in my case.
I have QuillEditor with scrollable: false and some minHeight.
When there is no content, to fill all min height, tapping to empty space under content throws error, because In this case condition `if (offset.dy >= size.height - _resolvedPadding!.bottom) {` always false