### PR TITLE
Rename `_AxisDivider` to `QuillDivider` and make it public

### DIFF
--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -409,7 +409,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
                 isButtonGroupShown[3] ||
                 isButtonGroupShown[4] ||
                 isButtonGroupShown[5]))
-          _AxisDivider(axis,
+          QuillDivider(axis,
               color: sectionDividerColor, space: sectionDividerSpace),
         if (showAlignmentButtons)
           SelectAlignmentButton(
@@ -445,7 +445,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
                 isButtonGroupShown[3] ||
                 isButtonGroupShown[4] ||
                 isButtonGroupShown[5]))
-          _AxisDivider(axis,
+          QuillDivider(axis,
               color: sectionDividerColor, space: sectionDividerSpace),
         if (showHeaderStyle)
           SelectHeaderStyleButton(
@@ -462,7 +462,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             (isButtonGroupShown[3] ||
                 isButtonGroupShown[4] ||
                 isButtonGroupShown[5]))
-          _AxisDivider(axis,
+          QuillDivider(axis,
               color: sectionDividerColor, space: sectionDividerSpace),
         if (showListNumbers)
           ToggleStyleButton(
@@ -507,7 +507,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
         if (showDividers &&
             isButtonGroupShown[3] &&
             (isButtonGroupShown[4] || isButtonGroupShown[5]))
-          _AxisDivider(axis,
+          QuillDivider(axis,
               color: sectionDividerColor, space: sectionDividerSpace),
         if (showQuote)
           ToggleStyleButton(
@@ -540,7 +540,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             afterButtonPressed: afterButtonPressed,
           ),
         if (showDividers && isButtonGroupShown[4] && isButtonGroupShown[5])
-          _AxisDivider(axis,
+          QuillDivider(axis,
               color: sectionDividerColor, space: sectionDividerSpace),
         if (showLink)
           LinkStyleButton(
@@ -563,7 +563,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           ),
         if (customButtons.isNotEmpty)
           if (showDividers)
-            _AxisDivider(axis,
+            QuillDivider(axis,
                 color: sectionDividerColor, space: sectionDividerSpace),
         for (var customButton in customButtons)
           QuillIconButton(
@@ -643,16 +643,33 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   }
 }
 
-class _AxisDivider extends StatelessWidget {
-  const _AxisDivider(
+/// The divider which is used for separation of buttons in the toolbar.
+///
+/// It can be used outside of this package, for example when user does not use
+/// [QuillToolbar.basic] and compose toolbat's children on its own.
+class QuillDivider extends StatelessWidget {
+  const QuillDivider(
     this.axis, {
     Key? key,
     this.color,
     this.space,
   }) : super(key: key);
 
+  /// Provides a horizonal divider for vertical toolbar.
+  const QuillDivider.horizontal({Color? color, double? space})
+      : this(Axis.horizontal, color: color, space: space);
+
+  /// Provides a horizonal divider for horizontal toolbar.
+  const QuillDivider.vertical({Color? color, double? space})
+      : this(Axis.vertical, color: color, space: space);
+
+  /// The axis along which the toolbar is.
   final Axis axis;
+
+  /// The color to use when painting this divider's line.
   final Color? color;
+
+  /// The divider's space (width or height) depending of [axis].
   final double? space;
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_quill
 description: A rich text editor supporting mobile and web (Demo App @ bulletjournal.us)
-version: 7.1.16
+version: 7.1.16+1
 #author: bulletjournal
 homepage: https://bulletjournal.us/home/index.html
 repository: https://github.com/singerdmx/flutter-quill


### PR DESCRIPTION
`QuillDivider` is used in a case when user compose toolbar buttons (`children`) on its own. This PR fixes this result of this #1202.