### PR TITLE
Restore old functionaliy for some Quill toolbar classes

### DIFF
--- a/lib/src/models/config/toolbar/buttons/font_size_configurations.dart
+++ b/lib/src/models/config/toolbar/buttons/font_size_configurations.dart
@@ -13,6 +13,7 @@ import 'package:flutter/widgets.dart'
         TextStyle;
 
 import '../../../documents/attribute.dart';
+import '../../../themes/quill_icon_theme.dart';
 import '../../quill_configurations.dart';
 
 class QuillToolbarFontSizeButtonExtraOptions
@@ -38,6 +39,7 @@ class QuillToolbarFontSizeButtonOptions extends QuillToolbarBaseButtonOptions<
     this.rawItemsMap,
     this.onSelected,
     this.attribute = Attribute.size,
+    super.iconTheme,
     super.afterButtonPressed,
     super.tooltip,
     this.padding,
@@ -92,9 +94,11 @@ class QuillToolbarFontSizeButtonOptions extends QuillToolbarBaseButtonOptions<
     VoidCallback? afterButtonPressed,
     String? tooltip,
     OutlinedBorder? shape,
+    QuillIconTheme? iconTheme,
   }) {
     return QuillToolbarFontSizeButtonOptions(
       iconSize: iconSize ?? this.iconSize,
+      iconTheme: iconTheme ?? this.iconTheme,
       iconButtonFactor: iconButtonFactor ?? this.iconButtonFactor,
       rawItemsMap: rawItemsMap ?? this.rawItemsMap,
       onSelected: onSelected ?? this.onSelected,

--- a/lib/src/models/config/toolbar/buttons/select_header_style_dropdown_button_configurations.dart
+++ b/lib/src/models/config/toolbar/buttons/select_header_style_dropdown_button_configurations.dart
@@ -1,5 +1,4 @@
-import 'package:flutter/widgets.dart'
-    show IconData, TextStyle, ValueChanged, VoidCallback;
+import 'package:flutter/material.dart';
 
 import '../../../../widgets/toolbar/base_toolbar.dart';
 import '../../../documents/attribute.dart';
@@ -21,46 +20,67 @@ class QuillToolbarSelectHeaderStyleDropdownButtonOptions
         QuillToolbarSelectHeaderStyleDropdownButtonOptions,
         QuillToolbarSelectHeaderStyleDropdownButtonExtraOptions> {
   const QuillToolbarSelectHeaderStyleDropdownButtonOptions({
+    super.iconData,
     super.afterButtonPressed,
-    super.childBuilder,
-    super.iconTheme,
     super.tooltip,
+    super.iconTheme,
+    super.childBuilder,
     this.iconSize,
     this.iconButtonFactor,
-    this.textStyle,
-    super.iconData,
+    this.fillColor,
+    this.hoverElevation = 1,
+    this.highlightElevation = 1,
+    this.onSelected,
     this.attributes,
+    this.padding,
+    this.style,
+    this.width,
+    this.labelOverflow = TextOverflow.visible,
+    this.itemHeight,
+    this.itemPadding,
+    this.defaultItemColor,
+    this.renderItemTextStyle = false,
   });
 
-  /// By default we will the toolbar axis from [QuillSimpleToolbarConfigurations]
   final double? iconSize;
   final double? iconButtonFactor;
-  final TextStyle? textStyle;
-
-  /// Header attributes, defaults to:
-  /// ```dart
-  /// [
-  ///   Attribute.h1,
-  ///   Attribute.h2,
-  ///   Attribute.h3,
-  ///   Attribute.h4,
-  ///   Attribute.h5,
-  ///   Attribute.h6,
-  ///   Attribute.header,
-  /// ]
-  /// ```
-  final List<Attribute<int>>? attributes;
+  final Color? fillColor;
+  final double hoverElevation;
+  final double highlightElevation;
+  final ValueChanged<String>? onSelected;
+  final List<Attribute>? attributes;
+  final EdgeInsetsGeometry? padding;
+  final TextStyle? style;
+  final double? width;
+  final TextOverflow labelOverflow;
+  final double? itemHeight;
+  final EdgeInsets? itemPadding;
+  final Color? defaultItemColor;
+  final bool renderItemTextStyle;
 
   QuillToolbarSelectHeaderStyleDropdownButtonOptions copyWith({
+    Color? fillColor,
+    double? hoverElevation,
+    double? highlightElevation,
+    List<PopupMenuEntry<String>>? items,
     ValueChanged<String>? onSelected,
-    List<Attribute<int>>? attributes,
+    List<Attribute>? attributes,
+    EdgeInsetsGeometry? padding,
     TextStyle? style,
+    double? width,
+    TextOverflow? labelOverflow,
+    bool? renderFontFamilies,
+    bool? overrideTooltipByFontFamily,
+    double? itemHeight,
+    EdgeInsets? itemPadding,
+    Color? defaultItemColor,
     double? iconSize,
     double? iconButtonFactor,
     IconData? iconData,
     VoidCallback? afterButtonPressed,
     String? tooltip,
     QuillIconTheme? iconTheme,
+    bool? renderItemTextStyle,
   }) {
     return QuillToolbarSelectHeaderStyleDropdownButtonOptions(
       attributes: attributes ?? this.attributes,
@@ -68,8 +88,20 @@ class QuillToolbarSelectHeaderStyleDropdownButtonOptions
       afterButtonPressed: afterButtonPressed ?? this.afterButtonPressed,
       tooltip: tooltip ?? this.tooltip,
       iconTheme: iconTheme ?? this.iconTheme,
+      onSelected: onSelected ?? this.onSelected,
+      padding: padding ?? this.padding,
+      style: style ?? this.style,
+      width: width ?? this.width,
+      labelOverflow: labelOverflow ?? this.labelOverflow,
+      itemHeight: itemHeight ?? this.itemHeight,
+      itemPadding: itemPadding ?? this.itemPadding,
+      defaultItemColor: defaultItemColor ?? this.defaultItemColor,
       iconSize: iconSize ?? this.iconSize,
       iconButtonFactor: iconButtonFactor ?? this.iconButtonFactor,
+      fillColor: fillColor ?? this.fillColor,
+      hoverElevation: hoverElevation ?? this.hoverElevation,
+      highlightElevation: highlightElevation ?? this.highlightElevation,
+      renderItemTextStyle: renderItemTextStyle ?? this.renderItemTextStyle,
     );
   }
 }

--- a/lib/src/widgets/toolbar/base_toolbar.dart
+++ b/lib/src/widgets/toolbar/base_toolbar.dart
@@ -9,6 +9,7 @@ import 'simple_toolbar.dart';
 
 export '../../models/config/toolbar/base_button_configurations.dart';
 export '../../models/config/toolbar/simple_toolbar_configurations.dart';
+export 'buttons/alignment/select_alignment_button.dart';
 export 'buttons/alignment/select_alignment_button_original.dart';
 export 'buttons/clear_format_button.dart';
 export 'buttons/color/color_button.dart';

--- a/lib/src/widgets/toolbar/base_toolbar.dart
+++ b/lib/src/widgets/toolbar/base_toolbar.dart
@@ -9,6 +9,7 @@ import 'simple_toolbar.dart';
 
 export '../../models/config/toolbar/base_button_configurations.dart';
 export '../../models/config/toolbar/simple_toolbar_configurations.dart';
+export 'buttons/alignment/select_alignment_button_original.dart';
 export 'buttons/clear_format_button.dart';
 export 'buttons/color/color_button.dart';
 export 'buttons/custom_button_button.dart';

--- a/lib/src/widgets/toolbar/base_toolbar.dart
+++ b/lib/src/widgets/toolbar/base_toolbar.dart
@@ -11,6 +11,7 @@ export '../../models/config/toolbar/base_button_configurations.dart';
 export '../../models/config/toolbar/simple_toolbar_configurations.dart';
 export 'buttons/alignment/select_alignment_button.dart';
 export 'buttons/alignment/select_alignment_button_original.dart';
+export 'buttons/alignment/select_alignment_buttons.dart';
 export 'buttons/clear_format_button.dart';
 export 'buttons/color/color_button.dart';
 export 'buttons/custom_button_button.dart';

--- a/lib/src/widgets/toolbar/buttons/alignment/select_alignment_button_original.dart
+++ b/lib/src/widgets/toolbar/buttons/alignment/select_alignment_button_original.dart
@@ -1,0 +1,274 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../../../../../extensions.dart';
+import '../../../../../flutter_quill.dart';
+import '../../../../../translations.dart';
+
+class QuillToolbarSelectTextAlignmentButton extends StatefulWidget {
+  const QuillToolbarSelectTextAlignmentButton({
+    required this.controller,
+    this.options = const QuillToolbarSelectAlignmentButtonOptions(),
+    this.showLeftAlignment = true,
+    this.showCenterAlignment = true,
+    this.showRightAlignment = true,
+    this.showJustifyAlignment = true,
+    this.padding,
+    super.key,
+  });
+
+  final QuillController controller;
+  final QuillToolbarSelectAlignmentButtonOptions options;
+
+  final bool showLeftAlignment;
+  final bool showCenterAlignment;
+  final bool showRightAlignment;
+  final bool showJustifyAlignment;
+  final EdgeInsetsGeometry? padding;
+
+  @override
+  QuillToolbarSelectTextAlignmentButtonState createState() =>
+      QuillToolbarSelectTextAlignmentButtonState();
+}
+
+class QuillToolbarSelectTextAlignmentButtonState
+    extends State<QuillToolbarSelectTextAlignmentButton> {
+  Attribute? _value;
+
+  Style get _selectionStyle => controller.getSelectionStyle();
+
+  @override
+  void initState() {
+    super.initState();
+    setState(() {
+      _value = _selectionStyle.attributes[Attribute.align.key] ??
+          Attribute.leftAlignment;
+    });
+    controller.addListener(_didChangeEditingValue);
+  }
+
+  QuillToolbarSelectAlignmentButtonOptions get options {
+    return widget.options;
+  }
+
+  QuillController get controller {
+    return widget.controller;
+  }
+
+  double get _iconSize {
+    final baseFontSize = baseButtonExtraOptions.globalIconSize;
+    final iconSize = options.iconSize;
+    return iconSize ?? baseFontSize;
+  }
+
+  double get _iconButtonFactor {
+    final baseIconFactor = baseButtonExtraOptions.globalIconButtonFactor;
+    final iconButtonFactor = options.iconButtonFactor;
+    return iconButtonFactor ?? baseIconFactor;
+  }
+
+  VoidCallback? get _afterButtonPressed {
+    return options.afterButtonPressed ??
+        baseButtonExtraOptions.afterButtonPressed;
+  }
+
+  QuillIconTheme? get _iconTheme {
+    return options.iconTheme ?? baseButtonExtraOptions.iconTheme;
+  }
+
+  QuillToolbarBaseButtonOptions get baseButtonExtraOptions {
+    return context.quillToolbarBaseButtonOptions!;
+  }
+
+  QuillSelectAlignmentValues<IconData> get _iconsData {
+    final iconsData = options.iconsData;
+    if (iconsData != null) {
+      return iconsData;
+    }
+    final baseIconData = baseButtonExtraOptions.iconData;
+    if (baseIconData != null) {
+      return QuillSelectAlignmentValues(
+        leftAlignment: baseIconData,
+        centerAlignment: baseIconData,
+        rightAlignment: baseIconData,
+        justifyAlignment: baseIconData,
+      );
+    }
+    return const QuillSelectAlignmentValues(
+      leftAlignment: Icons.format_align_left,
+      centerAlignment: Icons.format_align_center,
+      rightAlignment: Icons.format_align_right,
+      justifyAlignment: Icons.format_align_justify,
+    );
+  }
+
+  QuillSelectAlignmentValues<String> get _tooltips {
+    final tooltips = options.tooltips;
+    if (tooltips != null) {
+      return tooltips;
+    }
+    final baseToolTip = baseButtonExtraOptions.tooltip;
+    if (baseToolTip != null) {
+      return QuillSelectAlignmentValues(
+        leftAlignment: baseToolTip,
+        centerAlignment: baseToolTip,
+        rightAlignment: baseToolTip,
+        justifyAlignment: baseToolTip,
+      );
+    }
+    return QuillSelectAlignmentValues(
+      leftAlignment: context.loc.alignLeft,
+      centerAlignment: context.loc.alignCenter,
+      rightAlignment: context.loc.alignRight,
+      justifyAlignment: context.loc.justifyWinWidth,
+    );
+  }
+
+  void _didChangeEditingValue() {
+    setState(() {
+      _value = _selectionStyle.attributes[Attribute.align.key] ??
+          Attribute.leftAlignment;
+    });
+  }
+
+  @override
+  void didUpdateWidget(
+      covariant QuillToolbarSelectTextAlignmentButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != controller) {
+      oldWidget.controller.removeListener(_didChangeEditingValue);
+      controller.addListener(_didChangeEditingValue);
+      _value = _selectionStyle.attributes[Attribute.align.key] ??
+          Attribute.leftAlignment;
+    }
+  }
+
+  @override
+  void dispose() {
+    controller.removeListener(_didChangeEditingValue);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final valueToText = <Attribute, String>{
+      if (widget.showLeftAlignment)
+        Attribute.leftAlignment: Attribute.leftAlignment.value!,
+      if (widget.showCenterAlignment)
+        Attribute.centerAlignment: Attribute.centerAlignment.value!,
+      if (widget.showRightAlignment)
+        Attribute.rightAlignment: Attribute.rightAlignment.value!,
+      if (widget.showJustifyAlignment)
+        Attribute.justifyAlignment: Attribute.justifyAlignment.value!,
+    };
+
+    final valueAttribute = <Attribute>[
+      if (widget.showLeftAlignment) Attribute.leftAlignment,
+      if (widget.showCenterAlignment) Attribute.centerAlignment,
+      if (widget.showRightAlignment) Attribute.rightAlignment,
+      if (widget.showJustifyAlignment) Attribute.justifyAlignment
+    ];
+    final valueString = <String>[
+      if (widget.showLeftAlignment) Attribute.leftAlignment.value!,
+      if (widget.showCenterAlignment) Attribute.centerAlignment.value!,
+      if (widget.showRightAlignment) Attribute.rightAlignment.value!,
+      if (widget.showJustifyAlignment) Attribute.justifyAlignment.value!,
+    ];
+    final buttonCount = ((widget.showLeftAlignment) ? 1 : 0) +
+        ((widget.showCenterAlignment) ? 1 : 0) +
+        ((widget.showRightAlignment) ? 1 : 0) +
+        ((widget.showJustifyAlignment) ? 1 : 0);
+
+    final childBuilder =
+        options.childBuilder ?? baseButtonExtraOptions.childBuilder;
+
+    void sharedOnPressed(int index) {
+      valueAttribute[index] == Attribute.leftAlignment
+          ? controller.formatSelection(
+              Attribute.clone(Attribute.align, null),
+            )
+          : controller.formatSelection(valueAttribute[index]);
+      _afterButtonPressed?.call();
+    }
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: List.generate(buttonCount, (index) {
+        if (childBuilder != null) {
+          return childBuilder(
+            QuillToolbarSelectAlignmentButtonOptions(
+              afterButtonPressed: _afterButtonPressed,
+              iconSize: _iconSize,
+              iconButtonFactor: _iconButtonFactor,
+              iconTheme: _iconTheme,
+              tooltips: _tooltips,
+              iconsData: _iconsData,
+            ),
+            QuillToolbarSelectAlignmentButtonExtraOptions(
+              context: context,
+              controller: controller,
+              onPressed: () => sharedOnPressed(index),
+            ),
+          );
+        }
+        final theme = Theme.of(context);
+        return Padding(
+          padding: widget.padding ??
+              const EdgeInsets.symmetric(horizontal: !kIsWeb ? 1.0 : 5.0),
+          child: ConstrainedBox(
+            constraints: BoxConstraints.tightFor(
+              width: _iconSize * _iconButtonFactor,
+              height: _iconSize * _iconButtonFactor,
+            ),
+            child: UtilityWidgets.maybeTooltip(
+              message: valueString[index] == Attribute.leftAlignment.value
+                  ? _tooltips.leftAlignment
+                  : valueString[index] == Attribute.centerAlignment.value
+                      ? _tooltips.centerAlignment
+                      : valueString[index] == Attribute.rightAlignment.value
+                          ? _tooltips.rightAlignment
+                          : _tooltips.justifyAlignment,
+              child: theme.useMaterial3
+                  ? QuillToolbarToggleStyleButton(
+                      controller: controller,
+                      attribute: valueAttribute[index],
+                    )
+                  : RawMaterialButton(
+                      hoverElevation: 0,
+                      highlightElevation: 0,
+                      elevation: 0,
+                      visualDensity: VisualDensity.compact,
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(
+                              _iconTheme?.borderRadius ?? 2)),
+                      fillColor: valueToText[_value] == valueString[index]
+                          ? (_iconTheme?.iconSelectedFillColor ??
+                              theme.primaryColor)
+                          : (_iconTheme?.iconUnselectedFillColor ??
+                              theme.canvasColor),
+                      onPressed: () => sharedOnPressed(index),
+                      child: Icon(
+                        valueString[index] == Attribute.leftAlignment.value
+                            ? _iconsData.leftAlignment
+                            : valueString[index] ==
+                                    Attribute.centerAlignment.value
+                                ? _iconsData.centerAlignment
+                                : valueString[index] ==
+                                        Attribute.rightAlignment.value
+                                    ? _iconsData.rightAlignment
+                                    : _iconsData.justifyAlignment,
+                        size: _iconSize,
+                        color: valueToText[_value] == valueString[index]
+                            ? (_iconTheme?.iconSelectedColor ??
+                                theme.primaryIconTheme.color)
+                            : (_iconTheme?.iconUnselectedColor ??
+                                theme.iconTheme.color),
+                      ),
+                    ),
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/lib/src/widgets/toolbar/buttons/alignment/select_alignment_button_original.dart
+++ b/lib/src/widgets/toolbar/buttons/alignment/select_alignment_button_original.dart
@@ -77,7 +77,8 @@ class QuillToolbarSelectTextAlignmentButtonState
   }
 
   QuillToolbarBaseButtonOptions get baseButtonExtraOptions {
-    return context.quillToolbarBaseButtonOptions!;
+    return context.quillToolbarBaseButtonOptions ??
+        const QuillToolbarBaseButtonOptions();
   }
 
   QuillSelectAlignmentValues<IconData> get _iconsData {

--- a/lib/src/widgets/toolbar/buttons/clear_format_button.dart
+++ b/lib/src/widgets/toolbar/buttons/clear_format_button.dart
@@ -107,11 +107,14 @@ class QuillToolbarClearFormatButton extends StatelessWidget {
     final theme = Theme.of(context);
 
     final iconColor = iconTheme?.iconUnselectedColor ?? theme.iconTheme.color;
+    final fillColor = iconTheme?.iconUnselectedFillColor ?? theme.canvasColor;
 
     return QuillToolbarIconButton(
       tooltip: tooltip,
-      icon: Icon(iconData, size: iconSize * iconButtonFactor, color: iconColor),
+      size: iconSize * iconButtonFactor,
+      icon: Icon(iconData, size: iconSize, color: iconColor),
       isFilled: false,
+      iconFilledStyle: IconButton.styleFrom(backgroundColor: fillColor),
       onPressed: _sharedOnPressed,
       afterPressed: afterButtonPressed,
     );

--- a/lib/src/widgets/toolbar/buttons/color/color_button.dart
+++ b/lib/src/widgets/toolbar/buttons/color/color_button.dart
@@ -194,14 +194,18 @@ class QuillToolbarColorButtonState extends State<QuillToolbarColorButton> {
       );
     }
 
-    return IconButton(
+    return QuillToolbarIconButton(
       tooltip: tooltip,
-      iconSize: iconSize * iconButtonFactor,
-      icon: Icon(
-        iconData,
-        color: widget.isBackground ? iconColorBackground : iconColor,
-      ),
+      size: iconSize * iconButtonFactor,
+      icon: Icon(iconData,
+          size: iconSize,
+          color: widget.isBackground ? iconColorBackground : iconColor),
+      isFilled: false,
+      iconFilledStyle: IconButton.styleFrom(
+          backgroundColor:
+              widget.isBackground ? fillColorBackground : fillColor),
       onPressed: _showColorPicker,
+      afterPressed: afterButtonPressed,
     );
   }
 

--- a/lib/src/widgets/toolbar/buttons/color/color_button.dart
+++ b/lib/src/widgets/toolbar/buttons/color/color_button.dart
@@ -200,7 +200,7 @@ class QuillToolbarColorButtonState extends State<QuillToolbarColorButton> {
       icon: Icon(iconData,
           size: iconSize,
           color: widget.isBackground ? iconColorBackground : iconColor),
-      isFilled: false,
+      isFilled: _isToggledColor || _isToggledBackground,
       iconFilledStyle: IconButton.styleFrom(
           backgroundColor:
               widget.isBackground ? fillColorBackground : fillColor),

--- a/lib/src/widgets/toolbar/buttons/font_family_button.dart
+++ b/lib/src/widgets/toolbar/buttons/font_family_button.dart
@@ -165,6 +165,9 @@ class QuillToolbarFontFamilyButtonState
         ),
       );
     }
+
+    final borderRadius = BorderRadius.circular(iconTheme?.borderRadius ?? 2);
+
     return ConstrainedBox(
       constraints: BoxConstraints.tightFor(
         height: iconSize * 1.81,
@@ -181,31 +184,26 @@ class QuillToolbarFontFamilyButtonState
           }
           return Tooltip(message: effectiveTooltip, child: child);
         },
-        child: Builder(
-          builder: (context) {
-            final isMaterial3 = Theme.of(context).useMaterial3;
-            if (!isMaterial3) {
-              return RawMaterialButton(
+        child: Theme.of(context).useMaterial3
+            ? IconButton(
+                visualDensity: VisualDensity.compact,
+                style: IconButton.styleFrom(
+                  shape: iconTheme?.borderRadius != null
+                      ? RoundedRectangleBorder(borderRadius: borderRadius)
+                      : null,
+                ),
+                onPressed: _onPressed,
+                icon: _buildContent(context),
+              )
+            : RawMaterialButton(
+                visualDensity: VisualDensity.compact,
+                shape: RoundedRectangleBorder(borderRadius: borderRadius),
+                elevation: 0,
+                hoverElevation: 0,
+                highlightElevation: 0,
                 onPressed: _onPressed,
                 child: _buildContent(context),
-              );
-            }
-            return IconButton(
-              // tooltip: , // TODO: Use this here
-              visualDensity: VisualDensity.compact,
-              style: IconButton.styleFrom(
-                shape: iconTheme?.borderRadius != null
-                    ? RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(
-                            iconTheme?.borderRadius ?? -1),
-                      )
-                    : null,
               ),
-              onPressed: _onPressed,
-              icon: _buildContent(context),
-            );
-          },
-        ),
       ),
     );
   }

--- a/lib/src/widgets/toolbar/buttons/font_size_button.dart
+++ b/lib/src/widgets/toolbar/buttons/font_size_button.dart
@@ -136,36 +136,35 @@ class QuillToolbarFontSizeButtonState
         ),
       );
     }
