### PR TITLE
[Hoàng Sang] Fix some bugs

### DIFF
--- a/lib/src/models/documents/document.dart
+++ b/lib/src/models/documents/document.dart
@@ -156,7 +156,19 @@ class Document {
   /// included in the result.
   Style collectStyle(int index, int len) {
     final res = queryChild(index);
-    return (res.node as Line).collectStyle(res.offset, len);
+    // -1 because the cursor is at the part of the line that is not visible
+    // Bug: When the caret is in the middle of the paragraph 
+    // and at the end of the format string, it will display the wrong state 
+    // of the format button
+    final isNotLinkStyle =
+        res.node?.style.attributes[Attribute.link.key]?.value == false;
+    // In this case, we have an exception, this is a link.
+    // When node is a link we will not -1
+    return (res.node as Line).collectStyle(
+        len == 0 && res.node != null && isNotLinkStyle
+            ? res.offset - 1
+            : res.offset,
+        len);
   }
 
   /// Returns all styles and Embed for each node within selection

--- a/lib/src/models/documents/document.dart
+++ b/lib/src/models/documents/document.dart
@@ -157,15 +157,15 @@ class Document {
   Style collectStyle(int index, int len) {
     final res = queryChild(index);
     // -1 because the cursor is at the part of the line that is not visible
-    // Bug: When the caret is in the middle of the paragraph 
-    // and at the end of the format string, it will display the wrong state 
+    // Bug: When the caret is in the middle of the paragraph
+    // and at the end of the format string, it will display the wrong state
     // of the format button
-    final isNotLinkStyle =
-        res.node?.style.attributes[Attribute.link.key]?.value == false;
+    final isLinkStyle =
+        res.node?.style.attributes[Attribute.link.key]?.value == true;
     // In this case, we have an exception, this is a link.
     // When node is a link we will not -1
     return (res.node as Line).collectStyle(
-        len == 0 && res.node != null && isNotLinkStyle
+        len == 0 && res.node != null && !isLinkStyle
             ? res.offset - 1
             : res.offset,
         len);

--- a/lib/src/widgets/controller.dart
+++ b/lib/src/widgets/controller.dart
@@ -122,14 +122,13 @@ class QuillController extends ChangeNotifier {
       formatSelection(Attribute.clone(Attribute.indentL1, null));
       return;
     }
-    if (isIncrease && indent.value < 5) {
-      formatSelection(Attribute.getIndentLevel(indent.value + 1));
+    if (isIncrease) {
+      if (indent.value < 5) {
+        formatSelection(Attribute.getIndentLevel(indent.value + 1));
+      }
       return;
     }
-    if (indent.value > 0) {
-      formatSelection(Attribute.getIndentLevel(indent.value - 1));
-      return;
-    }
+    formatSelection(Attribute.getIndentLevel(indent.value - 1));
   }
 
   void _indentSelectionEachLine(bool isIncrease) {

--- a/lib/src/widgets/controller.dart
+++ b/lib/src/widgets/controller.dart
@@ -152,7 +152,9 @@ class QuillController extends ChangeNotifier {
       } else if (indent.value == 1 && !isIncrease) {
         formatAttribute = Attribute.clone(Attribute.indentL1, null);
       } else if (isIncrease) {
-        formatAttribute = Attribute.getIndentLevel(indent.value + 1);
+        if (indent.value < 5) {
+          formatAttribute = Attribute.getIndentLevel(indent.value + 1);
+        }
       } else {
         formatAttribute = Attribute.getIndentLevel(indent.value - 1);
       }

--- a/lib/src/widgets/controller.dart
+++ b/lib/src/widgets/controller.dart
@@ -122,11 +122,14 @@ class QuillController extends ChangeNotifier {
       formatSelection(Attribute.clone(Attribute.indentL1, null));
       return;
     }
-    if (isIncrease) {
+    if (isIncrease && indent.value < 5) {
       formatSelection(Attribute.getIndentLevel(indent.value + 1));
       return;
     }
-    formatSelection(Attribute.getIndentLevel(indent.value - 1));
+    if (indent.value > 0) {
+      formatSelection(Attribute.getIndentLevel(indent.value - 1));
+      return;
+    }
   }
 
   void _indentSelectionEachLine(bool isIncrease) {

--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -192,6 +192,7 @@ class QuillEditor extends StatefulWidget {
     this.dialogTheme,
     this.contentInsertionConfiguration,
     this.contextMenuBuilder,
+    this.editorKey,
     Key? key,
   }) : super(key: key);
 
@@ -205,6 +206,7 @@ class QuillEditor extends StatefulWidget {
     bool expands = false,
     FocusNode? focusNode,
     String? placeholder,
+    GlobalKey<EditorState>? editorKey,
 
     /// The locale to use for the editor toolbar, defaults to system locale
     /// More at https://github.com/singerdmx/flutter-quill#translation
@@ -223,6 +225,7 @@ class QuillEditor extends StatefulWidget {
       locale: locale,
       embedBuilders: embedBuilders,
       placeholder: placeholder,
+      editorKey: editorKey,
     );
   }
 
@@ -448,19 +451,24 @@ class QuillEditor extends StatefulWidget {
   /// See [https://api.flutter.dev/flutter/widgets/EditableText/contentInsertionConfiguration.html]
   final ContentInsertionConfiguration? contentInsertionConfiguration;
 
+  /// Using the editorKey for get getLocalRectForCaret
+  /// editorKey.currentState?.renderEditor.getLocalRectForCaret
+  final GlobalKey<EditorState>? editorKey;
+
   @override
   QuillEditorState createState() => QuillEditorState();
 }
 
 class QuillEditorState extends State<QuillEditor>
     implements EditorTextSelectionGestureDetectorBuilderDelegate {
-  final GlobalKey<EditorState> _editorKey = GlobalKey<EditorState>();
+  late GlobalKey<EditorState> _editorKey;
   late EditorTextSelectionGestureDetectorBuilder
       _selectionGestureDetectorBuilder;
 
   @override
   void initState() {
     super.initState();
+    _editorKey = widget.editorKey ?? GlobalKey<EditorState>();
     _selectionGestureDetectorBuilder =
         _QuillEditorSelectionGestureDetectorBuilder(
             this, widget.detectWordBoundary);


### PR DESCRIPTION
#1. When the caret is in the middle of the paragraph and at the end of the format string, it will display the wrong state of the format button (lib/src/models/documents/document.dart file)
| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/singerdmx/flutter-quill/assets/56586682/3379eacd-7f9e-4aef-8a55-4e57db6d9e2b)  |  ![image](https://github.com/singerdmx/flutter-quill/assets/56586682/4382b2e1-b21e-4f36-bdb8-4dd06f6d2af9)  |


#2. When the indent is too large, the content does not display well (lib/src/widgets/controller.dart file)
| Type | Before  | After |
| ------------ | ------------- | ------------- |
| Increase | ![image](https://github.com/singerdmx/flutter-quill/assets/56586682/13097139-382d-4425-97d7-68378d9f8433) | ![image](https://github.com/singerdmx/flutter-quill/assets/56586682/afdc458b-375c-41b2-867e-b49db8dd1898) |

#3. I want to add editorKey to get the caret position

