### PR TITLE
add enableUnfocusOnTapOutside field to RawEditor and Editor widgets

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -182,6 +182,7 @@ class QuillEditor extends StatefulWidget {
       this.customShortcuts,
       this.customActions,
       this.detectWordBoundary = true,
+      this.enableUnfocusOnTapOutside = true,
       this.customLinkPrefixes = const <String>[],
       Key? key})
       : super(key: key);
@@ -245,6 +246,9 @@ class QuillEditor extends StatefulWidget {
   ///
   /// Defaults to `false`. Cannot be `null`.
   final bool autoFocus;
+
+  /// Whether focus should be revoked on tap outside the editor.
+  final bool enableUnfocusOnTapOutside;
 
   /// Whether to show cursor.
   ///
@@ -506,6 +510,7 @@ class QuillEditorState extends State<QuillEditor>
       customShortcuts: widget.customShortcuts,
       customActions: widget.customActions,
       customLinkPrefixes: widget.customLinkPrefixes,
+      enableUnfocusOnTapOutside: widget.enableUnfocusOnTapOutside,
     );
 
     final editor = I18n(

--- a/lib/src/widgets/raw_editor.dart
+++ b/lib/src/widgets/raw_editor.dart
@@ -72,6 +72,7 @@ class RawEditor extends StatefulWidget {
       this.customActions,
       this.expands = false,
       this.autoFocus = false,
+      this.enableUnfocusOnTapOutside = true,
       this.keyboardAppearance = Brightness.light,
       this.enableInteractiveSelection = true,
       this.scrollPhysics,
@@ -95,6 +96,7 @@ class RawEditor extends StatefulWidget {
   final ScrollController scrollController;
   final bool scrollable;
   final double scrollBottomInset;
+  final bool enableUnfocusOnTapOutside;
 
   /// Additional space around the editor contents.
   final EdgeInsetsGeometry padding;
@@ -494,6 +496,7 @@ class RawEditorState extends EditorState
             maxHeight: widget.maxHeight ?? double.infinity);
 
     return TextFieldTapRegion(
+      enabled: widget.enableUnfocusOnTapOutside,
       onTapOutside: _defaultOnTapOutside,
       child: QuillStyles(
         data: _styles!,


### PR DESCRIPTION
### Context

There is a [PR with the implementation of unfocusing on tap outside the editor](https://github.com/singerdmx/flutter-quill/pull/1152).

### Requirement

But there is a different use case when we need to know if the text field is focused or not by tapping on the button outside the editor.

### Reasoning

Disabling unfocusing on tapping outside the editor we will be able to implement the following behavior:
1. The toolbar with style toggle buttons is outside of the editor.
2. If the editor text field is focused, a new style is applied to the selected text.
3. If the editor text field is not focused, a new style is applied to the whole text.

### New

- Add `enableUnfocusOnTapOutside` for enabling/disabling unfocusing on tapping outside the editor.