### PR TITLE
feat: Add conditional rendering for toolbar header style options

### DIFF
--- a/lib/src/widgets/toolbar/simple_toolbar.dart
+++ b/lib/src/widgets/toolbar/simple_toolbar.dart
@@ -195,12 +195,20 @@ class QuillSimpleToolbar extends StatelessWidget
             color: configurations.sectionDividerColor,
             space: configurations.sectionDividerSpace,
           ),
-        if (configurations.showHeaderStyle)
-          QuillToolbarSelectHeaderStyleDropdownButton(
-            controller: globalController,
-            options: toolbarConfigurations
-                .buttonOptions.selectHeaderStyleDropdownButton,
-          ),
+        if (configurations.showHeaderStyle) ...[
+          if (configurations.headerStyleType.isOriginal)
+            QuillToolbarSelectHeaderStyleButtons(
+              controller: globalController,
+              options:
+                  toolbarConfigurations.buttonOptions.selectHeaderStyleButtons,
+            )
+          else
+            QuillToolbarSelectHeaderStyleDropdownButton(
+              controller: globalController,
+              options: toolbarConfigurations
+                  .buttonOptions.selectHeaderStyleDropdownButton,
+            ),
+        ],
         if (configurations.showDividers &&
             configurations.showHeaderStyle &&
             isButtonGroupShown[2] &&


### PR DESCRIPTION
## Description

The toolbar header style now has two possible displays. If the `headerStyleType` configuration is set to `isOriginal`, the toolbar will exhibit `QuillToolbarSelectHeaderStyleButtons`. Otherwise, it will show a dropdown menu `QuillToolbarSelectHeaderStyleDropdownButton`. This adds flexibility to the UI of the toolbar.

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [ ] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.