### PR TITLE
pass linestyle to embeded block

### DIFF
--- a/lib/src/widgets/embeds.dart
+++ b/lib/src/widgets/embeds.dart
@@ -21,6 +21,7 @@ abstract class EmbedBuilder {
     leaf.Embed node,
     bool readOnly,
     bool inline,
+    TextStyle textStyle,
   );
 }
 

--- a/lib/src/widgets/text_line.dart
+++ b/lib/src/widgets/text_line.dart
@@ -148,15 +148,10 @@ class _TextLineState extends State<TextLine> {
       final embedBuilder = widget.embedBuilder(embed);
       if (embedBuilder.expanded) {
         // Creates correct node for custom embed
-
+        final lineStyle = _getLineStyle(widget.styles);
         return EmbedProxy(
-          embedBuilder.build(
-            context,
-            widget.controller,
-            embed,
-            widget.readOnly,
-            false,
-          ),
+          embedBuilder.build(context, widget.controller, embed, widget.readOnly,
+              false, lineStyle),
         );
       }
     }
@@ -208,6 +203,7 @@ class _TextLineState extends State<TextLine> {
             child,
             widget.readOnly,
             true,
+            lineStyle,
           ),
         );
         final embed = embedBuilder.buildWidgetSpan(embedWidget);


### PR DESCRIPTION
I needed to embed icons in the editor, and I needed the icon to take the same line font size, I found that I had no access to the line style from the embedded builder.
This will be helpful for inline embedded blocks.

![image](https://s11.gifyu.com/images/ezgif-3-9fc97a7bd2.gif)

Example code: I can access the font size now ( and other styles for sure) 
![image](https://github.com/singerdmx/flutter-quill/assets/4661009/414f9faa-3cc1-452a-80ad-a310369f4371)

