### PR TITLE
Allow for custom context menu

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -191,6 +191,7 @@ class QuillEditor extends StatefulWidget {
     this.customLinkPrefixes = const <String>[],
     this.dialogTheme,
     this.contentInsertionConfiguration,
+    this.contextMenuBuilder,
     Key? key,
   }) : super(key: key);
 
@@ -432,6 +433,9 @@ class QuillEditor extends StatefulWidget {
   /// Configures the dialog theme.
   final QuillDialogTheme? dialogTheme;
 
+  // Allows for creating a custom context menu
+  final QuillEditorContextMenuBuilder? contextMenuBuilder;
+
   /// Configuration of handler for media content inserted via the system input
   /// method.
   ///
@@ -503,8 +507,9 @@ class QuillEditorState extends State<QuillEditor>
       readOnly: widget.readOnly,
       placeholder: widget.placeholder,
       onLaunchUrl: widget.onLaunchUrl,
-      contextMenuBuilder:
-          showSelectionToolbar ? RawEditor.defaultContextMenuBuilder : null,
+      contextMenuBuilder: showSelectionToolbar
+          ? (widget.contextMenuBuilder ?? RawEditor.defaultContextMenuBuilder)
+          : null,
       showSelectionHandles: isMobile(theme.platform),
       showCursor: widget.showCursor,
       cursorStyle: CursorStyle(

--- a/test/widgets/editor_test.dart
+++ b/test/widgets/editor_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill/flutter_quill_test.dart';
+import 'package:flutter_quill/src/widgets/raw_editor.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -77,6 +78,33 @@ void main() {
       }
       expect(error, isNull);
       expect(latestUri, equals(uri));
+    });
+
+    Widget customBuilder(BuildContext context, RawEditorState state) {
+      return Container(key: const Key('customMenu'));
+    }
+
+    testWidgets('custom context menu builder', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: QuillEditor(
+          controller: controller,
+          focusNode: FocusNode(),
+          scrollController: ScrollController(),
+          scrollable: true,
+          padding: EdgeInsets.zero,
+          autoFocus: true,
+          readOnly: false,
+          expands: true,
+          contextMenuBuilder: customBuilder,
+        ),
+      ));
+
+      // Long press to show menu
+      await tester.longPress(find.byType(QuillEditor));
+      await tester.pumpAndSettle();
+
+      // Verify custom widget shows
+      expect(find.byKey(const Key('customMenu')), findsOneWidget);
     });
   });
 }

--- a/test/widgets/editor_test.dart
+++ b/test/widgets/editor_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   late QuillController controller;
+  var didCopy = false;
 
   setUp(() {
     controller = QuillController.basic();
@@ -81,7 +82,26 @@ void main() {
     });
 
     Widget customBuilder(BuildContext context, RawEditorState state) {
-      return Container(key: const Key('customMenu'));
+      return AdaptiveTextSelectionToolbar(
+        anchors: state.contextMenuAnchors,
+        children: [
+          Container(
+            height: 50,
+            color: Colors.white,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                IconButton(
+                  onPressed: () {
+                    didCopy = true;
+                  },
+                  icon: const Icon(Icons.copy),
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
     }
 
     testWidgets('custom context menu builder', (tester) async {
@@ -104,7 +124,10 @@ void main() {
       await tester.pumpAndSettle();
 
       // Verify custom widget shows
-      expect(find.byKey(const Key('customMenu')), findsOneWidget);
+      expect(find.byIcon(Icons.copy), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.copy));
+      expect(didCopy, isTrue);
     });
   });
 }


### PR DESCRIPTION
## Custom Context Menu 

For my app, I would like to customize the context menu that opens on text selection. 

I've been looking for a way to do it with the current implementation, but could not find a straight forward "clean" way. 

After exposing the `contextMenuBuilder` I was able to customize the menu.

<img width="343" alt="editor" src="https://github.com/singerdmx/flutter-quill/assets/26770848/f0f157cf-b0e1-45f9-997f-e62c31c89e2b">


For which the implementation looks like this: 

```dart
QuillEditor(
  // .. params 
  textSelectionControls: CustomTextSelectionControls(),
  // enableSelectionToolbar: true,  // <-- Still hides the context menu
  contextMenuBuilder: (context, state) {
    return AdaptiveTextSelectionToolbar(
      anchors: state.contextMenuAnchors,
      children: [
        Container(
          // Container attributes here...
          child: Row(
            children: <Widget>[
              // (Icon) Buttons here
            ],
          ),
        ),
      ],
    );
  },
),

```

<hr>

And/Or give more control over the native context menu: 


<small>Like adding or removing buttons to it.</small>
<img width="329" alt="editor2" src="https://github.com/singerdmx/flutter-quill/assets/26770848/cf677e5a-5cbf-4794-b169-ffd82a6368b7">

```dart
contextMenuBuilder: (context, state) {
  List<ContextMenuButtonItem> btnItems =
      List.from(state.contextMenuButtonItems);

  btnItems.removeWhere(
    (item) => item.type == ContextMenuButtonType.selectAll
  );

  return AdaptiveTextSelectionToolbar.buttonItems(
    buttonItems: btnItems,
    anchors: state.contextMenuAnchors,
  );
},

```                                

<hr>

If there is a way to come to the first result, I'd be happy to learn about it, otherwise I think this would be a welcome addition. 



Please let me know if changes or additions are needed.


