### PR TITLE
Fix Line.getPlainText can not get the last \n if the last child is embed

### DIFF
--- a/lib/src/models/documents/nodes/line.dart
+++ b/lib/src/models/documents/nodes/line.dart
@@ -521,7 +521,7 @@ class Line extends Container<Leaf?> {
 
   int _getPlainText(int offset, int len, StringBuffer plainText) {
     var _len = len;
-    final data = queryChild(offset, true);
+    final data = queryChild(offset, false);
     var node = data.node as Leaf?;
 
     while (_len > 0) {


### PR DESCRIPTION
LINE._getPlainText()  should call queryChild with inclusive=false, otherwise embed\n  can't get the last \n