### PR TITLE
Allow use of latest i18n dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   pedantic: ^1.11.1
   characters: ^1.2.1
   diff_match_patch: ^0.4.1
-  i18n_extension: ^8.0.0
+  i18n_extension: ">=8.0.0 <10.0.0"
   device_info_plus: ^9.0.0
   platform: ^3.1.0
   pasteboard: ^0.2.0


### PR DESCRIPTION
`i18n_extension` released a non-breaking change with a major version bump, so expanding the allowed version