### PR TITLE
add affinity for localPosition

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -1006,7 +1006,9 @@ class RenderEditor extends RenderEditableContainerBox
     if (textSelection.isCollapsed) {
       final child = childAtPosition(textSelection.extent);
       final localPosition = TextPosition(
-          offset: textSelection.extentOffset - child.container.offset,affinity: textSelection.affinity);
+        offset: textSelection.extentOffset - child.container.offset,
+        affinity: textSelection.affinity,
+      );
       final localOffset = child.getOffsetForCaret(localPosition);
       final parentData = child.parentData as BoxParentData;
       return <TextSelectionPoint>[

--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -1006,7 +1006,7 @@ class RenderEditor extends RenderEditableContainerBox
     if (textSelection.isCollapsed) {
       final child = childAtPosition(textSelection.extent);
       final localPosition = TextPosition(
-          offset: textSelection.extentOffset - child.container.offset);
+          offset: textSelection.extentOffset - child.container.offset,affinity: textSelection.affinity);
       final localOffset = child.getOffsetForCaret(localPosition);
       final parentData = child.parentData as BoxParentData;
       return <TextSelectionPoint>[


### PR DESCRIPTION
I'm trying to get the position of the cursor, but I found that when I click at the end of a line, it returns the position at the beginning of the second line.

Code sample
```   
 Widget quillEditor = MouseRegion(
      cursor: SystemMouseCursors.text,
      child: QuillEditor(
        key: quillEditorKey,
        controller: _controller!,
        scrollController: scrollController,
        scrollable: true,
        focusNode: _focusNode,
        autoFocus: false,
        readOnly: false,
        placeholder: 'Add content',
        enableSelectionToolbar: isMobile(),
        expands: false,
        padding: EdgeInsets.zero,
        onImagePaste: _onImagePaste,
        onTapUp: (details, p1) {
          TextPosition textPosition = p1.call(details.globalPosition);
          var renderEditor = quillEditorKey.currentState!.editableTextKey.currentState!.renderEditor;
          TextSelection textSelection = TextSelection.fromPosition(textPosition);
          print('position == ${renderEditor.getEndpointsForSelection(textSelection)[0].point}');
          return _onTripleClickSelection();
        },
        embedBuilders: [...FlutterQuillEmbeds.builders()],
      ),
    );