### PR TITLE
Fix around image use backspace key can't delete break line.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [7.2.13]
+- Fix around image can't delete line break.
+
+# [7.2.12]
+- Add support for copy/cut select image and text together.
+
 # [7.2.12]
 - Add support for copy/cut select image and text together.
 

--- a/flutter_quill_extensions/lib/embeds/builders.dart
+++ b/flutter_quill_extensions/lib/embeds/builders.dart
@@ -22,6 +22,9 @@ class ImageEmbedBuilder extends EmbedBuilder {
   String get key => BlockEmbed.imageType;
 
   @override
+  bool get expanded => false;
+
+  @override
   Widget build(
     BuildContext context,
     QuillController controller,

--- a/lib/src/models/rules/delete.dart
+++ b/lib/src/models/rules/delete.dart
@@ -1,4 +1,5 @@
 import '../documents/attribute.dart';
+import '../documents/nodes/embeddable.dart';
 import '../quill_delta.dart';
 import 'rule.dart';
 
@@ -118,6 +119,12 @@ class EnsureEmbedLineRule extends DeleteRule {
     final itr = DeltaIterator(document);
 
     var op = itr.skip(index);
+    final opAfter = itr.skip(index + 1);
+
+    if (!_isVideo(op) || !_isVideo(opAfter)) {
+      return null;
+    }
+
     int? indexDelta = 0, lengthDelta = 0, remain = len;
     var embedFound = op != null && op.data is! String;
     final hasLineBreakBefore =
@@ -156,5 +163,11 @@ class EnsureEmbedLineRule extends DeleteRule {
     return Delta()
       ..retain(index + indexDelta)
       ..delete(len! + lengthDelta);
+  }
+
+  bool _isVideo(op) {
+    return op != null &&
+        op.data is! String &&
+        !(op.data as Map).containsKey(BlockEmbed.videoType);
   }
 }

--- a/lib/src/models/rules/delete.dart
+++ b/lib/src/models/rules/delete.dart
@@ -109,7 +109,10 @@ class PreserveLineStyleOnMergeRule extends DeleteRule {
   }
 }
 
-/// Prevents user from merging a line containing an embed with other lines.
+/// This rule applies to video, not image
+///
+/// Prevents user from merging a line containing an video embed with other
+/// lines, Corresponds [InsertEmbedsRule].
 class EnsureEmbedLineRule extends DeleteRule {
   const EnsureEmbedLineRule();
 
@@ -121,6 +124,7 @@ class EnsureEmbedLineRule extends DeleteRule {
     var op = itr.skip(index);
     final opAfter = itr.skip(index + 1);
 
+    //Only video embed need can't merging a line.
     if (!_isVideo(op) || !_isVideo(opAfter)) {
       return null;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_quill
 description: A rich text editor supporting mobile and web (Demo App @ bulletjournal.us)
-version: 7.2.12
+version: 7.2.13
 #author: bulletjournal
 homepage: https://bulletjournal.us/home/index.html
 repository: https://github.com/singerdmx/flutter-quill


### PR DESCRIPTION
Fix around image use backspace key can't delete break line. issue #1306

https://github.com/singerdmx/flutter-quill/assets/49644098/8ef9213f-774b-432d-9fb5-27a9b05e3312

I think EnsureEmbedLineRule and InsertEmbedsRule both apply for embed.EnsureEmbedLineRule only work for video, but InsertEmbedsRule for all embed. Must idea control block or inline element by expend of embed. 
```
/// Handles all format operations which manipulate embeds.
/// This rule wraps line breaks around video, not image.
class InsertEmbedsRule extends InsertRule {
  const InsertEmbedsRule();

  @override
  Delta? applyRule(Delta document, int index,
      {int? len, Object? data, Attribute? attribute}) {
    if (data is String) {
      return null;
    }

    assert(data is Map);

    if (!(data as Map).containsKey(BlockEmbed.videoType)) {
      return null;
    }
```