### PR TITLE
keep style when creating embedded element

### DIFF
--- a/lib/src/widgets/text_line.dart
+++ b/lib/src/widgets/text_line.dart
@@ -193,7 +193,8 @@ class _TextLineState extends State<TextLine> {
         }
         // Creates correct node for custom embed
         if (child.value.type == BlockEmbed.customType) {
-          child = Embed(CustomBlockEmbed.fromJsonString(child.value.data));
+          child = Embed(CustomBlockEmbed.fromJsonString(child.value.data))
+            ..applyStyle(child.style);
         }
         final embedBuilder = widget.embedBuilder(child);
         final embedWidget = EmbedProxy(


### PR DESCRIPTION
I inserted an icon as an embedded widget, but I still want it to take the same color/font size as the text; applying the style to the embedded element will allow the developer to read the attributes from the node and apply them to the element if needed.

Result:
![image](https://s11.gifyu.com/images/ezgif-5-2032730b6b1.gif)
![image](https://github.com/singerdmx/flutter-quill/assets/4661009/c22b8ed8-b6aa-4ba9-aa91-e69f00990192)


I inserted an icon as an embedded widget, but I still want it to take the same color/font size as the text; applying the style to the embedded element will allow the developer to read the attributes from the node and apply them to the element if needed.

Result:
image

Usage example:
textStyle now refer to the whole line style and node.style refers to the current element style
```
@override
  Widget build(
    BuildContext context,
    flutter_quill.QuillController controller,
    flutter_quill.Embed node,
    bool readOnly,
    bool inline,
    TextStyle textStyle,
  ) {
    final iconInfo = jsonDecode(node.value.data);

    String? iconName;
    if (iconInfo != null) {
      iconName = iconInfo['iconName'];
    }
    iconName ??= 'accessibleIcon';

    var color = Colors.black;
    if (iconInfo != null) {
      var clr = node.style!.attributes['color']?.value?.toString();
      if (clr != null) {
        color = Color(int.parse(clr.replaceAll("#", "FF"), radix: 16));
      }
    }

    return Padding(
        padding: EdgeInsets.only(bottom: (textStyle.fontSize! > 24) ? 0 : 6),
        child: FaIcon(faIconNameMapping[iconName],
            color: color, size: textStyle.fontSize!));
  }

```
![image](https://github.com/singerdmx/flutter-quill/assets/4661009/f14fba25-9cf1-43cb-8f18-f87de6e94d38)

