### PR TITLE
Add padding control in for toolbar buttons

### DIFF
--- a/lib/src/models/themes/quill_icon_theme.dart
+++ b/lib/src/models/themes/quill_icon_theme.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/widgets.dart' show Color;
-
+import 'package:flutter/material.dart';
 import 'package:meta/meta.dart' show immutable;
 
 @immutable
@@ -11,7 +11,8 @@ class QuillIconTheme {
       this.iconUnselectedFillColor,
       this.disabledIconColor,
       this.disabledIconFillColor,
-      this.borderRadius});
+      this.borderRadius,
+      this.padding});
 
   ///The color to use for selected icons in the toolbar
   final Color? iconSelectedColor;
@@ -33,4 +34,7 @@ class QuillIconTheme {
 
   ///The borderRadius for icons
   final double? borderRadius;
+
+  ///The padding for icons
+  final EdgeInsets? padding;  
 }

--- a/lib/src/models/themes/quill_icon_theme.dart
+++ b/lib/src/models/themes/quill_icon_theme.dart
@@ -1,6 +1,4 @@
-import 'package:flutter/widgets.dart' show Color;
 import 'package:flutter/material.dart';
-import 'package:meta/meta.dart' show immutable;
 
 @immutable
 class QuillIconTheme {

--- a/lib/src/widgets/toolbar/buttons/quill_icon_button.dart
+++ b/lib/src/widgets/toolbar/buttons/quill_icon_button.dart
@@ -24,12 +24,12 @@ class QuillToolbarIconButton extends StatelessWidget {
     if (isFilled) {
       return IconButton.filled(
         padding: padding,
-        constraints: BoxConstraints(),
+        constraints: const BoxConstraints(),
         onPressed: onPressed, icon: icon);
     }
     return IconButton(
       padding: padding,
-      constraints: BoxConstraints(),
+      constraints: const BoxConstraints(),
       onPressed: () {
         onPressed?.call();
         afterPressed?.call();

--- a/lib/src/widgets/toolbar/buttons/quill_icon_button.dart
+++ b/lib/src/widgets/toolbar/buttons/quill_icon_button.dart
@@ -7,6 +7,7 @@ class QuillToolbarIconButton extends StatelessWidget {
     required this.isFilled,
     this.afterPressed,
     this.tooltip,
+    this.padding,
     super.key,
   });
 
@@ -15,14 +16,20 @@ class QuillToolbarIconButton extends StatelessWidget {
   final Widget icon;
 
   final String? tooltip;
+  final EdgeInsets? padding;
   final bool isFilled;
 
   @override
   Widget build(BuildContext context) {
     if (isFilled) {
-      return IconButton.filled(onPressed: onPressed, icon: icon);
+      return IconButton.filled(
+        padding: (padding != null) ? padding : null,
+        constraints: BoxConstraints(),
+        onPressed: onPressed, icon: icon);
     }
     return IconButton(
+      padding: (padding != null) ? padding : null,
+      constraints: BoxConstraints(),
       onPressed: () {
         onPressed?.call();
         afterPressed?.call();

--- a/lib/src/widgets/toolbar/buttons/quill_icon_button.dart
+++ b/lib/src/widgets/toolbar/buttons/quill_icon_button.dart
@@ -23,12 +23,12 @@ class QuillToolbarIconButton extends StatelessWidget {
   Widget build(BuildContext context) {
     if (isFilled) {
       return IconButton.filled(
-        padding: (padding != null) ? padding : null,
+        padding: padding,
         constraints: BoxConstraints(),
         onPressed: onPressed, icon: icon);
     }
     return IconButton(
-      padding: (padding != null) ? padding : null,
+      padding: padding,
       constraints: BoxConstraints(),
       onPressed: () {
         onPressed?.call();

--- a/lib/src/widgets/toolbar/buttons/toggle_style_button.dart
+++ b/lib/src/widgets/toolbar/buttons/toggle_style_button.dart
@@ -254,5 +254,6 @@ Widget defaultToggleStyleButtonBuilder(
     isFilled: isEnabled ? isToggled == true : false,
     onPressed: onPressed,
     afterPressed: afterPressed,
+    padding: iconTheme?.padding
   );
 }


### PR DESCRIPTION
So many controls for the appearance of toolbar buttons has been lost.  Adding them back in one by one.  In this case padding control is added via the QuillIconTheme class