### PR TITLE
Fix toolbar dividers condition

### DIFF
--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -175,7 +175,11 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           showBackgroundColorButton ||
           showClearFormat ||
           embedButtons?.isNotEmpty == true,
-      showLeftAlignment || showCenterAlignment || showRightAlignment || showJustifyAlignment || showDirection,
+      showLeftAlignment ||
+          showCenterAlignment ||
+          showRightAlignment ||
+          showJustifyAlignment ||
+          showDirection,
       showHeaderStyle,
       showListNumbers || showListBullets || showListCheck || showCodeBlock,
       showQuote || showIndent,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -175,11 +175,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           showBackgroundColorButton ||
           showClearFormat ||
           embedButtons?.isNotEmpty == true,
-      showAlignmentButtons || showDirection,
-      showLeftAlignment,
-      showCenterAlignment,
-      showRightAlignment,
-      showJustifyAlignment,
+      (showAlignmentButtons && (showLeftAlignment || showCenterAlignment || showRightAlignment || showJustifyAlignment)) || showDirection,
       showHeaderStyle,
       showListNumbers || showListBullets || showListCheck || showCodeBlock,
       showQuote || showIndent,

--- a/lib/src/widgets/toolbar.dart
+++ b/lib/src/widgets/toolbar.dart
@@ -175,7 +175,7 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
           showBackgroundColorButton ||
           showClearFormat ||
           embedButtons?.isNotEmpty == true,
-      (showAlignmentButtons && (showLeftAlignment || showCenterAlignment || showRightAlignment || showJustifyAlignment)) || showDirection,
+      showLeftAlignment || showCenterAlignment || showRightAlignment || showJustifyAlignment || showDirection,
       showHeaderStyle,
       showListNumbers || showListBullets || showListCheck || showCodeBlock,
       showQuote || showIndent,


### PR DESCRIPTION
There are only 6 groups of buttons but isButtonGroupShown has 10 members instead of 6. All conditions related to dividers access only members of isButtonGroupShown array with indexes 0-5. 

Alignment buttons should be grouped into one condition, which is what I adjusted and separators are showing as expected.