### PR TITLE
Update QuillCustomButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [8.4.0]
 - **Breaking change**: Update the `QuillCustomButton` to have `QuillCustomButtonOptions`. We moved everything that is in the `QuillCustomButton` to `QuillCustomButtonOptions` but replaced the `iconData` with `icon` widget for more customizations
+- **Breaking change**: the `customButtons` in the `QuillToolbarConfigurations` is now of type `List<QuillToolbarCustomButtonOptions>`
 - Bug fixes with the new `8.0.0` update
+- Update `README.md`
 
 ## [8.3.0]
 - Added a `iconButtonFactor` property to `QuillToolbarBaseButtonOptions` to customise how big the button is compared to its icon size (defaults to `kIconButtonFactor` which is the same as previous releases)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [8.4.0]
+- **Breaking change**: Update the `QuillCustomButton` to have `QuillCustomButtonOptions`. We moved everything that is in the `QuillCustomButton` to `QuillCustomButtonOptions` but replaced the `iconData` with `icon` widget for more customizations
+- Bug fixes with the new `8.0.0` update
+
 ## [8.3.0]
 - Added a `iconButtonFactor` property to `QuillToolbarBaseButtonOptions` to customise how big the button is compared to its icon size (defaults to `kIconButtonFactor` which is the same as previous releases)
 

