### PR TITLE
feat!: Add the image source to to onImageClicked

### DIFF
--- a/flutter_quill_extensions/lib/embeds/image/editor/image_embed.dart
+++ b/flutter_quill_extensions/lib/embeds/image/editor/image_embed.dart
@@ -56,8 +56,9 @@ class QuillEditorImageEmbedBuilder extends EmbedBuilder {
         QuillSharedExtensionsConfigurations.get(context: context)
             .imageSaverService;
     return GestureDetector(
-      onTap: configurations.onImageClicked ??
-          () => showDialog(
+      onTap: configurations.onImageClicked != null
+          ? () => configurations.onImageClicked!(imageSource)
+          : () => showDialog(
                 context: context,
                 builder: (_) => FlutterQuillLocalizationsWidget(
                   child: ImageOptionsMenu(

--- a/flutter_quill_extensions/lib/models/config/editor/image/image.dart
+++ b/flutter_quill_extensions/lib/models/config/editor/image/image.dart
@@ -1,6 +1,5 @@
 import 'dart:io' show File;
 
-import 'package:flutter/foundation.dart' show VoidCallback;
 import 'package:flutter_quill/extensions.dart';
 import 'package:meta/meta.dart' show immutable;
 
@@ -103,8 +102,9 @@ class QuillEditorImageEmbedConfigurations {
 
   /// What should happen when the image is pressed?
   ///
-  /// By default will show `ImageOptionsMenu` dialog
-  final VoidCallback? onImageClicked;
+  /// By default will show `ImageOptionsMenu` dialog. If you want to handle what happens
+  /// to the image when it's clicked, you can pass a callback to this property.
+  final void Function(String imageSource)? onImageClicked;
 
   static ImageEmbedBuilderOnRemovedCallback get defaultOnImageRemovedCallback {
     return (imageUrl) async {


### PR DESCRIPTION
allow users to know which image has been clicked

## Description

Add the image source to to `onImageClicked`. current implementation of `onImageClicked` does not tell what is the image source is.

## Related Issues

- Fix #1654

## Additional notes
BREAKING CHANGES!

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.