+
+    final borderRadius = BorderRadius.circular(iconTheme?.borderRadius ?? 2);
+
     return ConstrainedBox(
       constraints: BoxConstraints.tightFor(
         height: iconSize * 1.81,
         width: options.width,
       ),
-      child: Builder(
-        builder: (context) {
-          final isMaterial3 = Theme.of(context).useMaterial3;
-          if (!isMaterial3) {
-            return RawMaterialButton(
+      child: Theme.of(context).useMaterial3
+          ? IconButton(
+              tooltip: tooltip,
+              visualDensity: VisualDensity.compact,
+              style: IconButton.styleFrom(
+                shape: iconTheme?.borderRadius != null
+                    ? RoundedRectangleBorder(borderRadius: borderRadius)
+                    : null,
+              ),
+              onPressed: _onPressed,
+              icon: _buildContent(context),
+            )
+          : RawMaterialButton(
+              visualDensity: VisualDensity.compact,
+              shape: RoundedRectangleBorder(borderRadius: borderRadius),
+              elevation: 0,
+              hoverElevation: 0,
+              highlightElevation: 0,
               onPressed: _onPressed,
               child: _buildContent(context),
-            );
-          }
-          return IconButton(
-            tooltip: tooltip,
-            visualDensity: VisualDensity.compact,
-            style: IconButton.styleFrom(
-              shape: iconTheme?.borderRadius != null
-                  ? RoundedRectangleBorder(
-                      borderRadius:
-                          BorderRadius.circular(iconTheme?.borderRadius ?? -1),
-                    )
-                  : null,
             ),
-            onPressed: _onPressed,
-            icon: _buildContent(context),
-          );
-        },
-      ),
     );
   }
 

