### PR TITLE
Fix direction of toolbar dividers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [7.1.15]
+- Fixed a bug introduced in 7.1.7 where each section in `QuillToolbar` was displayed on its own line.
+
 # [7.1.14]
 - Add indents change for multiline selection.
 

--- a/flutter_quill_extensions/pubspec.yaml
+++ b/flutter_quill_extensions/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  flutter_quill: ^7.1.12
+  flutter_quill: ^7.1.15
 
   image_picker: ^0.8.5+3
   photo_view: ^0.14.0

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -663,7 +663,8 @@ class AxisDivider extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return axis == Axis.horizontal
+    // Vertical toolbar requires horizontal divider, and vice versa
+    return axis == Axis.vertical
         ? Divider(
             height: space,
             color: color,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -409,7 +409,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
                 isButtonGroupShown[3] ||
                 isButtonGroupShown[4] ||
                 isButtonGroupShown[5]))
-          AxisDivider(axis,
+          _AxisDivider(axis,
               color: sectionDividerColor, space: sectionDividerSpace),
         if (showAlignmentButtons)
           SelectAlignmentButton(
@@ -445,7 +445,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
                 isButtonGroupShown[3] ||
                 isButtonGroupShown[4] ||
                 isButtonGroupShown[5]))
-          AxisDivider(axis,
+          _AxisDivider(axis,
               color: sectionDividerColor, space: sectionDividerSpace),
         if (showHeaderStyle)
           SelectHeaderStyleButton(
@@ -462,7 +462,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             (isButtonGroupShown[3] ||
                 isButtonGroupShown[4] ||
                 isButtonGroupShown[5]))
-          AxisDivider(axis,
+          _AxisDivider(axis,
               color: sectionDividerColor, space: sectionDividerSpace),
         if (showListNumbers)
           ToggleStyleButton(
@@ -507,7 +507,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
         if (showDividers &&
             isButtonGroupShown[3] &&
             (isButtonGroupShown[4] || isButtonGroupShown[5]))
-          AxisDivider(axis,
+          _AxisDivider(axis,
               color: sectionDividerColor, space: sectionDividerSpace),
         if (showQuote)
           ToggleStyleButton(
@@ -540,7 +540,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             afterButtonPressed: afterButtonPressed,
           ),
         if (showDividers && isButtonGroupShown[4] && isButtonGroupShown[5])
-          AxisDivider(axis,
+          _AxisDivider(axis,
               color: sectionDividerColor, space: sectionDividerSpace),
         if (showLink)
           LinkStyleButton(
@@ -563,7 +563,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           ),
         if (customButtons.isNotEmpty)
           if (showDividers)
-            AxisDivider(axis,
+            _AxisDivider(axis,
                 color: sectionDividerColor, space: sectionDividerSpace),
         for (var customButton in customButtons)
           QuillIconButton(
@@ -643,19 +643,13 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   }
 }
 
-class AxisDivider extends StatelessWidget {
-  const AxisDivider(
+class _AxisDivider extends StatelessWidget {
+  const _AxisDivider(
     this.axis, {
     Key? key,
     this.color,
     this.space,
   }) : super(key: key);
-
-  const AxisDivider.horizontal({Color? color, double? space})
-      : this(Axis.horizontal, color: color, space: space);
-
-  const AxisDivider.vertical({Color? color, double? space})
-      : this(Axis.vertical, color: color, space: space);
 
   final Axis axis;
   final Color? color;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_quill
 description: A rich text editor supporting mobile and web (Demo App @ bulletjournal.us)
-version: 7.1.14
+version: 7.1.15
 #author: bulletjournal
 homepage: https://bulletjournal.us/home/index.html
 repository: https://github.com/singerdmx/flutter-quill


### PR DESCRIPTION
- Fixes the bug introduced in https://github.com/singerdmx/flutter-quill/pull/1179

> @bambinoua This PR appears to have broken the example app toolbar (at least on Windows). Please fix: ![image](https://user-images.githubusercontent.com/26483285/233013692-68e16da3-7889-4f3f-a708-23fd2354a02e.png)
- https://github.com/singerdmx/flutter-quill/pull/1179#issuecomment-1514327911

