### PR TITLE
Fix color picker dialog overflow

### DIFF
--- a/lib/src/widgets/toolbar/color_button.dart
+++ b/lib/src/widgets/toolbar/color_button.dart
@@ -170,9 +170,9 @@ class _ColorButtonState extends State<ColorButton> {
                   child: Text('OK'.i18n)),
             ],
             backgroundColor: Theme.of(context).canvasColor,
-            content: SizedBox(
-              height: 400,
+            content: SingleChildScrollView(
               child: Column(
+                mainAxisSize: MainAxisSize.min,
                 children: [
                   Row(
                     children: [
@@ -192,8 +192,7 @@ class _ColorButtonState extends State<ColorButton> {
                           child: Text('Color'.i18n)),
                     ],
                   ),
-                  Expanded(
-                      child: Column(children: [
+                  Column(children: [
                     if (pickerType == 'material')
                       MaterialPicker(
                         pickerColor: selectedColor,
@@ -253,7 +252,7 @@ class _ColorButtonState extends State<ColorButton> {
                         }),
                       ],
                     ),
-                  ]))
+                  ])
                 ],
               ),
             ));


### PR DESCRIPTION
Moved all dialog contents into a SingleChildScrollView as they were overflowing. 

Some before and after comparisons:

Oneplus 7T 1080x2400

![Screenshot_20230605-193913_THUD](https://github.com/singerdmx/flutter-quill/assets/14836161/9df71d7f-0cbd-425f-bbb6-5951e28fb2d3)
![Screenshot_20230605-195329_THUD](https://github.com/singerdmx/flutter-quill/assets/14836161/7becbe69-5207-434a-8e8b-4c46afd79c47)
![Screenshot_20230605-194453_THUD](https://github.com/singerdmx/flutter-quill/assets/14836161/b77f2f0f-3c89-4509-9d7c-ba7a7babe1aa)
![Screenshot_20230605-195029_THUD](https://github.com/singerdmx/flutter-quill/assets/14836161/cf8c94bc-9637-4a28-8f9d-f786fe391026)

Pixel XL 1440x2560

![Screenshot_1685965247](https://github.com/singerdmx/flutter-quill/assets/14836161/b499deb4-5466-4ea4-a07e-fa5db4682c27)
![Screenshot_1685966284](https://github.com/singerdmx/flutter-quill/assets/14836161/a0ffd237-33c4-435c-96f3-c399cbd996bb)
![Screenshot_1685965834](https://github.com/singerdmx/flutter-quill/assets/14836161/14f38fa5-56d5-4c51-84a5-0fccb2728e5d)
![Screenshot_1685965837](https://github.com/singerdmx/flutter-quill/assets/14836161/6c56ecc9-6e3c-4a58-91bd-801273c87fb1)
![Screenshot_1685965831](https://github.com/singerdmx/flutter-quill/assets/14836161/dad89164-9ea9-406c-b1af-b9ae5197fe72)

