### PR TITLE
refactor: Simplifying `universal_ui` in the example app

### DIFF
--- a/example/lib/universal_ui/fake_ui.dart
+++ b/example/lib/universal_ui/fake_ui.dart
@@ -1,3 +1,0 @@
-class PlatformViewRegistry {
-  static void registerViewFactory(String viewId, dynamic cb) {}
-}

--- a/example/lib/universal_ui/real_ui.dart
+++ b/example/lib/universal_ui/real_ui.dart
@@ -1,7 +1,0 @@
-import 'dart:ui' as ui;
-
-class PlatformViewRegistry {
-  static void registerViewFactory(String viewId, dynamic cb) {
-    ui.platformViewRegistry.registerViewFactory(viewId, cb);
-  }
-}

--- a/example/lib/universal_ui/universal_ui.dart
+++ b/example/lib/universal_ui/universal_ui.dart
@@ -1,31 +1,14 @@
 library universal_ui;
 
+import 'dart:ui_web' as ui_web;
+
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill_extensions/flutter_quill_extensions.dart';
 import 'package:universal_html/html.dart' as html;
 import 'package:youtube_player_flutter/youtube_player_flutter.dart';
 
-import '../widgets/responsive_widget.dart';
-import 'fake_ui.dart' if (dart.library.html) 'real_ui.dart' as ui_instance;
-
-class PlatformViewRegistryFix {
-  void registerViewFactory(dynamic x, dynamic y) {
-    if (kIsWeb) {
-      ui_instance.PlatformViewRegistry.registerViewFactory(
-        x,
-        y,
-      );
-    }
-  }
-}
-
-class UniversalUI {
-  PlatformViewRegistryFix platformViewRegistry = PlatformViewRegistryFix();
-}
-
-var ui = UniversalUI();
+import '../widgets/responsive_widget.dart'; 
 
 class ImageEmbedBuilderWeb extends EmbedBuilder {
   @override
@@ -46,10 +29,10 @@ class ImageEmbedBuilderWeb extends EmbedBuilder {
       return const SizedBox();
     }
     final size = MediaQuery.of(context).size;
-    UniversalUI().platformViewRegistry.registerViewFactory(imageUrl, (viewId) {
+    ui_web.platformViewRegistry.registerViewFactory(imageUrl, (viewId) {
       return html.ImageElement()
         ..src = imageUrl
-        ..style.height = 'auto'
+        ..style.height = '300px'
         ..style.width = 'auto';
     });
     return Padding(
@@ -91,7 +74,7 @@ class VideoEmbedBuilderWeb extends EmbedBuilder {
       }
     }
 
-    UniversalUI().platformViewRegistry.registerViewFactory(
+    ui_web.platformViewRegistry.registerViewFactory(
         videoUrl,
         (id) => html.IFrameElement()
           ..width = MediaQuery.of(context).size.width.toString()


### PR DESCRIPTION
In the example app, in order to embed an image into the editor, we need to use `platformViewRegistry.registerViewFactory` so the image is properly displayed in `web` applications.

Because `platformViewRegistry.registerViewFactory(...)` was introduced in https://github.com/flutter/engine/pull/41877, we don't need to use a `fake_ui.dart` and `real_ui.dart` to do conditional imports as a workaround for that not compiling on `web`.

Therefore, we can simply use:

```dart
import 'dart:ui_web' as ui_web; // New import for all web-only stuff...

...

ui_web.platformViewRegistry.registerViewFactory(...); // as usual!
```


This PR makes this simple change and removes consequential dead code 😃 .