### PR TITLE
Fix ios cursor bug if word.length==1

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -1135,7 +1135,7 @@ class RenderEditor extends RenderEditableContainerBox
       start: localWord.start + nodeOffset,
       end: localWord.end + nodeOffset,
     );
-    if (position.offset - word.start <= 1) {
+    if (position.offset - word.start <= 1 && word.end != position.offset) {
       _handleSelectionChange(
         TextSelection.collapsed(offset: word.start),
         cause,


### PR DESCRIPTION
#1082 #1074 #1156 #1098 
Fix the bug that the cursor cant be placed at the end of a word if QuillEditor.detectWordBoundary==true && word.length==1 on ios