### PR TITLE
fix selection.affinity always downstream after updateEditingValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 9.2.3
+* Allow to use any version of intl
+
 ## 9.2.2
 * Fix bug [#1627](https://github.com/singerdmx/flutter-quill/issues/1627)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 9.2.4
+* Use fixed version of intl
+
 ## 9.2.3
-* Allow to use any version of intl
+* remove unncessary column in Flutter quill video embed block
 
 ## 9.2.2
 * Fix bug [#1627](https://github.com/singerdmx/flutter-quill/issues/1627)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 9.2.5
+* Bumb version of `super_clipboard`
+
 ## 9.2.4
 * Use fixed version of intl
 

--- a/flutter_quill_extensions/CHANGELOG.md
+++ b/flutter_quill_extensions/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 9.2.3
+* Allow to use any version of intl
+
 ## 9.2.2
 * Fix bug [#1627](https://github.com/singerdmx/flutter-quill/issues/1627)
 

--- a/flutter_quill_extensions/CHANGELOG.md
+++ b/flutter_quill_extensions/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 9.2.4
+* Use fixed version of intl
+
 ## 9.2.3
-* Allow to use any version of intl
+* remove unncessary column in Flutter quill video embed block
 
 ## 9.2.2
 * Fix bug [#1627](https://github.com/singerdmx/flutter-quill/issues/1627)

--- a/flutter_quill_extensions/CHANGELOG.md
+++ b/flutter_quill_extensions/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 9.2.5
+* Bumb version of `super_clipboard`
+
 ## 9.2.4
 * Use fixed version of intl
 

--- a/flutter_quill_extensions/lib/embeds/video/editor/video_embed.dart
+++ b/flutter_quill_extensions/lib/embeds/video/editor/video_embed.dart
@@ -36,7 +36,6 @@ class QuillEditorVideoEmbedBuilder extends EmbedBuilder {
     if (isYouTubeUrl(videoUrl)) {
       return YoutubeVideoApp(
         videoUrl: videoUrl,
-        context: context,
         readOnly: readOnly,
       );
     }

--- a/flutter_quill_extensions/lib/embeds/widgets/youtube_video_app.dart
+++ b/flutter_quill_extensions/lib/embeds/widgets/youtube_video_app.dart
@@ -60,23 +60,14 @@ class YoutubeVideoAppState extends State<YoutubeVideoApp> {
       );
     }
 
-    return SizedBox(
-      height: 300,
-      child: YoutubePlayerBuilder(
-        player: YoutubePlayer(
-          controller: youtubeController,
-          showVideoProgressIndicator: true,
-        ),
-        builder: (context, player) {
-          return Column(
-            children: [
-              // some widgets
-              player,
-              //some other widgets
-            ],
-          );
-        },
+    return YoutubePlayerBuilder(
+      player: YoutubePlayer(
+        controller: youtubeController,
+        showVideoProgressIndicator: true,
       ),
+      builder: (context, player) {
+        return player;
+      },
     );
   }
 

--- a/flutter_quill_extensions/lib/embeds/widgets/youtube_video_app.dart
+++ b/flutter_quill_extensions/lib/embeds/widgets/youtube_video_app.dart
@@ -5,14 +5,13 @@ import 'package:url_launcher/url_launcher.dart' show launchUrl;
 import 'package:youtube_player_flutter/youtube_player_flutter.dart';
 
 class YoutubeVideoApp extends StatefulWidget {
-  const YoutubeVideoApp(
-      {required this.videoUrl,
-      required this.context,
-      required this.readOnly,
-      super.key});
+  const YoutubeVideoApp({
+    required this.videoUrl,
+    required this.readOnly,
+    super.key,
+  });
 
   final String videoUrl;
-  final BuildContext context;
   final bool readOnly;
 
   @override

--- a/flutter_quill_extensions/pubspec.yaml
+++ b/flutter_quill_extensions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_quill_extensions
 description: Embed extensions for flutter_quill including image, video, formula and etc.
-version: 9.2.2
+version: 9.2.3
 homepage: https://github.com/singerdmx/flutter-quill/tree/master/flutter_quill_extensions/
 repository: https://github.com/singerdmx/flutter-quill/tree/master/flutter_quill_extensions/
 issue_tracker: https://github.com/singerdmx/flutter-quill/issues/

--- a/flutter_quill_extensions/pubspec.yaml
+++ b/flutter_quill_extensions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_quill_extensions
 description: Embed extensions for flutter_quill including image, video, formula and etc.
-version: 9.2.3
+version: 9.2.4
 homepage: https://github.com/singerdmx/flutter-quill/tree/master/flutter_quill_extensions/
 repository: https://github.com/singerdmx/flutter-quill/tree/master/flutter_quill_extensions/
 issue_tracker: https://github.com/singerdmx/flutter-quill/issues/

--- a/flutter_quill_extensions/pubspec.yaml
+++ b/flutter_quill_extensions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_quill_extensions
 description: Embed extensions for flutter_quill including image, video, formula and etc.
-version: 9.2.4
+version: 9.2.5
 homepage: https://github.com/singerdmx/flutter-quill/tree/master/flutter_quill_extensions/
 repository: https://github.com/singerdmx/flutter-quill/tree/master/flutter_quill_extensions/
 issue_tracker: https://github.com/singerdmx/flutter-quill/issues/
@@ -42,7 +42,7 @@ dependencies:
   video_player: ^2.8.1
   youtube_player_flutter: ^8.1.2
   url_launcher: ^6.2.1
-  super_clipboard: ^0.8.2+1
+  super_clipboard: ^0.8.3
   gal: ^2.2.0
   gal_linux: ^0.0.1
   image_picker: ^1.0.4

--- a/flutter_quill_extensions/pubspec.yaml
+++ b/flutter_quill_extensions/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
 
   # Plugins
   video_player: ^2.8.1
-  youtube_player_flutter: ^9.0.0-beta.0
+  youtube_player_flutter: ^8.1.2
   url_launcher: ^6.2.1
   super_clipboard: ^0.8.2+1
   gal: ^2.2.0

--- a/flutter_quill_test/CHANGELOG.md
+++ b/flutter_quill_test/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 9.2.3
+* Allow to use any version of intl
+
 ## 9.2.2
 * Fix bug [#1627](https://github.com/singerdmx/flutter-quill/issues/1627)
 

--- a/flutter_quill_test/CHANGELOG.md
+++ b/flutter_quill_test/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 9.2.4
+* Use fixed version of intl
+
 ## 9.2.3
-* Allow to use any version of intl
+* remove unncessary column in Flutter quill video embed block
 
 ## 9.2.2
 * Fix bug [#1627](https://github.com/singerdmx/flutter-quill/issues/1627)

--- a/flutter_quill_test/CHANGELOG.md
+++ b/flutter_quill_test/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 9.2.5
+* Bumb version of `super_clipboard`
+
 ## 9.2.4
 * Use fixed version of intl
 

--- a/flutter_quill_test/pubspec.yaml
+++ b/flutter_quill_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_quill_test
 description: Test utilities for flutter_quill which includes methods to simplify interacting with the editor in test cases.
-version: 9.2.2
+version: 9.2.3
 homepage: https://github.com/singerdmx/flutter-quill/tree/master/flutter_quill_test/
 repository: https://github.com/singerdmx/flutter-quill/tree/master/flutter_quill_test/
 issue_tracker: https://github.com/singerdmx/flutter-quill/issues/

--- a/flutter_quill_test/pubspec.yaml
+++ b/flutter_quill_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_quill_test
 description: Test utilities for flutter_quill which includes methods to simplify interacting with the editor in test cases.
-version: 9.2.3
+version: 9.2.4
 homepage: https://github.com/singerdmx/flutter-quill/tree/master/flutter_quill_test/
 repository: https://github.com/singerdmx/flutter-quill/tree/master/flutter_quill_test/
 issue_tracker: https://github.com/singerdmx/flutter-quill/issues/

--- a/flutter_quill_test/pubspec.yaml
+++ b/flutter_quill_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_quill_test
 description: Test utilities for flutter_quill which includes methods to simplify interacting with the editor in test cases.
-version: 9.2.4
+version: 9.2.5
 homepage: https://github.com/singerdmx/flutter-quill/tree/master/flutter_quill_test/
 repository: https://github.com/singerdmx/flutter-quill/tree/master/flutter_quill_test/
 issue_tracker: https://github.com/singerdmx/flutter-quill/issues/

--- a/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -203,7 +203,8 @@ mixin RawEditorStateTextInputClientMixin on EditorState
         diff.start,
         diff.deleted.length,
         diff.inserted,
-        value.selection.copyWith(affinity: widget.configurations.controller.selection.affinity),
+        value.selection.copyWith(
+            affinity: widget.configurations.controller.selection.affinity),
       );
 
       // if (widget.configurations.controller.selectedFontFamily != null) {

--- a/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -203,7 +203,7 @@ mixin RawEditorStateTextInputClientMixin on EditorState
         diff.start,
         diff.deleted.length,
         diff.inserted,
-        value.selection,
+        value.selection.copyWith(affinity: widget.configurations.controller.selection.affinity),
       );
 
       // if (widget.configurations.controller.selectedFontFamily != null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_quill
 description: A rich text editor built for the modern Android, iOS, web and desktop platforms. It is the WYSIWYG editor and a Quill component for Flutter.
-version: 9.2.4
+version: 9.2.5
 homepage: https://1o24bbs.com/c/bulletjournal/108/
 repository: https://github.com/singerdmx/flutter-quill/
 issue_tracker: https://github.com/singerdmx/flutter-quill/issues/
@@ -62,7 +62,7 @@ dependencies:
   url_launcher: ^6.1.14
   flutter_keyboard_visibility: ^6.0.0
   device_info_plus: ^9.1.0
-  super_clipboard: ^0.8.2+1
+  super_clipboard: ^0.8.3
 
 dev_dependencies:
   flutter_lints: ^3.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_quill
 description: A rich text editor built for the modern Android, iOS, web and desktop platforms. It is the WYSIWYG editor and a Quill component for Flutter.
-version: 9.2.3
+version: 9.2.4
 homepage: https://1o24bbs.com/c/bulletjournal/108/
 repository: https://github.com/singerdmx/flutter-quill/
 issue_tracker: https://github.com/singerdmx/flutter-quill/issues/
@@ -43,7 +43,7 @@ dependencies:
     sdk: flutter
 
   # Normal packages
-  intl: any
+  intl: ^0.18.1
   dart_quill_delta: ^0.0.1
   collection: ^1.17.0
   quiver: ^3.2.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_quill
 description: A rich text editor built for the modern Android, iOS, web and desktop platforms. It is the WYSIWYG editor and a Quill component for Flutter.
-version: 9.2.2
+version: 9.2.3
 homepage: https://1o24bbs.com/c/bulletjournal/108/
 repository: https://github.com/singerdmx/flutter-quill/
 issue_tracker: https://github.com/singerdmx/flutter-quill/issues/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,9 +41,9 @@ dependencies:
 
   flutter_localizations:
     sdk: flutter
-  intl: ^0.18.1
 
   # Normal packages
+  intl: any
   dart_quill_delta: ^0.0.1
   collection: ^1.17.0
   quiver: ^3.2.1
@@ -70,7 +70,7 @@ dev_dependencies:
     sdk: flutter
   flutter_quill_test: ^9.0.0-dev-6
   test: ^1.24.3
-  intl_translation: ^0.18.2
+  # intl_translation: ^0.19.0
   yaml_edit: ^2.1.1
 
 flutter:

--- a/quill_html_converter/CHANGELOG.md
+++ b/quill_html_converter/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 9.2.3
+* Allow to use any version of intl
+
 ## 9.2.2
 * Fix bug [#1627](https://github.com/singerdmx/flutter-quill/issues/1627)
 

--- a/quill_html_converter/CHANGELOG.md
+++ b/quill_html_converter/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 9.2.4
+* Use fixed version of intl
+
 ## 9.2.3
-* Allow to use any version of intl
+* remove unncessary column in Flutter quill video embed block
 
 ## 9.2.2
 * Fix bug [#1627](https://github.com/singerdmx/flutter-quill/issues/1627)

--- a/quill_html_converter/CHANGELOG.md
+++ b/quill_html_converter/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 9.2.5
+* Bumb version of `super_clipboard`
+
 ## 9.2.4
 * Use fixed version of intl
 

--- a/quill_html_converter/pubspec.yaml
+++ b/quill_html_converter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: quill_html_converter
 description: A extension for flutter_quill package to add support for dealing with conversion to/from html
-version: 9.2.2
+version: 9.2.3
 homepage: https://github.com/singerdmx/flutter-quill/tree/master/quill_html_converter/
 repository: https://github.com/singerdmx/flutter-quill/tree/master/quill_html_converter/
 issue_tracker: https://github.com/singerdmx/flutter-quill/issues/

--- a/quill_html_converter/pubspec.yaml
+++ b/quill_html_converter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: quill_html_converter
 description: A extension for flutter_quill package to add support for dealing with conversion to/from html
-version: 9.2.3
+version: 9.2.4
 homepage: https://github.com/singerdmx/flutter-quill/tree/master/quill_html_converter/
 repository: https://github.com/singerdmx/flutter-quill/tree/master/quill_html_converter/
 issue_tracker: https://github.com/singerdmx/flutter-quill/issues/

--- a/quill_html_converter/pubspec.yaml
+++ b/quill_html_converter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: quill_html_converter
 description: A extension for flutter_quill package to add support for dealing with conversion to/from html
-version: 9.2.4
+version: 9.2.5
 homepage: https://github.com/singerdmx/flutter-quill/tree/master/quill_html_converter/
 repository: https://github.com/singerdmx/flutter-quill/tree/master/quill_html_converter/
 issue_tracker: https://github.com/singerdmx/flutter-quill/issues/

--- a/quill_pdf_converter/CHANGELOG.md
+++ b/quill_pdf_converter/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 9.2.3
+* Allow to use any version of intl
+
 ## 9.2.2
 * Fix bug [#1627](https://github.com/singerdmx/flutter-quill/issues/1627)
 

--- a/quill_pdf_converter/CHANGELOG.md
+++ b/quill_pdf_converter/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 9.2.4
+* Use fixed version of intl
+
 ## 9.2.3
-* Allow to use any version of intl
+* remove unncessary column in Flutter quill video embed block
 
 ## 9.2.2
 * Fix bug [#1627](https://github.com/singerdmx/flutter-quill/issues/1627)

--- a/quill_pdf_converter/CHANGELOG.md
+++ b/quill_pdf_converter/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 9.2.5
+* Bumb version of `super_clipboard`
+
 ## 9.2.4
 * Use fixed version of intl
 

--- a/quill_pdf_converter/pubspec.yaml
+++ b/quill_pdf_converter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: quill_pdf_converter
 description: A extension for flutter_quill package to add support for dealing with conversion to pdf
-version: 9.2.3
+version: 9.2.4
 homepage: https://github.com/singerdmx/flutter-quill/tree/master/quill_pdf_converter/
 repository: https://github.com/singerdmx/flutter-quill/tree/master/quill_pdf_converter/
 issue_tracker: https://github.com/singerdmx/flutter-quill/issues/

--- a/quill_pdf_converter/pubspec.yaml
+++ b/quill_pdf_converter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: quill_pdf_converter
 description: A extension for flutter_quill package to add support for dealing with conversion to pdf
-version: 9.2.2
+version: 9.2.3
 homepage: https://github.com/singerdmx/flutter-quill/tree/master/quill_pdf_converter/
 repository: https://github.com/singerdmx/flutter-quill/tree/master/quill_pdf_converter/
 issue_tracker: https://github.com/singerdmx/flutter-quill/issues/

--- a/quill_pdf_converter/pubspec.yaml
+++ b/quill_pdf_converter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: quill_pdf_converter
 description: A extension for flutter_quill package to add support for dealing with conversion to pdf
-version: 9.2.4
+version: 9.2.5
 homepage: https://github.com/singerdmx/flutter-quill/tree/master/quill_pdf_converter/
 repository: https://github.com/singerdmx/flutter-quill/tree/master/quill_pdf_converter/
 issue_tracker: https://github.com/singerdmx/flutter-quill/issues/

--- a/scripts/regenerate_versions.dart
+++ b/scripts/regenerate_versions.dart
@@ -6,7 +6,6 @@ import 'package:yaml_edit/yaml_edit.dart';
 
 // You must run this script in the root folder of the repo and not inside the scripts
 
-// ignore: unused_import
 import '../version.dart';
 
 final packages = [

--- a/version.dart
+++ b/version.dart
@@ -1,1 +1,1 @@
-const version = '9.2.3';
+const version = '9.2.4';

--- a/version.dart
+++ b/version.dart
@@ -1,1 +1,1 @@
-const version = '9.2.4';
+const version = '9.2.5';

--- a/version.dart
+++ b/version.dart
@@ -1,1 +1,1 @@
-const version = '9.2.2';
+const version = '9.2.3';


### PR DESCRIPTION
## Description
After editing text, the affinity of selection changes to  downstream. When editing text in front of  image, the cursor position is unintended.

https://github.com/singerdmx/flutter-quill/assets/36870873/889af161-5f53-4b0e-bad3-d3a2f89248c0




