### PR TITLE
Fixed tab editing when in readOnly mode

### DIFF
--- a/lib/src/widgets/raw_editor.dart
+++ b/lib/src/widgets/raw_editor.dart
@@ -757,6 +757,9 @@ class RawEditorState extends EditorState
         controller.document.queryChild(controller.selection.baseOffset);
 
     KeyEventResult insertTabCharacter() {
+      if (widget.readOnly) {
+        return KeyEventResult.ignored;
+      }
       controller.replaceText(controller.selection.baseOffset, 0, '\t', null);
       _moveCursor(1);
       return KeyEventResult.handled;


### PR DESCRIPTION
We were having an issue where if we were tabbing around the interface, the document would be edited even in readOnly mode.