### PR TITLE
feat: Export Container node as QuillContainer

### DIFF
--- a/lib/flutter_quill.dart
+++ b/lib/flutter_quill.dart
@@ -8,6 +8,7 @@ export 'src/models/config/toolbar/toolbar_configurations.dart';
 export 'src/models/documents/attribute.dart';
 export 'src/models/documents/document.dart';
 export 'src/models/documents/nodes/block.dart';
+export 'src/models/documents/nodes/container.dart';
 export 'src/models/documents/nodes/embeddable.dart';
 export 'src/models/documents/nodes/leaf.dart';
 export 'src/models/documents/nodes/line.dart';

--- a/lib/flutter_quill.dart
+++ b/lib/flutter_quill.dart
@@ -1,5 +1,7 @@
 library flutter_quill;
 
+import 'src/models/documents/nodes/container.dart';
+
 export '/src/widgets/raw_editor/quill_single_child_scroll_view.dart';
 export 'src/extensions/quill_configurations_ext.dart';
 export 'src/models/config/quill_configurations.dart';
@@ -8,7 +10,6 @@ export 'src/models/config/toolbar/toolbar_configurations.dart';
 export 'src/models/documents/attribute.dart';
 export 'src/models/documents/document.dart';
 export 'src/models/documents/nodes/block.dart';
-export 'src/models/documents/nodes/container.dart';
 export 'src/models/documents/nodes/embeddable.dart';
 export 'src/models/documents/nodes/leaf.dart';
 export 'src/models/documents/nodes/line.dart';
@@ -38,3 +39,5 @@ export 'src/widgets/toolbar/buttons/alignment/select_alignment_button.dart';
 export 'src/widgets/toolbar/buttons/hearder_style/select_header_style_dropdown_button.dart';
 export 'src/widgets/toolbar/simple_toolbar.dart';
 export 'src/widgets/utils/provider.dart';
+
+typedef QuillContainer = Container;


### PR DESCRIPTION
## Description

Knowing about the `Container` (exported via `QuillContainer` alias) type is needed to perform a generalized lookup for a specific node in user code. Right now it requires handling `Root`, `Line` and `Block` separately.

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [ ] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.