### PR TITLE
Add node params to custom recognizer function

### DIFF
--- a/lib/src/widgets/delegate.dart
+++ b/lib/src/widgets/delegate.dart
@@ -15,7 +15,7 @@ typedef EmbedsBuilder = EmbedBuilder Function(Embed node);
 typedef CustomStyleBuilder = TextStyle Function(Attribute attribute);
 
 typedef CustomRecognizerBuilder = GestureRecognizer? Function(
-    Attribute attribute);
+    Attribute attribute, Leaf leaf);
 
 /// Delegate interface for the [EditorTextSelectionGestureDetectorBuilder].
 ///

--- a/lib/src/widgets/text_line.dart
+++ b/lib/src/widgets/text_line.dart
@@ -420,7 +420,7 @@ class _TextLineState extends State<TextLine> {
       final nodeStyle = textNode.style;
 
       nodeStyle.attributes.forEach((key, value) {
-        final recognizer = widget.customRecognizerBuilder!.call(value);
+        final recognizer = widget.customRecognizerBuilder!.call(value, segment);
         if (recognizer != null) {
           _linkRecognizers[segment] = recognizer;
           return;


### PR DESCRIPTION
I have a requirement, such as wanting to pop up a toast when clicking on a custom styles to display the words I clicked on, so I need to know the node I clicked on.