### PR TITLE
Add support for android keyboard image insertion

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -187,6 +187,7 @@ class QuillEditor extends StatefulWidget {
     this.enableUnfocusOnTapOutside = true,
     this.customLinkPrefixes = const <String>[],
     this.dialogTheme,
+    this.contentInsertionConfiguration,
     Key? key,
   }) : super(key: key);
 
@@ -427,6 +428,11 @@ class QuillEditor extends StatefulWidget {
   /// Configures the dialog theme.
   final QuillDialogTheme? dialogTheme;
 
+  /// Configuration of handler for media content inserted via the system input method.
+  ///
+  /// See [https://api.flutter.dev/flutter/widgets/EditableText/contentInsertionConfiguration.html]
+  final ContentInsertionConfiguration? contentInsertionConfiguration;
+
   @override
   QuillEditorState createState() => QuillEditorState();
 }
@@ -528,6 +534,7 @@ class QuillEditorState extends State<QuillEditor>
       customLinkPrefixes: widget.customLinkPrefixes,
       enableUnfocusOnTapOutside: widget.enableUnfocusOnTapOutside,
       dialogTheme: widget.dialogTheme,
+      contentInsertionConfiguration: widget.contentInsertionConfiguration,
     );
 
     final editor = I18n(

--- a/lib/src/widgets/raw_editor.dart
+++ b/lib/src/widgets/raw_editor.dart
@@ -84,6 +84,7 @@ class RawEditor extends StatefulWidget {
     this.onImagePaste,
     this.customLinkPrefixes = const <String>[],
     this.dialogTheme,
+    this.contentInsertionConfiguration,
   })  : assert(maxHeight == null || maxHeight > 0, 'maxHeight cannot be null'),
         assert(minHeight == null || minHeight >= 0, 'minHeight cannot be null'),
         assert(maxHeight == null || minHeight == null || maxHeight >= minHeight,
@@ -270,6 +271,11 @@ class RawEditor extends StatefulWidget {
   /// Configures the dialog theme.
   final QuillDialogTheme? dialogTheme;
 
+  /// Configuration of handler for media content inserted via the system input method.
+  ///
+  /// See [https://api.flutter.dev/flutter/widgets/EditableText/contentInsertionConfiguration.html]
+  final ContentInsertionConfiguration? contentInsertionConfiguration;
+
   @override
   State<StatefulWidget> createState() => RawEditorState();
 }
@@ -326,7 +332,12 @@ class RawEditorState extends EditorState
   TextDirection get _textDirection => Directionality.of(context);
 
   @override
-  void insertContent(KeyboardInsertedContent content) {}
+  void insertContent(KeyboardInsertedContent content) {
+    assert(widget.contentInsertionConfiguration?.allowedMimeTypes
+            .contains(content.mimeType) ??
+        false);
+    widget.contentInsertionConfiguration?.onContentInserted.call(content);
+  }
 
   /// Returns the [ContextMenuButtonItem]s representing the buttons in this
   /// platform's default selection menu for [RawEditor].

--- a/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -59,6 +59,9 @@ mixin RawEditorStateTextInputClientMixin on EditorState
           enableSuggestions: !widget.readOnly,
           keyboardAppearance: widget.keyboardAppearance,
           textCapitalization: widget.textCapitalization,
+          allowedMimeTypes: widget.contentInsertionConfiguration == null
+        ? const <String>[]
+        : widget.contentInsertionConfiguration!.allowedMimeTypes,
         ),
       );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ repository: https://github.com/singerdmx/flutter-quill
 
 environment:
   sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Updates the Editor and RawEditor widgets to support an optional `contentInsertionConfiguration` parameter for handling keyboard image insertion on android.

This change is based on the changes made to Flutters EditableText widget in v3.10.