### PR TITLE
Fix custom text style of lists not work

### DIFF
--- a/lib/src/widgets/text_line.dart
+++ b/lib/src/widgets/text_line.dart
@@ -282,7 +282,7 @@ class _TextLineState extends State<TextLine> {
       toMerge = defaultStyles.quote!.style;
     } else if (block == Attribute.codeBlock) {
       toMerge = defaultStyles.code!.style;
-    } else if (block == Attribute.list) {
+    } else if (block?.key == Attribute.list.key) {
       toMerge = defaultStyles.lists!.style;
     }
 


### PR DESCRIPTION
fix #1206 

left: before, right: fixed
<p float="left">
  <img width="400" alt="1" src="https://github.com/singerdmx/flutter-quill/assets/12003831/480880c5-273e-4b60-9210-ea97bda3f7fc">
  <img width="400" alt="1" src="https://github.com/singerdmx/flutter-quill/assets/12003831/13261ef2-ef94-433f-ba59-c81f5dbd4455">
</p>
