### PR TITLE
fix: Update 'attributes' list type to enable nulls in header style dropdow

### DIFF
--- a/lib/src/models/config/toolbar/buttons/select_header_style_dropdown_button_configurations.dart
+++ b/lib/src/models/config/toolbar/buttons/select_header_style_dropdown_button_configurations.dart
@@ -49,7 +49,7 @@ class QuillToolbarSelectHeaderStyleDropdownButtonOptions
   ///   Attribute.header,
   /// ]
   /// ```
-  final List<Attribute<int>>? attributes;
+  final List<Attribute<int?>>? attributes;
 
   QuillToolbarSelectHeaderStyleDropdownButtonOptions copyWith({
     ValueChanged<String>? onSelected,


### PR DESCRIPTION
## Description

In `select_header_style_dropdown_button_configurations.dart`, the `attributes` list type has been modified. Now it accepts `Attribute<int?>` instead of `Attribute<int>`. This change allows for custom dropdown attributes with a nullable level.

Before this change, the following custom configuration was not possible:

```dart
 selectHeaderStyleDropdownButton:
                  const QuillToolbarSelectHeaderStyleDropdownButtonOptions(
                attributes: [
                  Attribute.h1,
                  Attribute.h2,
                  Attribute.h3,
                  Attribute.header,
                ],
              ),
```

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.