### PR TITLE
fix bug #1696 - Allow insert/replace styled text from clipboard

### DIFF
--- a/lib/src/models/documents/document.dart
+++ b/lib/src/models/documents/document.dart
@@ -60,7 +60,7 @@ class Document {
   }
 
   final StreamController<DocChange> documentChangeObserver =
-      StreamController.broadcast();
+  StreamController.broadcast();
 
   final History history = History();
 
@@ -114,23 +114,42 @@ class Document {
   /// Returns an instance of [Delta] actually composed into this document.
   Delta replace(int index, int len, Object? data) {
     assert(index >= 0);
-    assert(data is String || data is Embeddable);
-
-    final dataIsNotEmpty = (data is String) ? data.isNotEmpty : true;
-
-    assert(dataIsNotEmpty || len > 0);
+    assert(data is String || data is Embeddable || data is Delta);
 
     var delta = Delta();
 
-    // We have to insert before applying delete rules
-    // Otherwise delete would be operating on stale document snapshot.
-    if (dataIsNotEmpty) {
-      delta = insert(index, data, replaceLength: len);
-    }
+    if (data is Delta) {
+      // move to insertion point and add the inserted content
+      if (index > 0) {
+        delta.retain(index);
+      }
 
-    if (len > 0) {
-      final deleteDelta = delete(index, len);
-      delta = delta.compose(deleteDelta);
+      // remove any text we are replacing
+      if (len > 0) {
+        delta.delete(len);
+      }
+
+      // add the pasted content
+      for (final op in data.operations) {
+        delta.push(op);
+      }
+
+      compose(delta, ChangeSource.local);
+    } else {
+      final dataIsNotEmpty = (data is String) ? data.isNotEmpty : true;
+
+      assert(dataIsNotEmpty || len > 0);
+
+      // We have to insert before applying delete rules
+      // Otherwise delete would be operating on stale document snapshot.
+      if (dataIsNotEmpty) {
+        delta = insert(index, data, replaceLength: len);
+      }
+
+      if (len > 0) {
+        final deleteDelta = delete(index, len);
+        delta = delta.compose(deleteDelta);
+      }
     }
 
     return delta;
@@ -301,7 +320,7 @@ class Document {
     final originalDelta = toDelta();
     for (final op in delta.toList()) {
       final style =
-          op.attributes != null ? Style.fromJson(op.attributes) : null;
+      op.attributes != null ? Style.fromJson(op.attributes) : null;
 
       if (op.isInsert) {
         // Must normalize data before inserting into the document, makes sure
@@ -420,7 +439,7 @@ class Document {
             'Document can only contain insert operations but ${op.key} found.');
       }
       final style =
-          op.attributes != null ? Style.fromJson(op.attributes) : null;
+      op.attributes != null ? Style.fromJson(op.attributes) : null;
       final data = _normalize(op.data);
       _root.insert(offset, data, style);
       offset += op.length!;
@@ -467,8 +486,8 @@ class Document {
   static Delta fromHtml(String html) {
     final markdown = html2md
         .convert(
-          html,
-        )
+      html,
+    )
         .replaceAll('unsafe:', '');
 
     final mdDocument = md.Document(encodeHtml: false);

--- a/lib/src/models/documents/document.dart
+++ b/lib/src/models/documents/document.dart
@@ -60,7 +60,7 @@ class Document {
   }
 
   final StreamController<DocChange> documentChangeObserver =
-  StreamController.broadcast();
+      StreamController.broadcast();
 
   final History history = History();
 
@@ -320,7 +320,7 @@ class Document {
     final originalDelta = toDelta();
     for (final op in delta.toList()) {
       final style =
-      op.attributes != null ? Style.fromJson(op.attributes) : null;
+          op.attributes != null ? Style.fromJson(op.attributes) : null;
 
       if (op.isInsert) {
         // Must normalize data before inserting into the document, makes sure
@@ -439,7 +439,7 @@ class Document {
             'Document can only contain insert operations but ${op.key} found.');
       }
       final style =
-      op.attributes != null ? Style.fromJson(op.attributes) : null;
+          op.attributes != null ? Style.fromJson(op.attributes) : null;
       final data = _normalize(op.data);
       _root.insert(offset, data, style);
       offset += op.length!;
@@ -486,8 +486,8 @@ class Document {
   static Delta fromHtml(String html) {
     final markdown = html2md
         .convert(
-      html,
-    )
+          html,
+        )
         .replaceAll('unsafe:', '');
 
     final mdDocument = md.Document(encodeHtml: false);

--- a/lib/src/widgets/quill/quill_controller.dart
+++ b/lib/src/widgets/quill/quill_controller.dart
@@ -303,7 +303,9 @@ class QuillController extends ChangeNotifier {
       var shouldRetainDelta = toggledStyle.isNotEmpty &&
           delta.isNotEmpty &&
           delta.length <= 2 &&
-          delta.last.isInsert;
+          delta.last.isInsert &&
+          // pasted text should not use toggledStyle
+          (data is! String || data.length < 2);
       if (shouldRetainDelta &&
           toggledStyle.isNotEmpty &&
           delta.length == 2 &&

--- a/lib/src/widgets/quill/quill_controller.dart
+++ b/lib/src/widgets/quill/quill_controller.dart
@@ -291,7 +291,7 @@ class QuillController extends ChangeNotifier {
     bool ignoreFocus = false,
     bool shouldNotifyListeners = true,
   }) {
-    assert(data is String || data is Embeddable);
+    assert(data is String || data is Embeddable || data is Delta);
 
     if (onReplaceText != null && !onReplaceText!(index, len, data)) {
       return;

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -224,8 +224,7 @@ class QuillRawEditorState extends EditorState
             textEditingValue.selection.start,
             textEditingValue.selection.end - textEditingValue.selection.start,
             deltaFromClipboard,
-            TextSelection.collapsed(
-                offset: textEditingValue.selection.end));
+            TextSelection.collapsed(offset: textEditingValue.selection.end));
 
         bringIntoView(textEditingValue.selection.extent);
 

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -221,22 +221,12 @@ class QuillRawEditorState extends EditorState
         final htmlBody = html_parser.parse(html).body?.outerHtml;
         final deltaFromClipboard = Document.fromHtml(htmlBody ?? html);
 
-        var newDelta = Delta();
-        newDelta = newDelta.compose(deltaFromClipboard);
-        if (!controller.document.isEmpty()) {
-          newDelta = newDelta.compose(controller.document.toDelta());
-        }
-
-        controller
-          ..setContents(
-            newDelta,
-          )
-          ..updateSelection(
+        controller.replaceText(
+            textEditingValue.selection.start,
+            textEditingValue.selection.end - textEditingValue.selection.start,
+            deltaFromClipboard,
             TextSelection.collapsed(
-              offset: controller.document.length,
-            ),
-            ChangeSource.local,
-          );
+                offset: textEditingValue.selection.end));
 
         bringIntoView(textEditingValue.selection.extent);
 

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -22,7 +22,6 @@ import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart'
 import 'package:html/parser.dart' as html_parser;
 import 'package:super_clipboard/super_clipboard.dart';
 
-import '../../../quill_delta.dart';
 import '../../models/documents/attribute.dart';
 import '../../models/documents/document.dart';
 import '../../models/documents/nodes/block.dart';


### PR DESCRIPTION
## Description

When pasting html data, edit the current document and insert / replace at the correct location w/o creating a new document so listeners continue to work.

- *Fix #1696*

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x ] No, this is *not* a breaking change.