--- a/README.md
+++ b/README.md
@@ -199,17 +199,17 @@ To use your own fonts, update your [assets folder](https://github.com/singerdmx/
 
 ### Custom Buttons
 
-You may add custom buttons to the _end_ of the toolbar, via the `customButtons` option, which is a `List` of `QuillCustomButton`.
+You may add custom buttons to the _end_ of the toolbar, via the `customButtons` option, which is a `List` of `QuillToolbarCustomButtonOptions`.
 
-To add an Icon, we should use a new QuillCustomButton class
+To add an Icon, we should use a new `QuillToolbarCustomButtonOptions` class
 
 ```dart
-    QuillCustomButton(
-        iconData: Icons.ac_unit,
-        onTap: () {
-          debugPrint('snowflake');
-        }
-    ),
+    QuillToolbarCustomButtonOptions(
+        icon: const Icon(Icons.ac_unit),
+        tooltip: '',
+        onPressed: () {},
+        afterButtonPressed: () {},
+      ),
 ```
 
 Each `QuillCustomButton` is used as part of the `customButtons` option as follows:
@@ -218,21 +218,21 @@ Each `QuillCustomButton` is used as part of the `customButtons` option as follow
 QuillToolbar(
   configurations: QuillToolbarConfigurations(
     customButtons: [
-      QuillCustomButton(
-        iconData: Icons.ac_unit,
-        onTap: () {
+      QuillToolbarCustomButtonOptions(
+        icon: const Icon(Icons.ac_unit),
+        onPressed: () {
           debugPrint('snowflake1');
         },
       ),
-      QuillCustomButton(
-        iconData: Icons.ac_unit,
-        onTap: () {
+      QuillToolbarCustomButtonOptions(
+        icon: const Icon(Icons.ac_unit),
+        onPressed: () {
           debugPrint('snowflake2');
         },
       ),
-      QuillCustomButton(
-        iconData: Icons.ac_unit,
-        onTap: () {
+      QuillToolbarCustomButtonOptions(
+        icon: const Icon(Icons.ac_unit),
+        onPressed: () {
           debugPrint('snowflake3');
         },
       ),

--- a/example/lib/pages/home_page.dart
+++ b/example/lib/pages/home_page.dart
@@ -457,9 +457,15 @@ class _HomePageState extends State<HomePage> {
   }
 
   QuillToolbar get quillToolbar {
+    final customButtons = [
+      const QuillToolbarCustomButtonOptions(
+        icon: Icon(Icons.add),
+      ),
+    ];
     if (kIsWeb) {
       return QuillToolbar(
         configurations: QuillToolbarConfigurations(
+          customButtons: customButtons,
           embedButtons: FlutterQuillEmbeds.toolbarButtons(
             imageButtonOptions: QuillToolbarImageButtonOptions(
               imageButtonConfigurations: QuillToolbarImageConfigurations(
@@ -482,6 +488,7 @@ class _HomePageState extends State<HomePage> {
     if (isDesktop()) {
       return QuillToolbar(
         configurations: QuillToolbarConfigurations(
+          customButtons: customButtons,
           embedButtons: FlutterQuillEmbeds.toolbarButtons(
             imageButtonOptions: QuillToolbarImageButtonOptions(
               imageButtonConfigurations: QuillToolbarImageConfigurations(
@@ -502,6 +509,7 @@ class _HomePageState extends State<HomePage> {
     }
     return QuillToolbar(
       configurations: QuillToolbarConfigurations(
+        customButtons: customButtons,
         embedButtons: FlutterQuillEmbeds.toolbarButtons(
           videoButtonOptions: QuillToolbarVideoButtonOptions(
             videoConfigurations: QuillToolbarVideoConfigurations(

--- a/example/lib/pages/home_page.dart
+++ b/example/lib/pages/home_page.dart
@@ -458,8 +458,23 @@ class _HomePageState extends State<HomePage> {
 
   QuillToolbar get quillToolbar {
     final customButtons = [
-      const QuillToolbarCustomButtonOptions(
-        icon: Icon(Icons.add),
+      QuillToolbarCustomButtonOptions(
+        icon: const Icon(Icons.ac_unit),
+        onPressed: () {
+          debugPrint('snowflake1');
+        },
+      ),
+      QuillToolbarCustomButtonOptions(
+        icon: const Icon(Icons.ac_unit),
+        onPressed: () {
+          debugPrint('snowflake2');
+        },
+      ),
+      QuillToolbarCustomButtonOptions(
+        icon: const Icon(Icons.ac_unit),
+        onPressed: () {
+          debugPrint('snowflake3');
+        },
       ),
     ];
     if (kIsWeb) {

--- a/flutter_quill_test/CHANGELOG.md
+++ b/flutter_quill_test/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.4+1
+* Update `README.md`
+
 ## 0.0.4
 * Update `README.md`
 * Documentation comments.

--- a/flutter_quill_test/pubspec.yaml
+++ b/flutter_quill_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_quill_test
 description: Test utilities for flutter_quill which includes methods to simplify interacting with the editor in test cases.
-version: 0.0.4
+version: 0.0.4+1
 homepage: https://1o24bbs.com/c/bulletjournal/108
 repository: https://github.com/singerdmx/flutter-quill/tree/master/flutter_quill_test
 

--- a/lib/src/models/config/toolbar/base_configurations.dart
+++ b/lib/src/models/config/toolbar/base_configurations.dart
@@ -4,7 +4,6 @@ import 'package:flutter/widgets.dart'
 
 import '../../../widgets/toolbar/base_toolbar.dart';
 import '../../structs/link_dialog_action.dart';
-import '../../themes/quill_custom_button.dart';
 
 @immutable
 class QuillBaseToolbarConfigurations extends Equatable {

--- a/lib/src/models/config/toolbar/base_configurations.dart
+++ b/lib/src/models/config/toolbar/base_configurations.dart
@@ -40,7 +40,7 @@ class QuillBaseToolbarConfigurations extends Equatable {
   final Color? color;
 
   /// List of custom buttons
-  final List<QuillToolbarCustomButton> customButtons;
+  final List<QuillToolbarCustomButtonOptions> customButtons;
 
   /// The color to use when painting the toolbar section divider.
   ///

--- a/lib/src/models/config/toolbar/base_configurations.dart
+++ b/lib/src/models/config/toolbar/base_configurations.dart
@@ -41,7 +41,7 @@ class QuillBaseToolbarConfigurations extends Equatable {
   final Color? color;
 
   /// List of custom buttons
-  final List<QuillCustomButton> customButtons;
+  final List<QuillToolbarCustomButton> customButtons;
 
   /// The color to use when painting the toolbar section divider.
   ///

--- a/lib/src/models/config/toolbar/buttons/custom_button.dart
+++ b/lib/src/models/config/toolbar/buttons/custom_button.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/widgets.dart' show VoidCallback, Widget;
+
+import 'base.dart';
+
+class QuillToolbarCustomButtonExtraOptions
+    extends QuillToolbarBaseButtonExtraOptions {
+  const QuillToolbarCustomButtonExtraOptions({
+    required super.controller,
+    required super.context,
+    required super.onPressed,
+  });
+}
+
+class QuillToolbarCustomButtonOptions extends QuillToolbarBaseButtonOptions<
+    QuillToolbarBaseButtonOptions, QuillToolbarCustomButtonExtraOptions> {
+  const QuillToolbarCustomButtonOptions({
+    this.icon,
+    this.iconButtonFactor,
+    this.iconSize,
+    super.iconData,
+    super.afterButtonPressed,
+    super.tooltip,
+    super.iconTheme,
+    super.childBuilder,
+    super.controller,
+    this.onPressed,
+  });
+
+  final double? iconButtonFactor;
+  final double? iconSize;
+  final VoidCallback? onPressed;
+  final Widget? icon;
+}

--- a/lib/src/models/config/toolbar/buttons/custom_button.dart
+++ b/lib/src/models/config/toolbar/buttons/custom_button.dart
@@ -17,7 +17,6 @@ class QuillToolbarCustomButtonOptions extends QuillToolbarBaseButtonOptions<
     this.icon,
     this.iconButtonFactor,
     this.iconSize,
-    super.iconData,
     super.afterButtonPressed,
     super.tooltip,
     super.iconTheme,

--- a/lib/src/models/config/toolbar/configurations.dart
+++ b/lib/src/models/config/toolbar/configurations.dart
@@ -4,8 +4,8 @@ import 'package:flutter/widgets.dart'
     show Axis, Color, Decoration, Widget, WrapAlignment, WrapCrossAlignment;
 import '../../../widgets/embeds.dart';
 
+import '../../../widgets/toolbar/buttons/custom_button.dart';
 import '../../structs/link_dialog_action.dart';
-import '../../themes/quill_custom_button.dart';
 import '../../themes/quill_dialog_theme.dart';
 import '../../themes/quill_icon_theme.dart';
 import 'buttons/base.dart';
@@ -212,7 +212,7 @@ class QuillToolbarConfigurations extends Equatable {
   final bool showSearchButton;
   final bool showSubscript;
   final bool showSuperscript;
-  final List<QuillCustomButton> customButtons;
+  final List<QuillToolbarCustomButton> customButtons;
 
   /// The decoration to use for the toolbar.
   final Decoration? decoration;

--- a/lib/src/models/config/toolbar/configurations.dart
+++ b/lib/src/models/config/toolbar/configurations.dart
@@ -2,9 +2,8 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart' show immutable;
 import 'package:flutter/widgets.dart'
     show Axis, Color, Decoration, Widget, WrapAlignment, WrapCrossAlignment;
-import '../../../widgets/embeds.dart';
 
-import '../../../widgets/toolbar/buttons/custom_button.dart';
+import '../../../widgets/embeds.dart';
 import '../../structs/link_dialog_action.dart';
 import '../../themes/quill_dialog_theme.dart';
 import '../../themes/quill_icon_theme.dart';
@@ -27,6 +26,7 @@ export './../../../widgets/toolbar/buttons/search/search_dialog.dart';
 export './buttons/base.dart';
 export './buttons/clear_format.dart';
 export './buttons/color.dart';
+export './buttons/custom_button.dart';
 export './buttons/font_family.dart';
 export './buttons/font_size.dart';
 export './buttons/history.dart';
@@ -212,7 +212,7 @@ class QuillToolbarConfigurations extends Equatable {
   final bool showSearchButton;
   final bool showSubscript;
   final bool showSuperscript;
-  final List<QuillToolbarCustomButton> customButtons;
+  final List<QuillToolbarCustomButtonOptions> customButtons;
 
   /// The decoration to use for the toolbar.
   final Decoration? decoration;

--- a/lib/src/models/config/toolbar/configurations.dart
+++ b/lib/src/models/config/toolbar/configurations.dart
@@ -11,6 +11,7 @@ import '../../themes/quill_icon_theme.dart';
 import 'buttons/base.dart';
 import 'buttons/clear_format.dart';
 import 'buttons/color.dart';
+import 'buttons/custom_button.dart';
 import 'buttons/font_family.dart';
 import 'buttons/font_size.dart';
 import 'buttons/history.dart';
@@ -284,6 +285,7 @@ class QuillToolbarButtonOptions extends Equatable {
     this.selectHeaderStyleButtons =
         const QuillToolbarSelectHeaderStyleButtonsOptions(),
     this.linkStyle = const QuillToolbarLinkStyleButtonOptions(),
+    this.customButtons = const QuillToolbarCustomButtonOptions(),
   });
 
   /// The base configurations for all the buttons which will apply to all
@@ -328,6 +330,8 @@ class QuillToolbarButtonOptions extends Equatable {
   final QuillToolbarSelectHeaderStyleButtonsOptions selectHeaderStyleButtons;
 
   final QuillToolbarLinkStyleButtonOptions linkStyle;
+
+  final QuillToolbarCustomButtonOptions customButtons;
 
   @override
   List<Object?> get props => [

--- a/lib/src/models/themes/quill_custom_button.dart
+++ b/lib/src/models/themes/quill_custom_button.dart
@@ -1,22 +1,22 @@
-import 'package:flutter/material.dart';
+// import 'package:flutter/material.dart';
 
-import '../../widgets/toolbar/base_toolbar.dart';
+// import '../../widgets/toolbar/base_toolbar.dart';
 
-class QuillCustomButton extends QuillToolbarBaseButtonOptions {
-  const QuillCustomButton({
-    this.icon,
-    this.onTap,
-    super.tooltip,
-    this.child,
-    super.iconTheme,
-  });
+// class QuillCustomButton extends QuillToolbarBaseButtonOptions {
+//   const QuillCustomButton({
+//     this.icon,
+//     this.onTap,
+//     super.tooltip,
+//     this.child,
+//     super.iconTheme,
+//   });
 
-  /// The icon widget
-  final Widget? icon;
+//   /// The icon widget
+//   final Widget? icon;
 
-  /// The function when the icon is tapped
-  final VoidCallback? onTap;
+//   /// The function when the icon is tapped
+//   final VoidCallback? onTap;
 
-  /// The customButton placeholder
-  final Widget? child;
-}
+//   /// The customButton placeholder
+//   final Widget? child;
+// }

--- a/lib/src/models/themes/quill_custom_button.dart
+++ b/lib/src/models/themes/quill_custom_button.dart
@@ -4,23 +4,19 @@ import '../../widgets/toolbar/base_toolbar.dart';
 
 class QuillCustomButton extends QuillToolbarBaseButtonOptions {
   const QuillCustomButton({
-    super.iconData,
-    this.iconColor,
+    this.icon,
     this.onTap,
     super.tooltip,
-    this.iconSize,
     this.child,
     super.iconTheme,
   });
 
-  ///The icon color;
-  final Color? iconColor;
+  /// The icon widget
+  final Widget? icon;
 
-  ///The function when the icon is tapped
+  /// The function when the icon is tapped
   final VoidCallback? onTap;
 
-  ///The customButton placeholder
+  /// The customButton placeholder
   final Widget? child;
-
-  final double? iconSize;
 }

--- a/lib/src/widgets/toolbar/buttons/custom_button.dart
+++ b/lib/src/widgets/toolbar/buttons/custom_button.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../../../models/config/toolbar/buttons/custom_button.dart';
 import '../../../models/themes/quill_icon_theme.dart';
 import '../../../utils/extensions/build_context.dart';
 import '../../controller.dart';

--- a/lib/src/widgets/toolbar/buttons/custom_button.dart
+++ b/lib/src/widgets/toolbar/buttons/custom_button.dart
@@ -1,43 +1,93 @@
 import 'package:flutter/material.dart';
 
+import '../../../models/config/toolbar/buttons/custom_button.dart';
 import '../../../models/themes/quill_icon_theme.dart';
+import '../../../utils/extensions/build_context.dart';
+import '../../controller.dart';
 import '../base_toolbar.dart';
 
-class CustomButton extends StatelessWidget {
-  const CustomButton({
-    required this.onPressed,
-    required this.icon,
-    this.iconColor,
-    this.iconSize = kDefaultIconSize,
-    this.iconButtonFactor = kIconButtonFactor,
-    this.iconTheme,
-    this.afterButtonPressed,
-    this.tooltip,
+class QuillToolbarCustomButton extends StatelessWidget {
+  const QuillToolbarCustomButton({
+    required this.options,
+    required this.controller,
     super.key,
   });
 
-  final VoidCallback? onPressed;
-  final IconData? icon;
-  final Color? iconColor;
-  final double iconSize;
-  final double iconButtonFactor;
-  final QuillIconTheme? iconTheme;
-  final VoidCallback? afterButtonPressed;
-  final String? tooltip;
+  final QuillController controller;
+  final QuillToolbarCustomButtonOptions options;
+
+  double _iconSize(BuildContext context) {
+    final baseFontSize = baseButtonExtraOptions(context).globalIconSize;
+    final iconSize = options.iconSize;
+    return iconSize ?? baseFontSize;
+  }
+
+  double _iconButtonFactor(BuildContext context) {
+    final baseIconFactor =
+        baseButtonExtraOptions(context).globalIconButtonFactor;
+    final iconButtonFactor = options.iconButtonFactor;
+    return iconButtonFactor ?? baseIconFactor;
+  }
+
+  VoidCallback? _afterButtonPressed(BuildContext context) {
+    return options.afterButtonPressed ??
+        baseButtonExtraOptions(context).afterButtonPressed;
+  }
+
+  QuillIconTheme? _iconTheme(BuildContext context) {
+    return options.iconTheme ?? baseButtonExtraOptions(context).iconTheme;
+  }
+
+  QuillToolbarBaseButtonOptions baseButtonExtraOptions(BuildContext context) {
+    return context.requireQuillToolbarBaseButtonOptions;
+  }
+
+  String? _tooltip(BuildContext context) {
+    return options.tooltip ?? baseButtonExtraOptions(context).tooltip;
+  }
+
+  void _onPressed(BuildContext context) {
+    options.onPressed?.call();
+    _afterButtonPressed(context)?.call();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final iconTheme = _iconTheme(context);
+    final tooltip = _tooltip(context);
+    final iconSize = _iconSize(context);
+    final iconButtonFactor = _iconButtonFactor(context);
 
-    final iconColor = iconTheme?.iconUnselectedColor ?? theme.iconTheme.color;
+    final childBuilder =
+        options.childBuilder ?? baseButtonExtraOptions(context).childBuilder;
+    final afterButtonPressed = _afterButtonPressed(context);
+
+    if (childBuilder != null) {
+      return childBuilder(
+        QuillToolbarCustomButtonOptions(
+          iconButtonFactor: iconButtonFactor,
+          iconSize: iconSize,
+          afterButtonPressed: afterButtonPressed,
+          controller: controller,
+          iconTheme: iconTheme,
+          tooltip: tooltip,
+          icon: options.icon,
+        ),
+        QuillToolbarCustomButtonExtraOptions(
+          context: context,
+          controller: controller,
+          onPressed: () => _onPressed(context),
+        ),
+      );
+    }
+
+    final theme = Theme.of(context);
     return QuillToolbarIconButton(
-      highlightElevation: 0,
-      hoverElevation: 0,
       size: iconSize * iconButtonFactor,
-      icon: Icon(icon, size: iconSize, color: iconColor),
+      icon: options.icon,
       tooltip: tooltip,
       borderRadius: iconTheme?.borderRadius ?? 2,
-      onPressed: onPressed,
+      onPressed: () => _onPressed(context),
       afterPressed: afterButtonPressed,
       fillColor: iconTheme?.iconUnselectedFillColor ?? theme.canvasColor,
     );

--- a/lib/src/widgets/toolbar/toolbar.dart
+++ b/lib/src/widgets/toolbar/toolbar.dart
@@ -411,20 +411,21 @@ class QuillToolbar extends StatelessWidget {
                     space: configurations.sectionDividerSpace,
                   ),
                 for (final customButton in configurations.customButtons)
-                  if (customButton.child != null) ...[
-                    InkWell(
-                      onTap: customButton.onTap,
-                      child: customButton.child,
-                    ),
-                  ] else ...[
-                    QuillToolbarCustomButton(
-                      options:
-                          toolbarConfigurations.buttonOptions.customButtons,
-                      controller: toolbarConfigurations
-                              .buttonOptions.customButtons.controller ??
-                          globalController,
-                    ),
-                  ],
+                  customButton,
+                // if (customButton.child != null) ...[
+                //   InkWell(
+                //     onTap: customButton.onTap,
+                //     child: customButton.child,
+                //   ),
+                // ] else ...[
+                //   QuillToolbarCustomButton(
+                //     options:
+                //         toolbarConfigurations.buttonOptions.customButtons,
+                //     controller: toolbarConfigurations
+                //             .buttonOptions.customButtons.controller ??
+                //         globalController,
+                //   ),
+                // ],
                 spacerWidget,
               ],
             ];

--- a/lib/src/widgets/toolbar/toolbar.dart
+++ b/lib/src/widgets/toolbar/toolbar.dart
@@ -411,7 +411,10 @@ class QuillToolbar extends StatelessWidget {
                     space: configurations.sectionDividerSpace,
                   ),
                 for (final customButton in configurations.customButtons)
-                  customButton,
+                  QuillToolbarCustomButton(
+                    options: customButton,
+                    controller: customButton.controller ?? globalController,
+                  ),
                 // if (customButton.child != null) ...[
                 //   InkWell(
                 //     onTap: customButton.onTap,

--- a/lib/src/widgets/toolbar/toolbar.dart
+++ b/lib/src/widgets/toolbar/toolbar.dart
@@ -59,8 +59,6 @@ class QuillToolbar extends StatelessWidget {
           sectionDividerSpace: configurations.sectionDividerSpace,
           toolbarSize: configurations.toolbarSize,
           childrenBuilder: (context) {
-            final controller = context.requireQuillController;
-
             final toolbarConfigurations =
                 context.requireQuillToolbarConfigurations;
 
@@ -192,7 +190,9 @@ class QuillToolbar extends StatelessWidget {
               ],
               if (configurations.showColorButton) ...[
                 QuillToolbarColorButton(
-                  controller: controller,
+                  controller:
+                      toolbarConfigurations.buttonOptions.color.controller ??
+                          globalController,
                   isBackground: false,
                   options: toolbarConfigurations.buttonOptions.color,
                 ),
@@ -201,14 +201,18 @@ class QuillToolbar extends StatelessWidget {
               if (configurations.showBackgroundColorButton) ...[
                 QuillToolbarColorButton(
                   options: toolbarConfigurations.buttonOptions.backgroundColor,
-                  controller: controller,
+                  controller:
+                      toolbarConfigurations.buttonOptions.color.controller ??
+                          globalController,
                   isBackground: true,
                 ),
                 spacerWidget,
               ],
               if (configurations.showClearFormat) ...[
                 QuillToolbarClearFormatButton(
-                  controller: controller,
+                  controller: toolbarConfigurations
+                          .buttonOptions.clearFormat.controller ??
+                      globalController,
                   options: toolbarConfigurations.buttonOptions.clearFormat,
                 ),
                 spacerWidget,
@@ -216,7 +220,7 @@ class QuillToolbar extends StatelessWidget {
               if (theEmbedButtons != null)
                 for (final builder in theEmbedButtons)
                   builder(
-                      controller,
+                      globalController,
                       globalIconSize,
                       context.requireQuillToolbarBaseButtonOptions.iconTheme,
                       configurations.dialogTheme),
@@ -234,7 +238,9 @@ class QuillToolbar extends StatelessWidget {
                 ),
               if (configurations.showAlignmentButtons) ...[
                 QuillToolbarSelectAlignmentButton(
-                  controller: controller,
+                  controller: toolbarConfigurations
+                          .buttonOptions.selectAlignmentButtons.controller ??
+                      globalController,
                   options: toolbarConfigurations
                       .buttonOptions.selectAlignmentButtons,
                   // tooltips: Map.of(buttonTooltips)
@@ -274,7 +280,9 @@ class QuillToolbar extends StatelessWidget {
                 ),
               if (configurations.showHeaderStyle) ...[
                 QuillToolbarSelectHeaderStyleButtons(
-                  controller: controller,
+                  controller: toolbarConfigurations
+                          .buttonOptions.selectHeaderStyleButtons.controller ??
+                      globalController,
                   options: toolbarConfigurations
                       .buttonOptions.selectHeaderStyleButtons,
                 ),
@@ -379,14 +387,18 @@ class QuillToolbar extends StatelessWidget {
                 ),
               if (configurations.showLink) ...[
                 QuillToolbarLinkStyleButton(
-                  controller: controller,
+                  controller: toolbarConfigurations
+                          .buttonOptions.linkStyle.controller ??
+                      globalController,
                   options: toolbarConfigurations.buttonOptions.linkStyle,
                 ),
                 spacerWidget,
               ],
               if (configurations.showSearchButton) ...[
                 QuillToolbarSearchButton(
-                  controller: controller,
+                  controller:
+                      toolbarConfigurations.buttonOptions.search.controller ??
+                          globalController,
                   options: toolbarConfigurations.buttonOptions.search,
                 ),
                 spacerWidget,
@@ -405,19 +417,12 @@ class QuillToolbar extends StatelessWidget {
                       child: customButton.child,
                     ),
                   ] else ...[
-                    CustomButton(
-                      onPressed: customButton.onTap,
-                      icon: customButton.iconData ??
-                          context.quillToolbarBaseButtonOptions?.iconData,
-                      iconColor: customButton.iconColor,
-                      iconSize: customButton.iconSize ?? globalIconSize,
-                      iconTheme: context
-                          .requireQuillToolbarBaseButtonOptions.iconTheme,
-                      afterButtonPressed: customButton.afterButtonPressed ??
-                          context.quillToolbarBaseButtonOptions
-                              ?.afterButtonPressed,
-                      tooltip: customButton.tooltip ??
-                          context.quillToolbarBaseButtonOptions?.tooltip,
+                    QuillToolbarCustomButton(
+                      options:
+                          toolbarConfigurations.buttonOptions.customButtons,
+                      controller: toolbarConfigurations
+                              .buttonOptions.customButtons.controller ??
+                          globalController,
                     ),
                   ],
                 spacerWidget,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_quill
 description: A rich text editor built for the modern Android, iOS, web and desktop platforms. It is the WYSIWYG editor and a Quill component for Flutter.
-version: 8.3.0
+version: 8.4.0
 homepage: https://1o24bbs.com/c/bulletjournal/108
 repository: https://github.com/singerdmx/flutter-quill
 

--- a/test/bug_fix_test.dart
+++ b/test/bug_fix_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_quill/src/models/config/toolbar/buttons/custom_button.dart';
 import 'package:flutter_quill_test/flutter_quill_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -12,17 +13,24 @@ void main() {
           (tester) async {
         const tooltip = 'custom button';
 
+        final controller = QuillController.basic();
+
         await tester.pumpWidget(
           MaterialApp(
             home: QuillProvider(
               configurations: QuillConfigurations(
-                controller: QuillController.basic(),
+                controller: controller,
               ),
-              child: const QuillToolbar(
+              child: QuillToolbar(
                 configurations: QuillToolbarConfigurations(
                   showRedo: false,
                   customButtons: [
-                    QuillCustomButton(tooltip: tooltip),
+                    QuillToolbarCustomButton(
+                      options: const QuillToolbarCustomButtonOptions(
+                        tooltip: tooltip,
+                      ),
+                      controller: controller,
+                    ),
                   ],
                 ),
               ),

--- a/test/bug_fix_test.dart
+++ b/test/bug_fix_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
-import 'package:flutter_quill/src/models/config/toolbar/buttons/custom_button.dart';
 import 'package:flutter_quill_test/flutter_quill_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -21,16 +20,13 @@ void main() {
               configurations: QuillConfigurations(
                 controller: controller,
               ),
-              child: QuillToolbar(
+              child: const QuillToolbar(
                 configurations: QuillToolbarConfigurations(
                   showRedo: false,
                   customButtons: [
-                    QuillToolbarCustomButton(
-                      options: const QuillToolbarCustomButtonOptions(
-                        tooltip: tooltip,
-                      ),
-                      controller: controller,
-                    ),
+                    QuillToolbarCustomButtonOptions(
+                      tooltip: tooltip,
+                    )
                   ],
                 ),
               ),


### PR DESCRIPTION
This pull request is update the options of the custom buttons to be matched with the rest of the buttons

It replaces the `iconData` with `icon` widget for more customizations, [#1095](https://github.com/singerdmx/flutter-quill/issues/1095)

- **Breaking change**: Update the `QuillCustomButton` to have `QuillCustomButtonOptions`. We moved everything that is in the `QuillCustomButton` to `QuillCustomButtonOptions` but replaced the `iconData` with `icon` widget for more customizations
- **Breaking change**: the `customButtons` in the `QuillToolbarConfigurations` is now of type `List<QuillToolbarCustomButtonOptions>`
- Bug fixes with the new `8.0.0` update
- Update `README.md`
