### PR TITLE
Fix PR #1230

### DIFF
--- a/example/lib/pages/home_page.dart
+++ b/example/lib/pages/home_page.dart
@@ -502,6 +502,7 @@ class NotesEmbedBuilder extends EmbedBuilder {
     Embed node,
     bool readOnly,
     bool inline,
+    TextStyle textStyle,
   ) {
     final notes = NotesBlockEmbed(node.value.data).document;
 

--- a/example/lib/universal_ui/universal_ui.dart
+++ b/example/lib/universal_ui/universal_ui.dart
@@ -38,6 +38,7 @@ class ImageEmbedBuilderWeb extends EmbedBuilder {
     Embed node,
     bool readOnly,
     bool inline,
+    TextStyle textStyle,
   ) {
     final imageUrl = node.value.data;
     if (isImageBase64(imageUrl)) {
@@ -80,6 +81,7 @@ class VideoEmbedBuilderWeb extends EmbedBuilder {
     Embed node,
     bool readOnly,
     bool inline,
+    TextStyle textStyle,
   ) {
     var videoUrl = node.value.data;
     if (videoUrl.contains('youtube.com') || videoUrl.contains('youtu.be')) {

--- a/flutter_quill_extensions/CHANGELOG.md
+++ b/flutter_quill_extensions/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.3
+* Fix a prototype bug which was bring by [PR #1230](https://github.com/singerdmx/flutter-quill/pull/1230#issuecomment-1560597099)
+
 ## 0.3.2
 * Updated dependencies to support intl 0.18
 

--- a/flutter_quill_extensions/lib/embeds/builders.dart
+++ b/flutter_quill_extensions/lib/embeds/builders.dart
@@ -28,6 +28,7 @@ class ImageEmbedBuilder extends EmbedBuilder {
     base.Embed node,
     bool readOnly,
     bool inline,
+    TextStyle textStyle,
   ) {
     assert(!kIsWeb, 'Please provide image EmbedBuilder for Web');
 
@@ -164,6 +165,7 @@ class ImageEmbedBuilderWeb extends EmbedBuilder {
     Embed node,
     bool readOnly,
     bool inline,
+    TextStyle textStyle,
   ) {
     final imageUrl = node.value.data;
 
@@ -198,6 +200,7 @@ class VideoEmbedBuilder extends EmbedBuilder {
     base.Embed node,
     bool readOnly,
     bool inline,
+    TextStyle textStyle,
   ) {
     assert(!kIsWeb, 'Please provide video EmbedBuilder for Web');
 
@@ -226,6 +229,7 @@ class FormulaEmbedBuilder extends EmbedBuilder {
     base.Embed node,
     bool readOnly,
     bool inline,
+    TextStyle textStyle,
   ) {
     assert(!kIsWeb, 'Please provide formula EmbedBuilder for Web');
 

--- a/flutter_quill_extensions/pubspec.yaml
+++ b/flutter_quill_extensions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_quill_extensions
 description: Embed extensions for flutter_quill including image, video, formula and etc.
-version: 0.3.2
+version: 0.3.3
 homepage: https://bulletjournal.us/home/index.html
 repository: https://github.com/singerdmx/flutter-quill/tree/master/flutter_quill_extensions
 
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  flutter_quill: ^7.1.17
+  flutter_quill: ^7.1.20
 
   image_picker: ^0.8.5+3
   photo_view: ^0.14.0


### PR DESCRIPTION
The PR #1230 is broken because it contains broken change (prototype of `EmbedBuilder.build` method. This PR will fix it.

- Update all overriden methods in all successors of `EmbedBuilder`.
- Update `flutter_quill` dependency version