### PR TITLE
Fix bug with keepStyleOnNewLine for link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [7.4.2]
+- Fix bug with keepStyleOnNewLine for link.
+
 # [7.4.1]
 - Fix toolbar dividers condition.
 

--- a/lib/src/widgets/controller.dart
+++ b/lib/src/widgets/controller.dart
@@ -400,10 +400,10 @@ class QuillController extends ChangeNotifier {
         extentOffset: math.min(selection.extentOffset, end));
     if (_keepStyleOnNewLine) {
       final style = getSelectionStyle();
-      final notInlineStyle = style.attributes.values.where(
+      final ignoredStyles = style.attributes.values.where(
         (s) => !s.isInline || s.key == Attribute.link.key,
       );
-      toggledStyle = style.removeAll(notInlineStyle.toSet());
+      toggledStyle = style.removeAll(ignoredStyles.toSet());
     } else {
       toggledStyle = Style();
     }

--- a/lib/src/widgets/controller.dart
+++ b/lib/src/widgets/controller.dart
@@ -400,7 +400,9 @@ class QuillController extends ChangeNotifier {
         extentOffset: math.min(selection.extentOffset, end));
     if (_keepStyleOnNewLine) {
       final style = getSelectionStyle();
-      final notInlineStyle = style.attributes.values.where((s) => !s.isInline);
+      final notInlineStyle = style.attributes.values.where(
+        (s) => !s.isInline || s.key == Attribute.link.key,
+      );
       toggledStyle = style.removeAll(notInlineStyle.toSet());
     } else {
       toggledStyle = Style();


### PR DESCRIPTION
the bug is that when moving to a new line from a line where there is a link and the `keepStyleOnNewLine=true ` for `quill controller`, all text after that applies the link attribute to itself because

```
if (_keepStyleOnNewLine) {
  final style = getSelectionStyle();
  final notInlineStyle = style.attributes.values.where((s) => !s.isInline);
  toggledStyle = style.removeAll(notInlineStyle.toSet());
}
```
`and LinkAttribute is a Inline`

```
class LinkAttribute extends Attribute<String?> {
  const LinkAttribute(String? val) : super('link', AttributeScope.INLINE, val);
}
```