### PR TITLE
fix: block styles on inline text

### DIFF
--- a/lib/src/models/documents/nodes/line.dart
+++ b/lib/src/models/documents/nodes/line.dart
@@ -317,6 +317,14 @@ base class Line extends Container<Leaf?> {
   void _insertSafe(int index, Object data, Style? style) {
     assert(index == 0 || (index > 0 && index < length));
 
+    var inlineStyles = style;
+    if (style != null) {
+      final nonInlineStyles =
+          style.attributes.values.where((v) => !v.isInline).toSet();
+      final styleToApply = style.removeAll(nonInlineStyles);
+      inlineStyles = styleToApply;
+    }
+
     if (data is String) {
       assert(!data.contains('\n'));
       if (data.isEmpty) {
@@ -327,10 +335,10 @@ base class Line extends Container<Leaf?> {
     if (isEmpty) {
       final child = Leaf(data);
       add(child);
-      child.format(style);
+      child.format(inlineStyles);
     } else {
       final result = queryChild(index, true);
-      result.node!.insert(result.offset, data, style);
+      result.node!.insert(result.offset, data, inlineStyles);
     }
   }
 


### PR DESCRIPTION
## Description

If block styles are applied to inline text during rendering, an exception will occur because it is not allowed. This patch solves the fitting so that only the inline styles allowed are applied, and the rest of the block styles are applied only to the block.

Instead of removing of the assert as suggested in the #1118 we could find the root of this problem.

## Related Issues

- Fix #1118 

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before-push.sh` and it all passed successfully

## Additional info

Tested with our internal App with many quill delta messages.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.