### PR TITLE
Expose contextMenuBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,28 @@ And voila, we have a custom widget inside of the rich text editor!
 > 1. For more info and a video example, see the [PR of this feature](https://github.com/singerdmx/flutter-quill/pull/877)
 > 2. For more details, check out [this YouTube video](https://youtu.be/pI5p5j7cfHc)
 
+### Custom Context Menu
+You can customize the context menu by providing a `contextMenuBuilder` to the `QuillEditor` widget. If you want to keep the default ContextMenueItems, you can use `state.defaultContextMenuItems` and add your own items to it.
+
+```dart
+contextMenuBuilder: (BuildContext context, RawEditorState state) {
+        return TextFieldTapRegion(
+          child: AdaptiveTextSelectionToolbar.buttonItems(
+            buttonItems: [
+              ...state.contextMenuButtonItems,
+              ContextMenuButtonItem(
+                label: 'Custom Context Menu Action',
+                onPressed: () {
+                  print(_controller?.getPlainText()); // Print the selected text, by accessing the QuillController
+                },
+              ),
+            ],
+            anchors: state.contextMenuAnchors,
+          ),
+        );
+}
+```
+
 ### Translation
 
 The package offers translations for the quill toolbar and editor, it will follow the system locale unless you set your own locale with:

--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -1,5 +1,4 @@
 import 'dart:math' as math;
-
 // ignore: unnecessary_import
 import 'dart:typed_data';
 
@@ -191,6 +190,7 @@ class QuillEditor extends StatefulWidget {
     this.customLinkPrefixes = const <String>[],
     this.dialogTheme,
     this.contentInsertionConfiguration,
+    this.contextMenuBuilder,
     Key? key,
   }) : super(key: key);
 
@@ -438,6 +438,9 @@ class QuillEditor extends StatefulWidget {
   /// See [https://api.flutter.dev/flutter/widgets/EditableText/contentInsertionConfiguration.html]
   final ContentInsertionConfiguration? contentInsertionConfiguration;
 
+  /// Builds the text selection toolbar when requested by the user.
+  final Widget Function(BuildContext, RawEditorState)? contextMenuBuilder;
+
   @override
   QuillEditorState createState() => QuillEditorState();
 }
@@ -503,8 +506,9 @@ class QuillEditorState extends State<QuillEditor>
       readOnly: widget.readOnly,
       placeholder: widget.placeholder,
       onLaunchUrl: widget.onLaunchUrl,
-      contextMenuBuilder:
-          showSelectionToolbar ? RawEditor.defaultContextMenuBuilder : null,
+      contextMenuBuilder: showSelectionToolbar
+          ? widget.contextMenuBuilder ?? RawEditor.defaultContextMenuBuilder
+          : null,
       showSelectionHandles: isMobile(theme.platform),
       showCursor: widget.showCursor,
       cursorStyle: CursorStyle(


### PR DESCRIPTION
This PR exposes the contextMenuBuilder to the QuillEditor to allow the customization of the SelectionMenu. This is also possible in most [text-related Flutter widgets](https://api.flutter.dev/flutter/material/TextField/contextMenuBuilder.html).

A implementation could look like this:

```dart
QuillEditor(
	contextMenuBuilder: (BuildContext context, RawEditorState state) {
        return TextFieldTapRegion(
          child: AdaptiveTextSelectionToolbar.buttonItems(
            buttonItems: [
              ...state.contextMenuButtonItems,
              ContextMenuButtonItem(
                label: 'Custom Context Menu Action',
                onPressed: () {
                  print(_controller?.getPlainText()); // Print the selected text, by accessing the QuillController
                },
              ),
            ],
            anchors: state.contextMenuAnchors,
          ),
        );
}
)
```

This changes also allows a workaround for this issue: https://github.com/singerdmx/flutter-quill/issues/1148