### PR TITLE
Allow QuillProvider to rebuild w/o exception

### DIFF
--- a/lib/src/widgets/utils/provider.dart
+++ b/lib/src/widgets/utils/provider.dart
@@ -18,7 +18,7 @@ class QuillProvider extends InheritedWidget {
 
   @override
   bool updateShouldNotify(covariant InheritedWidget oldWidget) {
-    throw false;
+    return true;
   }
 
   static QuillProvider? of(BuildContext context) {


### PR DESCRIPTION
QuillProvider is throwing an exception in updateShouldNotify.  Since editor configuration setting readOnly is now in the QuillProvider I'm not able to start the editor in read only mode then toggle to editable mode.

My code fragment follows. When _editMode toggles - QuillProvider is throwing an exception

`QuillProvider(
        configurations: QuillConfigurations(
          controller: controller,
          editorConfigurations: QuillEditorConfigurations(readOnly: !_editMode),
          toolbarConfigurations: QuillToolbarConfigurations(
            toolbarSize: toolbarIconSize * 2,
            multiRowsDisplay: false,
          ),
        ),
        child: child`