### PR TITLE
Style recognition fixes

### DIFF
--- a/lib/src/models/documents/document.dart
+++ b/lib/src/models/documents/document.dart
@@ -156,19 +156,28 @@ class Document {
   /// included in the result.
   Style collectStyle(int index, int len) {
     final res = queryChild(index);
-    // -1 because the cursor is at the part of the line that is not visible
-    // Bug: When the caret is in the middle of the paragraph
-    // and at the end of the format string, it will display the wrong state
-    // of the format button
-    final isLinkStyle =
-        res.node?.style.attributes[Attribute.link.key]?.value == true;
-    // In this case, we have an exception, this is a link.
-    // When node is a link we will not -1
-    return (res.node as Line).collectStyle(
-        len == 0 && res.node != null && !isLinkStyle
-            ? res.offset - 1
-            : res.offset,
-        len);
+    Style rangeStyle;
+    if (len > 0) {
+      return (res.node as Line).collectStyle(res.offset, len);
+    }
+    if (res.offset == 0) {
+      rangeStyle = (res.node as Line).collectStyle(res.offset, len);
+      return rangeStyle.removeAll({
+        for (final attr in rangeStyle.values)
+          if (attr.isInline) attr
+      });
+    }
+    rangeStyle = (res.node as Line).collectStyle(res.offset - 1, len);
+    final linkAttribute = rangeStyle.attributes[Attribute.link.key];
+    if ((linkAttribute != null) &&
+        (linkAttribute.value !=
+            (res.node as Line)
+                .collectStyle(res.offset, len)
+                .attributes[Attribute.link.key]
+                ?.value)) {
+      return rangeStyle.removeAll({linkAttribute});
+    }
+    return rangeStyle;
   }
 
   /// Returns all styles and Embed for each node within selection

--- a/lib/src/models/documents/nodes/line.dart
+++ b/lib/src/models/documents/nodes/line.dart
@@ -352,18 +352,13 @@ class Line extends Container<Leaf?> {
     final excluded = <Attribute>{};
 
     void _handle(Style style) {
-      if (result.isEmpty) {
-        excluded.addAll(style.values);
-      } else {
-        for (final attr in result.values) {
-          if (!style.containsKey(attr.key)) {
-            excluded.add(attr);
-          }
+      for (final attr in result.values) {
+        if (!style.containsKey(attr.key) ||
+            (style.attributes[attr.key] != attr.value)) {
+          excluded.add(attr);
         }
       }
-      final remaining = style.removeAll(excluded);
       result = result.removeAll(excluded);
-      result = result.mergeAll(remaining);
     }
 
     final data = queryChild(offset, true);


### PR DESCRIPTION
1) Improves this [fix](https://github.com/singerdmx/flutter-quill/commit/2045d45e882e7b830b41a2e92aa0669ec13c2070), so that it works correctly for links and block styles.
Editor input works in the following way:
If the caret is just before some style, then text input doesn't share this style. For example, if the caret is before "b" in "**bold**", the input is not bold.
If the caret is just after some style, then text input does share this style. For example,  if the caret is after "d" in "**bold**", the input is bold. Links are the exceptions from this rule.
The fix aligns style recognition with that approach.
Block styles are also taken into account in the fix.

2) Fixes #1404 and other selection style recognition issues.
Before the fix range style was defined as symmetric difference of each individual segment's styles (at least for the case of two such segments in the range). That's why, for example, selecting  "**some**_text_" indicated it as an Italic (despite that the first part is Bold).
Moreover, style values are also compared now. So, different colors or links in the range are not considered as having the same style.