### PR TITLE
Prevent operations on stale editor state

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -46,6 +46,9 @@ abstract class EditorState extends State<RawEditor>
   /// The floating cursor is animated to merge with the regular cursor.
   AnimationController get floatingCursorResetController;
 
+  /// Returns true if the editor has been marked as needing to be rebuilt.
+  bool get dirty;
+
   bool showToolbar();
 
   void requestKeyboard();

--- a/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -91,7 +91,8 @@ mixin RawEditorStateTextInputClientMixin on EditorState
 
   void _updateCaretRectIfNeeded() {
     if (hasConnection) {
-      if (renderEditor.selection.isValid &&
+      if (!dirty &&
+          renderEditor.selection.isValid &&
           renderEditor.selection.isCollapsed) {
         final currentTextPosition =
             TextPosition(offset: renderEditor.selection.baseOffset);


### PR DESCRIPTION
Adds a way for the editor to mark itself as dirty when requesting a rebuild of the widget. This enables methods that operate on data from both the controller and the editor to defer their action until after the rebuild process completes.

This prevents problems with changing focus after toolbar actions that change the document structure, changes to the document directly using the controller, toggling checkbox list times, and possibly other cases.

It is possible there are other methods that should be checking the dirty flag but the changes in this PR seem to resolve the problems I have run into as well as those mentioned in #1189.