### PR TITLE
Added buttonTextStyle & support for custom button in _LinkDialog

### DIFF
--- a/lib/flutter_quill.dart
+++ b/lib/flutter_quill.dart
@@ -11,6 +11,7 @@ export 'src/models/documents/style.dart';
 export 'src/models/quill_delta.dart';
 export 'src/models/structs/doc_change.dart';
 export 'src/models/structs/image_url.dart';
+export 'src/models/structs/link_dialog_action.dart';
 export 'src/models/structs/offset_value.dart';
 export 'src/models/structs/optional_size.dart';
 export 'src/models/structs/vertical_spacing.dart';

--- a/lib/src/models/structs/link_dialog_action.dart
+++ b/lib/src/models/structs/link_dialog_action.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+class LinkDialogAction {
+  LinkDialogAction({required this.builder});
+
+  Widget Function(bool canPress, void Function() applyLink) builder;
+}

--- a/lib/src/models/themes/quill_dialog_theme.dart
+++ b/lib/src/models/themes/quill_dialog_theme.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 /// Used to configure the dialog's look and feel.
 class QuillDialogTheme with Diagnosticable {
   const QuillDialogTheme({
+    this.buttonTextStyle,
     this.labelTextStyle,
     this.inputTextStyle,
     this.dialogBackgroundColor,
@@ -16,6 +17,9 @@ class QuillDialogTheme with Diagnosticable {
     this.isWrappable = false,
     this.runSpacing = 8.0,
   }) : assert(runSpacing >= 0);
+
+  ///The text style to use for the button shown in the dialog
+  final TextStyle? buttonTextStyle;
 
   ///The text style to use for the label shown in the link-input dialog
   final TextStyle? labelTextStyle;
@@ -59,6 +63,7 @@ class QuillDialogTheme with Diagnosticable {
   final double runSpacing;
 
   QuillDialogTheme copyWith({
+    TextStyle? buttonTextStyle,
     TextStyle? labelTextStyle,
     TextStyle? inputTextStyle,
     Color? dialogBackgroundColor,
@@ -72,6 +77,7 @@ class QuillDialogTheme with Diagnosticable {
     double? runSpacing,
   }) {
     return QuillDialogTheme(
+      buttonTextStyle: buttonTextStyle ?? this.buttonTextStyle,
       labelTextStyle: labelTextStyle ?? this.labelTextStyle,
       inputTextStyle: inputTextStyle ?? this.inputTextStyle,
       dialogBackgroundColor:
@@ -96,6 +102,7 @@ class QuillDialogTheme with Diagnosticable {
       return false;
     }
     return other is QuillDialogTheme &&
+        other.buttonTextStyle == buttonTextStyle &&
         other.labelTextStyle == labelTextStyle &&
         other.inputTextStyle == inputTextStyle &&
         other.dialogBackgroundColor == dialogBackgroundColor &&
@@ -112,6 +119,7 @@ class QuillDialogTheme with Diagnosticable {
 
   @override
   int get hashCode => Object.hash(
+        buttonTextStyle,
         labelTextStyle,
         inputTextStyle,
         dialogBackgroundColor,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:i18n_extension/i18n_widget.dart';
 
 import '../models/documents/attribute.dart';
+import '../models/structs/link_dialog_action.dart';
 import '../models/themes/quill_custom_button.dart';
 import '../models/themes/quill_dialog_theme.dart';
 import '../models/themes/quill_icon_theme.dart';
@@ -64,6 +65,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
     VoidCallback? afterButtonPressed,
     this.sectionDividerColor,
     this.sectionDividerSpace,
+    this.linkDialogAction,
     Key? key,
   }) : super(key: key);
 
@@ -157,6 +159,9 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
 
     /// Validate the legitimacy of hyperlinks
     RegExp? linkRegExp,
+
+    LinkDialogAction? linkDialogAction,
+
     Key? key,
   }) {
     final isButtonGroupShown = [
@@ -555,6 +560,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
             dialogTheme: dialogTheme,
             afterButtonPressed: afterButtonPressed,
             linkRegExp: linkRegExp,
+            linkDialogAction: linkDialogAction,
           ),
         if (showSearchButton)
           SearchButton(
@@ -598,6 +604,9 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
   final WrapAlignment toolbarIconAlignment;
   final WrapCrossAlignment toolbarIconCrossAlignment;
   final bool multiRowsDisplay;
+
+  // Overrides the action in the _LinkDialog widget
+  final LinkDialogAction? linkDialogAction;
 
   /// The color of the toolbar.
   ///

--- a/lib/src/widgets/toolbar/link_style_button.dart
+++ b/lib/src/widgets/toolbar/link_style_button.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../models/documents/attribute.dart';
 import '../../models/rules/insert.dart';
+import '../../models/structs/link_dialog_action.dart';
 import '../../models/themes/quill_dialog_theme.dart';
 import '../../models/themes/quill_icon_theme.dart';
 import '../../translations/toolbar.i18n.dart';
@@ -19,6 +20,7 @@ class LinkStyleButton extends StatefulWidget {
     this.afterButtonPressed,
     this.tooltip,
     this.linkRegExp,
+    this.linkDialogAction,
     Key? key,
   }) : super(key: key);
 
@@ -30,6 +32,7 @@ class LinkStyleButton extends StatefulWidget {
   final VoidCallback? afterButtonPressed;
   final String? tooltip;
   final RegExp? linkRegExp;
+  final LinkDialogAction? linkDialogAction;
 
   @override
   _LinkStyleButtonState createState() => _LinkStyleButtonState();
@@ -114,6 +117,7 @@ class _LinkStyleButtonState extends State<LinkStyleButton> {
           link: link,
           text: text,
           linkRegExp: widget.linkRegExp,
+          action: widget.linkDialogAction,
         );
       },
     ).then(
@@ -154,6 +158,7 @@ class _LinkDialog extends StatefulWidget {
     this.link,
     this.text,
     this.linkRegExp,
+    this.action,
     Key? key,
   }) : super(key: key);
 
@@ -161,6 +166,7 @@ class _LinkDialog extends StatefulWidget {
   final String? link;
   final String? text;
   final RegExp? linkRegExp;
+  final LinkDialogAction? action;
 
   @override
   _LinkDialogState createState() => _LinkDialogState();
@@ -216,15 +222,21 @@ class _LinkDialogState extends State<_LinkDialog> {
           ),
         ],
       ),
-      actions: [
-        TextButton(
-          onPressed: _canPress() ? _applyLink : null,
-          child: Text(
-            'Ok'.i18n,
-            style: widget.dialogTheme?.labelTextStyle,
-          ),
-        ),
-      ],
+      actions: [_okButton()],
+    );
+  }
+
+    Widget _okButton() {
+    if (widget.action != null) {
+      return widget.action!.builder(_canPress(), _applyLink);
+    }
+
+    return TextButton(
+      onPressed: _canPress() ? _applyLink : null,
+      child: Text(
+        'Ok'.i18n,
+        style: widget.dialogTheme?.buttonTextStyle,
+      ),
     );
   }
 


### PR DESCRIPTION
Because of https://github.com/singerdmx/flutter-quill/issues/1339 I added support for adding your own widgets that you can use as ok button in the _LinkDialog component. You can also customize the style of the dialog button separately.