### PR TITLE
Restore use of alternative `QuillToolbarLinkStyleButton2` widget

### DIFF
--- a/lib/src/models/config/toolbar/toolbar_configurations.dart
+++ b/lib/src/models/config/toolbar/toolbar_configurations.dart
@@ -15,6 +15,7 @@ import 'buttons/font_size.dart';
 import 'buttons/history.dart';
 import 'buttons/indent.dart';
 import 'buttons/link_style.dart';
+import 'buttons/link_style2.dart';
 import 'buttons/search.dart';
 import 'buttons/select_alignment.dart';
 import 'buttons/select_header_style.dart';
@@ -32,6 +33,7 @@ export './buttons/font_size.dart';
 export './buttons/history.dart';
 export './buttons/indent.dart';
 export './buttons/link_style.dart';
+export './buttons/link_style2.dart';
 export './buttons/search.dart';
 export './buttons/select_alignment.dart';
 export './buttons/select_header_style.dart';
@@ -49,6 +51,17 @@ const double kIconButtonFactor = 1.77;
 
 /// The horizontal margin between the contents of each toolbar section.
 const double kToolbarSectionSpacing = 4;
+
+enum LinkStyleType {
+  /// Defines the original [QuillToolbarLinkStyleButton].
+  original,
+
+  /// Defines the alternative [QuillToolbarLinkStyleButton2].
+  alternative;
+
+  bool get isOriginal => this == LinkStyleType.original;
+  bool get isAlternative => this == LinkStyleType.alternative;
+}
 
 /// The configurations for the toolbar widget of flutter quill
 @immutable
@@ -91,6 +104,7 @@ class QuillToolbarConfigurations extends QuillSharedToolbarProperties {
     this.showSearchButton = true,
     this.showSubscript = true,
     this.showSuperscript = true,
+    this.linkStyleType = LinkStyleType.original,
     super.customButtons = const [],
 
     /// The decoration to use for the toolbar.
@@ -191,6 +205,9 @@ class QuillToolbarConfigurations extends QuillSharedToolbarProperties {
   ///shown when embedding an image, for example
   final QuillDialogTheme? dialogTheme;
 
+  /// Defines which dialog is used for applying link attribute.
+  final LinkStyleType linkStyleType;
+
   @override
   List<Object?> get props => [
         buttonOptions,
@@ -239,6 +256,7 @@ class QuillToolbarButtonOptions extends Equatable {
     this.selectHeaderStyleButtons =
         const QuillToolbarSelectHeaderStyleButtonsOptions(),
     this.linkStyle = const QuillToolbarLinkStyleButtonOptions(),
+    this.linkStyle2 = const QuillToolbarLinkStyleButton2Options(),
     this.customButtons = const QuillToolbarCustomButtonOptions(),
   });
 
@@ -284,6 +302,7 @@ class QuillToolbarButtonOptions extends Equatable {
   final QuillToolbarSelectHeaderStyleButtonsOptions selectHeaderStyleButtons;
 
   final QuillToolbarLinkStyleButtonOptions linkStyle;
+  final QuillToolbarLinkStyleButton2Options linkStyle2;
 
   final QuillToolbarCustomButtonOptions customButtons;
 

--- a/lib/src/widgets/toolbar/buttons/link_style2.dart
+++ b/lib/src/widgets/toolbar/buttons/link_style2.dart
@@ -6,11 +6,13 @@ import '../../../../extensions.dart'
     show UtilityWidgets, AutoFormatMultipleLinksRule;
 import '../../../extensions/quill_provider.dart';
 import '../../../l10n/extensions/localizations.dart';
+import '../../../l10n/widgets/localizations.dart';
 import '../../../models/documents/attribute.dart';
 import '../../../models/themes/quill_dialog_theme.dart';
 import '../../../models/themes/quill_icon_theme.dart';
 import '../../controller.dart';
 import '../../link.dart';
+import '../../utils/provider.dart';
 import '../base_toolbar.dart';
 
 /// Alternative version of [QuillToolbarLinkStyleButton]. This widget has more
@@ -171,18 +173,23 @@ class _QuillToolbarLinkStyleButton2State
     final textLink = await showDialog<QuillTextLink>(
       context: context,
       barrierColor: dialogBarrierColor,
-      builder: (_) => LinkStyleDialog(
-        dialogTheme: options.dialogTheme,
-        text: initialTextLink.text,
-        link: initialTextLink.link,
-        constraints: options.constraints,
-        addLinkLabel: options.addLinkLabel,
-        editLinkLabel: options.editLinkLabel,
-        linkColor: options.linkColor,
-        childrenSpacing: options.childrenSpacing,
-        autovalidateMode: options.autovalidateMode,
-        validationMessage: options.validationMessage,
-        buttonSize: options.buttonSize,
+      builder: (_) => QuillProvider.value(
+        value: context.requireQuillProvider,
+        child: FlutterQuillLocalizationsWidget(
+          child: LinkStyleDialog(
+            dialogTheme: options.dialogTheme,
+            text: initialTextLink.text,
+            link: initialTextLink.link,
+            constraints: options.constraints,
+            addLinkLabel: options.addLinkLabel,
+            editLinkLabel: options.editLinkLabel,
+            linkColor: options.linkColor,
+            childrenSpacing: options.childrenSpacing,
+            autovalidateMode: options.autovalidateMode,
+            validationMessage: options.validationMessage,
+            buttonSize: options.buttonSize,
+          ),
+        ),
       ),
     );
 

--- a/lib/src/widgets/toolbar/buttons/link_style2.dart
+++ b/lib/src/widgets/toolbar/buttons/link_style2.dart
@@ -6,7 +6,6 @@ import '../../../../extensions.dart'
     show UtilityWidgets, AutoFormatMultipleLinksRule;
 import '../../../extensions/quill_provider.dart';
 import '../../../l10n/extensions/localizations.dart';
-import '../../../models/config/toolbar/buttons/link_style2.dart';
 import '../../../models/documents/attribute.dart';
 import '../../../models/themes/quill_dialog_theme.dart';
 import '../../../models/themes/quill_icon_theme.dart';

--- a/lib/src/widgets/toolbar/toolbar.dart
+++ b/lib/src/widgets/toolbar/toolbar.dart
@@ -393,12 +393,19 @@ class QuillToolbar extends StatelessWidget implements PreferredSizeWidget {
                   space: configurations.sectionDividerSpace,
                 ),
               if (configurations.showLink) ...[
-                QuillToolbarLinkStyleButton(
-                  controller: toolbarConfigurations
-                          .buttonOptions.linkStyle.controller ??
-                      globalController,
-                  options: toolbarConfigurations.buttonOptions.linkStyle,
-                ),
+                toolbarConfigurations.linkStyleType.isOriginal
+                    ? QuillToolbarLinkStyleButton(
+                        controller: toolbarConfigurations
+                                .buttonOptions.linkStyle.controller ??
+                            globalController,
+                        options: toolbarConfigurations.buttonOptions.linkStyle,
+                      )
+                    : QuillToolbarLinkStyleButton2(
+                        controller: toolbarConfigurations
+                                .buttonOptions.linkStyle2.controller ??
+                            globalController,
+                        options: toolbarConfigurations.buttonOptions.linkStyle2,
+                      ),
                 spacerWidget,
               ],
               if (configurations.showSearchButton) ...[


### PR DESCRIPTION
## Description

There is a `QuillToolbarLinkStyleButton2` widget which suggest an alternative dialog for `link` attribute. It was added in one of the previous versions but was not restored in latest version. Not this widget is available again.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.