### PR TITLE
Export Delta datatype without Flutter dependency

### DIFF
--- a/lib/quill_delta.dart
+++ b/lib/quill_delta.dart
@@ -1,0 +1,3 @@
+library flutter_quill.delta;
+
+export 'src/models/quill_delta.dart';


### PR DESCRIPTION
Hi

I need to use the `Delta` datatype in a non-Flutter project (actually an API).
This datatype represents the output of the quill editor, is serialized into json, passed to an API, which need to deserialize it on its side.

Currently, the only way to import this class consists in importing `package:flutter_quill/flutter_quill.dart`. The `flutter_quill` library export lot of things, including some that depends on Flutter (like `dart:ui` or `flutter/material`, thus preventing non Flutter projects to compile.

I've tried this form of import, but this does not helps:
```dart
import 'package:flutter_quill/flutter_quill.dart' show Delta;
```

My first idea was to create a `flutter_quill.models` library which export classes contained in `src/models` directory, but dome of them depends indirectly on Flutter.
eg: `src/models/documents/document.dart > src/widgets/embeds.dart > package:flutter/material.dart`
I don't like the fact that a `models` library may not export all models ...

I finally chose to add a simple `flutter_quill.delta` library that only exports the `Delta` class. It can be imported with:
```dart
import "package:flutter_quill/quill_delta.dart";
```


