### PR TITLE
fix inserting tab character in lists

### DIFF
--- a/lib/src/widgets/raw_editor.dart
+++ b/lib/src/widgets/raw_editor.dart
@@ -665,16 +665,20 @@ class RawEditorState extends EditorState
       return insertTabCharacter();
     }
 
-    if (node.isNotEmpty && (node.first as leaf.Text).value.isNotEmpty) {
-      return insertTabCharacter();
-    }
-
     final parentBlock = parent;
     if (parentBlock.style.containsKey(Attribute.ol.key) ||
         parentBlock.style.containsKey(Attribute.ul.key) ||
         parentBlock.style.containsKey(Attribute.checked.key)) {
+      if (node.isNotEmpty && (node.first as leaf.Text).value.isNotEmpty
+          && controller.selection.base.offset > node.documentOffset) {
+        return insertTabCharacter();
+      }
       controller.indentSelection(!event.isShiftPressed);
       return KeyEventResult.handled;
+    }
+
+    if (node.isNotEmpty && (node.first as leaf.Text).value.isNotEmpty) {
+      return insertTabCharacter();
     }
 
     return insertTabCharacter();


### PR DESCRIPTION
#### Prerequisites:
The cursor is at the beginning of the text of the list item (a node of the list is not empty).

#### Actual result:
The `tab` button inserts `\t` symbol (`insertTabCharacter` method).

#### Expecter result:
The `tab` button adds an indent to the list item (`controller.indentSelection`).