--- a/lib/src/widgets/toolbar/buttons/font_size_button.dart
+++ b/lib/src/widgets/toolbar/buttons/font_size_button.dart
@@ -156,14 +156,17 @@ class QuillToolbarFontSizeButtonState
               onPressed: _onPressed,
               icon: _buildContent(context),
             )
-          : RawMaterialButton(
-              visualDensity: VisualDensity.compact,
-              shape: RoundedRectangleBorder(borderRadius: borderRadius),
-              elevation: 0,
-              hoverElevation: 0,
-              highlightElevation: 0,
-              onPressed: _onPressed,
-              child: _buildContent(context),
+          : Tooltip(
+              message: tooltip,
+              child: RawMaterialButton(
+                visualDensity: VisualDensity.compact,
+                shape: RoundedRectangleBorder(borderRadius: borderRadius),
+                elevation: 0,
+                hoverElevation: 0,
+                highlightElevation: 0,
+                onPressed: _onPressed,
+                child: _buildContent(context),
+              ),
             ),
     );
   }

--- a/lib/src/widgets/toolbar/buttons/hearder_style/select_header_style_dropdown_button.dart
+++ b/lib/src/widgets/toolbar/buttons/hearder_style/select_header_style_dropdown_button.dart
@@ -127,10 +127,8 @@ class _QuillToolbarSelectHeaderStyleDropdownButtonState
   Widget build(BuildContext context) {
     assert(_attrbuites.every((element) => _valueToText.keys.contains(element)));
 
-    final baseButtonConfigurations = context.quillToolbarBaseButtonOptions ??
-        const QuillToolbarBaseButtonOptions();
     final childBuilder =
-        options.childBuilder ?? baseButtonConfigurations.childBuilder;
+        options.childBuilder ?? baseButtonExtraOptions.childBuilder;
     if (childBuilder != null) {
       return childBuilder(
         options.copyWith(

--- a/lib/src/widgets/toolbar/buttons/hearder_style/select_header_style_dropdown_button.dart
+++ b/lib/src/widgets/toolbar/buttons/hearder_style/select_header_style_dropdown_button.dart
@@ -1,11 +1,8 @@
 import 'package:flutter/material.dart';
 
+import '../../../../../extensions.dart';
+import '../../../../../flutter_quill.dart';
 import '../../../../../translations.dart';
-import '../../../../extensions/quill_configurations_ext.dart';
-import '../../../../models/documents/attribute.dart';
-import '../../../../models/themes/quill_icon_theme.dart';
-import '../../../quill/quill_controller.dart';
-import '../../base_toolbar.dart';
 
 class QuillToolbarSelectHeaderStyleDropdownButton extends StatefulWidget {
   const QuillToolbarSelectHeaderStyleDropdownButton({
@@ -24,18 +21,69 @@ class QuillToolbarSelectHeaderStyleDropdownButton extends StatefulWidget {
 
 class _QuillToolbarSelectHeaderStyleDropdownButtonState
     extends State<QuillToolbarSelectHeaderStyleDropdownButton> {
-  Attribute<dynamic> _selectedItem = Attribute.header;
+  Attribute? _selectedAttribute;
 
-  final _menuController = MenuController();
-  @override
-  void initState() {
-    super.initState();
-    widget.controller.addListener(_didChangeEditingValue);
+  Style get _selectionStyle => controller.getSelectionStyle();
+
+  late final _valueToText = <Attribute, String>{
+    Attribute.h1: context.loc.heading1,
+    Attribute.h2: context.loc.heading2,
+    Attribute.h3: context.loc.heading3,
+    Attribute.h4: context.loc.heading4,
+    Attribute.h5: context.loc.heading5,
+    Attribute.h6: context.loc.heading6,
+    Attribute.header: context.loc.normal,
+  };
+
+  Map<Attribute, TextStyle>? _headerTextStyles;
+
+  QuillToolbarSelectHeaderStyleDropdownButtonOptions get options {
+    return widget.options;
+  }
+
+  QuillController get controller {
+    return widget.controller;
+  }
+
+  double get iconSize {
+    final baseFontSize = baseButtonExtraOptions.globalIconSize;
+    final iconSize = options.iconSize;
+    return iconSize ?? baseFontSize;
+  }
+
+  double get iconButtonFactor {
+    final baseIconFactor = baseButtonExtraOptions.globalIconButtonFactor;
+    final iconButtonFactor = options.iconButtonFactor;
+    return iconButtonFactor ?? baseIconFactor;
+  }
+
+  VoidCallback? get afterButtonPressed {
+    return options.afterButtonPressed ??
+        baseButtonExtraOptions.afterButtonPressed;
+  }
+
+  QuillIconTheme? get iconTheme {
+    return options.iconTheme ?? baseButtonExtraOptions.iconTheme;
+  }
+
+  QuillToolbarBaseButtonOptions get baseButtonExtraOptions {
+    return context.quillToolbarBaseButtonOptions ??
+        const QuillToolbarBaseButtonOptions();
+  }
+
+  String get tooltip {
+    return options.tooltip ??
+        baseButtonExtraOptions.tooltip ??
+        context.loc.headerStyle;
+  }
+
+  List<Attribute> get _attrbuites {
+    return options.attributes ?? _valueToText.keys.toList();
   }
 
   @override
   void dispose() {
-    widget.controller.removeListener(_didChangeEditingValue);
+    controller.removeListener(_didChangeEditingValue);
     super.dispose();
   }
 
@@ -43,170 +91,205 @@ class _QuillToolbarSelectHeaderStyleDropdownButtonState
   void didUpdateWidget(
       covariant QuillToolbarSelectHeaderStyleDropdownButton oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.controller == widget.controller) {
-      return;
+    if (oldWidget.controller != controller) {
+      oldWidget.controller.removeListener(_didChangeEditingValue);
+      controller.addListener(_didChangeEditingValue);
+      _selectedAttribute = _getHeaderValue();
     }
-    widget.controller
-      ..removeListener(_didChangeEditingValue)
-      ..addListener(_didChangeEditingValue);
   }
 
-  void _didChangeEditingValue() {
-    final newSelectedItem = _getHeaderValue();
-    if (newSelectedItem == _selectedItem) {
-      return;
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_headerTextStyles == null) {
+      final defaultStyles = DefaultStyles.getInstance(context);
+      _headerTextStyles = {
+        Attribute.h1: defaultStyles.h1!.style,
+        Attribute.h2: defaultStyles.h2!.style,
+        Attribute.h3: defaultStyles.h3!.style,
+        Attribute.h4: defaultStyles.h4!.style,
+        Attribute.h5: defaultStyles.h5!.style,
+        Attribute.h6: defaultStyles.h6!.style,
+        Attribute.header:
+            widget.options.style ?? defaultStyles.paragraph!.style,
+      };
     }
-    setState(() {
-      _selectedItem = newSelectedItem;
-    });
   }
 
-  Attribute<dynamic> _getHeaderValue() {
-    final attr = widget.controller.toolbarButtonToggler[Attribute.header.key];
-    if (attr != null) {
-      // checkbox tapping causes controller.selection to go to offset 0
-      widget.controller.toolbarButtonToggler.remove(Attribute.header.key);
-      return attr;
-    }
-    return widget.controller
-            .getSelectionStyle()
-            .attributes[Attribute.header.key] ??
-        Attribute.header;
-  }
-
-  String _label(Attribute<dynamic> value) {
-    final label = switch (value) {
-      Attribute.h1 => context.loc.heading1,
-      Attribute.h2 => context.loc.heading2,
-      Attribute.h3 => context.loc.heading3,
-      Attribute.h4 => context.loc.heading4,
-      Attribute.h5 => context.loc.heading5,
-      Attribute.h6 => context.loc.heading6,
-      Attribute.header => context.loc.normal,
-      Attribute<dynamic>() => throw ArgumentError(),
-    };
-    return label;
-  }
-
-  double get iconSize {
-    final baseFontSize = context.quillToolbarBaseButtonOptions?.globalIconSize;
-    final iconSize = widget.options.iconSize;
-    return iconSize ?? baseFontSize ?? kDefaultIconSize;
-  }
-
-  double get iconButtonFactor {
-    final baseIconFactor =
-        context.quillToolbarBaseButtonOptions?.globalIconButtonFactor;
-    final iconButtonFactor = widget.options.iconButtonFactor;
-    return iconButtonFactor ?? baseIconFactor ?? kIconButtonFactor;
-  }
-
-  QuillIconTheme? get iconTheme {
-    return widget.options.iconTheme ??
-        context.quillToolbarBaseButtonOptions?.iconTheme;
-  }
-
-  List<Attribute<int?>> get headerAttributes {
-    return widget.options.attributes ??
-        [
-          Attribute.h1,
-          Attribute.h2,
-          Attribute.h3,
-          Attribute.h4,
-          Attribute.h5,
-          Attribute.h6,
-          Attribute.header,
-        ];
-  }
-
-  QuillToolbarBaseButtonOptions? get baseButtonExtraOptions {
-    return context.quillToolbarBaseButtonOptions;
-  }
-
-  VoidCallback? get afterButtonPressed {
-    return widget.options.afterButtonPressed ??
-        baseButtonExtraOptions?.afterButtonPressed;
-  }
-
-  void _onPressed(Attribute<int?> e) {
-    setState(() => _selectedItem = e);
-    widget.controller.formatSelection(_selectedItem);
+  @override
+  void initState() {
+    super.initState();
+    controller.addListener(_didChangeEditingValue);
+    _selectedAttribute = _getHeaderValue();
   }
 
   @override
   Widget build(BuildContext context) {
-    final baseButtonConfigurations = context.quillToolbarBaseButtonOptions;
+    assert(_attrbuites.every((element) => _valueToText.keys.contains(element)));
+
+    final baseButtonConfigurations = context.quillToolbarBaseButtonOptions!;
     final childBuilder =
-        widget.options.childBuilder ?? baseButtonConfigurations?.childBuilder;
+        options.childBuilder ?? baseButtonConfigurations.childBuilder;
     if (childBuilder != null) {
       return childBuilder(
-        widget.options.copyWith(
+        options.copyWith(
           iconSize: iconSize,
           iconTheme: iconTheme,
+          tooltip: tooltip,
           afterButtonPressed: afterButtonPressed,
         ),
         QuillToolbarSelectHeaderStyleDropdownButtonExtraOptions(
-          currentValue: _selectedItem,
+          currentValue: _selectedAttribute!,
+          controller: controller,
           context: context,
-          controller: widget.controller,
-          onPressed: () {
-            throw UnimplementedError('Not implemented yet.');
-          },
+          onPressed: _onPressed,
         ),
       );
     }
 
-    return MenuAnchor(
-      controller: _menuController,
-      menuChildren: headerAttributes
-          .map(
-            (e) => MenuItemButton(
-              onPressed: () {
-                _onPressed(e);
-              },
-              child: Text(_label(e)),
+    final borderRadius = BorderRadius.circular(iconTheme?.borderRadius ?? 2);
+
+    return ConstrainedBox(
+      constraints: BoxConstraints.tightFor(
+        height: iconSize * 1.81,
+        width: options.width,
+      ),
+      child: Theme.of(context).useMaterial3
+          ? IconButton(
+              tooltip: tooltip,
+              visualDensity: VisualDensity.compact,
+              style: IconButton.styleFrom(
+                shape: iconTheme?.borderRadius != null
+                    ? RoundedRectangleBorder(borderRadius: borderRadius)
+                    : null,
+              ),
+              onPressed: _onPressed,
+              icon: _buildContent(context),
+            )
+          : Tooltip(
+              message: tooltip,
+              child: RawMaterialButton(
+                visualDensity: VisualDensity.compact,
+                shape: RoundedRectangleBorder(borderRadius: borderRadius),
+                fillColor: options.fillColor,
+                elevation: 0,
+                hoverElevation: options.hoverElevation,
+                highlightElevation: options.hoverElevation,
+                onPressed: _onPressed,
+                child: _buildContent(context),
+              ),
             ),
+    );
+  }
+
+  void _didChangeEditingValue() {
+    setState(() {
+      _selectedAttribute = _getHeaderValue();
+    });
+  }
+
+  Attribute<dynamic> _getHeaderValue() {
+    final attr = controller.toolbarButtonToggler[Attribute.header.key];
+    if (attr != null) {
+      // checkbox tapping causes controller.selection to go to offset 0
+      controller.toolbarButtonToggler.remove(Attribute.header.key);
+      return attr;
+    }
+    return _selectionStyle.attributes[Attribute.header.key] ?? Attribute.header;
+  }
+
+  Widget _buildContent(BuildContext context) {
+    final theme = Theme.of(context);
+    final hasFinalWidth = options.width != null;
+    return Padding(
+      padding: options.padding ?? const EdgeInsets.fromLTRB(10, 0, 0, 0),
+      child: Row(
+        mainAxisSize: !hasFinalWidth ? MainAxisSize.min : MainAxisSize.max,
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          UtilityWidgets.maybeWidget(
+            enabled: hasFinalWidth,
+            wrapper: (child) => Expanded(child: child),
+            child: Text(
+              _valueToText[_selectedAttribute]!,
+              overflow: options.labelOverflow,
+              style: options.style ??
+                  TextStyle(
+                    fontSize: iconSize / 1.15,
+                    color:
+                        iconTheme?.iconUnselectedColor ?? theme.iconTheme.color,
+                  ),
+            ),
+          ),
+          const SizedBox(width: 3),
+          Icon(
+            Icons.arrow_drop_down,
+            size: iconSize / 1.15,
+            color: iconTheme?.iconUnselectedColor ?? theme.iconTheme.color,
           )
-          .toList(),
-      child: Builder(
-        builder: (context) {
-          final isMaterial3 = Theme.of(context).useMaterial3;
-          final child = Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                _label(_selectedItem),
-                style: widget.options.textStyle ??
-                    TextStyle(
-                      fontSize: iconSize / 1.15,
-                    ),
-              ),
-              Icon(
-                Icons.arrow_drop_down,
-                size: iconSize * iconButtonFactor,
-              ),
-            ],
-          );
-          if (!isMaterial3) {
-            return RawMaterialButton(
-              onPressed: _onDropdownButtonPressed,
-              child: child,
-            );
-          }
-          return IconButton(
-            onPressed: _onDropdownButtonPressed,
-            icon: child,
-          );
-        },
+        ],
       ),
     );
   }
 
-  void _onDropdownButtonPressed() {
-    if (_menuController.isOpen) {
-      _menuController.close();
+  void _onPressed() {
+    _showMenu();
+    options.afterButtonPressed?.call();
+  }
+
+  Future<void> _showMenu() async {
+    final popupMenuTheme = PopupMenuTheme.of(context);
+    final button = context.findRenderObject() as RenderBox;
+    final overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
+    final position = RelativeRect.fromRect(
+      Rect.fromPoints(
+        button.localToGlobal(Offset.zero, ancestor: overlay),
+        button.localToGlobal(button.size.bottomLeft(Offset.zero),
+            ancestor: overlay),
+      ),
+      Offset.zero & overlay.size,
+    );
+    final newValue = await showMenu<Attribute>(
+      context: context,
+      elevation: 4,
+      items: [
+        for (final header in _valueToText.entries)
+          PopupMenuItem<Attribute>(
+            key: ValueKey(header.value),
+            value: header.key,
+            height: options.itemHeight ?? kMinInteractiveDimension,
+            padding: options.itemPadding,
+            child: Text(
+              header.value,
+              style: TextStyle(
+                fontSize: options.renderItemTextStyle
+                    ? _headerStyle(header.key).fontSize ??
+                        DefaultTextStyle.of(context).style.fontSize ??
+                        14
+                    : null,
+                color: header.key == _selectedAttribute
+                    ? options.defaultItemColor
+                    : null,
+              ),
+            ),
+          ),
+      ],
+      position: position,
+      shape: popupMenuTheme.shape,
+      color: popupMenuTheme.color,
+    );
+    if (newValue == null) {
       return;
     }
-    _menuController.open();
+
+    final attribute0 =
+        _selectedAttribute == newValue ? Attribute.header : newValue;
+    controller.formatSelection(attribute0);
+    afterButtonPressed?.call();
+  }
+
+  TextStyle _headerStyle(Attribute attribute) {
+    assert(_headerTextStyles!.containsKey(attribute));
+    return _headerTextStyles![attribute]!;
   }
 }

--- a/lib/src/widgets/toolbar/buttons/hearder_style/select_header_style_dropdown_button.dart
+++ b/lib/src/widgets/toolbar/buttons/hearder_style/select_header_style_dropdown_button.dart
@@ -127,7 +127,8 @@ class _QuillToolbarSelectHeaderStyleDropdownButtonState
   Widget build(BuildContext context) {
     assert(_attrbuites.every((element) => _valueToText.keys.contains(element)));
 
-    final baseButtonConfigurations = context.quillToolbarBaseButtonOptions!;
+    final baseButtonConfigurations = context.quillToolbarBaseButtonOptions ??
+        const QuillToolbarBaseButtonOptions();
     final childBuilder =
         options.childBuilder ?? baseButtonConfigurations.childBuilder;
     if (childBuilder != null) {

--- a/lib/src/widgets/toolbar/buttons/indent_button.dart
+++ b/lib/src/widgets/toolbar/buttons/indent_button.dart
@@ -107,10 +107,15 @@ class QuillToolbarIndentButtonState extends State<QuillToolbarIndentButton> {
     final theme = Theme.of(context);
 
     final iconColor = iconTheme?.iconUnselectedColor ?? theme.iconTheme.color;
+
+    final iconFillColor =
+        iconTheme?.iconUnselectedFillColor ?? theme.canvasColor;
     return QuillToolbarIconButton(
       tooltip: tooltip,
-      icon: Icon(iconData, size: iconSize * iconButtonFactor, color: iconColor),
+      size: iconSize * iconButtonFactor,
+      icon: Icon(iconData, size: iconSize, color: iconColor),
       isFilled: false,
+      iconFilledStyle: IconButton.styleFrom(backgroundColor: iconFillColor),
       onPressed: _sharedOnPressed,
       afterPressed: afterButtonPressed,
     );

--- a/lib/src/widgets/toolbar/buttons/link_style2_button.dart
+++ b/lib/src/widgets/toolbar/buttons/link_style2_button.dart
@@ -148,14 +148,19 @@ class _QuillToolbarLinkStyleButton2State
     final isToggled = _getLinkAttributeValue() != null;
     return QuillToolbarIconButton(
       tooltip: tooltip,
+      size: iconSize * iconButtonFactor,
       icon: Icon(
         iconData,
-        size: iconSize * iconButtonFactor,
+        size: iconSize,
         color: isToggled
             ? (iconTheme?.iconSelectedColor ?? theme.primaryIconTheme.color)
             : (iconTheme?.iconUnselectedColor ?? theme.iconTheme.color),
       ),
       isFilled: isToggled,
+      iconFilledStyle: IconButton.styleFrom(
+          backgroundColor: isToggled
+              ? (iconTheme?.iconSelectedFillColor ?? theme.primaryColor)
+              : (iconTheme?.iconUnselectedFillColor ?? theme.canvasColor)),
       onPressed: _openLinkDialog,
       afterPressed: afterButtonPressed,
     );

--- a/lib/src/widgets/toolbar/buttons/link_style_button.dart
+++ b/lib/src/widgets/toolbar/buttons/link_style_button.dart
@@ -140,14 +140,19 @@ class QuillToolbarLinkStyleButtonState
     final theme = Theme.of(context);
     return QuillToolbarIconButton(
       tooltip: tooltip,
+      size: iconSize * iconButtonFactor,
       icon: Icon(
         iconData,
-        size: iconSize * iconButtonFactor,
+        size: iconSize,
         color: isToggled
             ? (iconTheme?.iconSelectedColor ?? theme.primaryIconTheme.color)
             : (iconTheme?.iconUnselectedColor ?? theme.iconTheme.color),
       ),
       isFilled: isToggled,
+      iconFilledStyle: IconButton.styleFrom(
+          backgroundColor: isToggled
+              ? (iconTheme?.iconSelectedFillColor ?? theme.primaryColor)
+              : (iconTheme?.iconUnselectedFillColor ?? theme.canvasColor)),
       onPressed: () => _openLinkDialog(context),
       afterPressed: afterButtonPressed,
     );

--- a/lib/src/widgets/toolbar/buttons/quill_icon_button.dart
+++ b/lib/src/widgets/toolbar/buttons/quill_icon_button.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 
+import '../../../../extensions.dart';
+import '../../../../flutter_quill.dart';
+
 class QuillToolbarIconButton extends StatelessWidget {
   const QuillToolbarIconButton({
     required this.onPressed,
@@ -11,6 +14,8 @@ class QuillToolbarIconButton extends StatelessWidget {
     super.key,
     this.iconFilledStyle,
     this.iconStyle,
+    this.size = 40,
+    this.iconTheme,
   });
 
   final VoidCallback? onPressed;
@@ -20,27 +25,56 @@ class QuillToolbarIconButton extends StatelessWidget {
   final String? tooltip;
   final EdgeInsets? padding;
   final bool isFilled;
-
   final ButtonStyle? iconStyle;
   final ButtonStyle? iconFilledStyle;
+  final QuillIconTheme? iconTheme;
+
+  /// Container size.
+  final double size;
+
   @override
   Widget build(BuildContext context) {
-    if (isFilled) {
-      return IconButton.filled(
-        padding: padding,
-        onPressed: onPressed,
-        icon: icon,
-        style: iconStyle,
+    final theme = Theme.of(context);
+    Widget child;
+    if (theme.useMaterial3) {
+      child = isFilled
+          ? IconButton.filled(
+              padding: padding,
+              icon: icon,
+              style: iconFilledStyle,
+              onPressed: _onPressed,
+            )
+          : IconButton(
+              padding: padding,
+              icon: icon,
+              style: iconStyle,
+              onPressed: _onPressed,
+            );
+    } else {
+      child = UtilityWidgets.maybeTooltip(
+        message: tooltip,
+        child: RawMaterialButton(
+          visualDensity: VisualDensity.compact,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(iconTheme?.borderRadius ?? 2),
+          ),
+          fillColor: iconFilledStyle?.backgroundColor?.resolve({}),
+          elevation: 0,
+          hoverElevation: 0,
+          highlightElevation: 0,
+          onPressed: _onPressed,
+          child: icon,
+        ),
       );
     }
-    return IconButton(
-      padding: padding,
-      onPressed: () {
-        onPressed?.call();
-        afterPressed?.call();
-      },
-      icon: icon,
-      style: iconFilledStyle,
+    return ConstrainedBox(
+      constraints: BoxConstraints.tightFor(width: size, height: size),
+      child: child,
     );
+  }
+
+  void _onPressed() {
+    onPressed?.call();
+    afterPressed?.call();
   }
 }

--- a/lib/src/widgets/toolbar/buttons/toggle_style_button.dart
+++ b/lib/src/widgets/toolbar/buttons/toggle_style_button.dart
@@ -252,11 +252,19 @@ Widget defaultToggleStyleButtonBuilder(
                   .primaryIconTheme.color) //You can specify your own icon color
           : (iconTheme?.iconUnselectedColor ?? theme.iconTheme.color)
       : (iconTheme?.disabledIconColor ?? theme.disabledColor);
-  return QuillToolbarIconButton(
-    icon: Icon(icon, size: iconSize * iconButtonFactor, color: iconColor),
-    isFilled: isEnabled ? isToggled == true : false,
-    onPressed: onPressed,
-    afterPressed: afterPressed,
-    padding: iconTheme?.padding,
-  );
+  return theme.useMaterial3
+      ? QuillToolbarIconButton(
+          icon: Icon(icon, size: iconSize * iconButtonFactor, color: iconColor),
+          isFilled: isEnabled ? isToggled == true : false,
+          onPressed: onPressed,
+          afterPressed: afterPressed,
+          padding: iconTheme?.padding,
+        )
+      : QuillToolbarIconButton(
+          size: iconSize * iconButtonFactor,
+          isFilled: isEnabled ? isToggled == true : false,
+          icon: Icon(icon, size: iconSize, color: iconColor),
+          onPressed: onPressed,
+          afterPressed: afterPressed,
+        );
 }


### PR DESCRIPTION
## Description

Today I have again spent time to make my project looks as it must. I do not do anything critical just restore the funcitonality of some toolbar classes as they were. You may consider this PR as a starting point for all other buttons which I didn't change. The only thing is required is change call of `QuillToolbarIconButton` in `build` methods of embed buttons, search button and maybe others. You may see what I did. I also restored old `QuillToolbarSelectAlignmentButton` and save it as `QuillToolbarSelectTextAlignmentButton`. 

I need this modifications to make my project compiled and continue working. You may merge this PR or use it for understanding how to make package backward compatible. It will take less effors.

## Related Issues

- *Fix #1628*

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.