### PR TITLE
Feat: disableClipboard option

### DIFF
--- a/lib/src/models/config/editor/editor_configurations.dart
+++ b/lib/src/models/config/editor/editor_configurations.dart
@@ -33,6 +33,7 @@ class QuillEditorConfigurations extends Equatable {
     this.expands = false,
     this.placeholder,
     this.readOnly = false,
+    this.disableClipboard = false,
     this.textSelectionThemeData,
     this.showCursor,
     this.paintCursorAboveText,
@@ -91,6 +92,14 @@ class QuillEditorConfigurations extends Equatable {
   ///
   /// Defaults to `false`. Must not be `null`.
   final bool readOnly;
+
+  /// Disable Clipboard features
+  ///
+  /// when this is set to `true` clipboard can not be used
+  /// this disables the clipboard notification for requesting permissions
+  ///
+  /// Defaults to `false`. Must not be `null`.
+  final bool disableClipboard;
 
   /// Whether this editor should create a scrollable container for its content.
   ///
@@ -342,6 +351,7 @@ class QuillEditorConfigurations extends Equatable {
     QuillController? controller,
     String? placeholder,
     bool? readOnly,
+    bool? disableClipboard,
     bool? scrollable,
     double? scrollBottomInset,
     EdgeInsetsGeometry? padding,
@@ -389,6 +399,7 @@ class QuillEditorConfigurations extends Equatable {
       controller: controller ?? this.controller,
       placeholder: placeholder ?? this.placeholder,
       readOnly: readOnly ?? this.readOnly,
+      disableClipboard: disableClipboard ?? this.disableClipboard,
       scrollable: scrollable ?? this.scrollable,
       scrollBottomInset: scrollBottomInset ?? this.scrollBottomInset,
       padding: padding ?? this.padding,

--- a/lib/src/models/config/raw_editor/raw_editor_configurations.dart
+++ b/lib/src/models/config/raw_editor/raw_editor_configurations.dart
@@ -50,6 +50,7 @@ class QuillRawEditorConfigurations extends Equatable {
     this.scrollable = true,
     this.padding = EdgeInsets.zero,
     this.readOnly = false,
+    this.disableClipboard = false,
     this.placeholder,
     this.onLaunchUrl,
     this.contextMenuBuilder = defaultContextMenuBuilder,
@@ -98,6 +99,14 @@ class QuillRawEditorConfigurations extends Equatable {
   ///
   /// Defaults to false. Must not be null.
   final bool readOnly;
+
+  /// Disable Clipboard features
+  ///
+  /// when this is set to true clipboard can not be used
+  /// this disables the clipboard notification for requesting permissions
+  ///
+  /// Defaults to false. Must not be null.
+  final bool disableClipboard;
 
   final String? placeholder;
 

--- a/lib/src/widgets/editor/editor.dart
+++ b/lib/src/widgets/editor/editor.dart
@@ -235,6 +235,7 @@ class QuillEditorState extends State<QuillEditor>
               scrollBottomInset: configurations.scrollBottomInset,
               padding: configurations.padding,
               readOnly: configurations.readOnly,
+              disableClipboard: configurations.disableClipboard,
               placeholder: configurations.placeholder,
               onLaunchUrl: configurations.onLaunchUrl,
               contextMenuBuilder: showSelectionToolbar

--- a/lib/src/widgets/others/text_selection.dart
+++ b/lib/src/widgets/others/text_selection.dart
@@ -70,8 +70,8 @@ class EditorTextSelectionOverlay {
     required this.debugRequiredFor,
     required this.selectionCtrls,
     required this.selectionDelegate,
-    required this.clipboardStatus,
     required this.contextMenuBuilder,
+    this.clipboardStatus,
     this.onSelectionHandleTapped,
     this.dragStartBehavior = DragStartBehavior.start,
     this.handlesVisible = false,
@@ -82,7 +82,9 @@ class EditorTextSelectionOverlay {
     // our listener being created
     // we won't know the status unless there is forced update
     // i.e. occasionally no paste
-    clipboardStatus.update();
+    if (clipboardStatus != null) {
+      clipboardStatus!.update();
+    }
   }
 
   TextEditingValue value;
@@ -167,7 +169,7 @@ class EditorTextSelectionOverlay {
   ///
   /// Useful because the actual value of the clipboard can only be checked
   /// asynchronously (see [Clipboard.getData]).
-  final ClipboardStatusNotifier clipboardStatus;
+  final ClipboardStatusNotifier? clipboardStatus;
 
   /// A pair of handles. If this is non-null, there are always 2, though the
   /// second is hidden when the selection is collapsed.

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -319,8 +319,8 @@ class QuillRawEditorState extends EditorState
   /// Copied from [EditableTextState].
   List<ContextMenuButtonItem> get contextMenuButtonItems {
     return EditableText.getEditableButtonItems(
-//      clipboardStatus: _clipboardStatus.value,
-      clipboardStatus: null,
+      clipboardStatus:
+          (_clipboardStatus != null) ? _clipboardStatus!.value : null,
       onCopy: copyEnabled
           ? () => copySelection(SelectionChangedCause.toolbar)
           : null,
@@ -1121,8 +1121,9 @@ class QuillRawEditorState extends EditorState
   @override
   void initState() {
     super.initState();
-
-//    _clipboardStatus.addListener(_onChangedClipboardStatus);
+    if (clipboardStatus != null) {
+      _clipboardStatus!.addListener(_onChangedClipboardStatus);
+    }
 
     controller.addListener(_didChangeTextEditingValueListener);
 
@@ -1276,9 +1277,11 @@ class QuillRawEditorState extends EditorState
     controller.removeListener(_didChangeTextEditingValueListener);
     widget.configurations.focusNode.removeListener(_handleFocusChanged);
     _cursorCont.dispose();
-    //_clipboardStatus
-    //  ..removeListener(_onChangedClipboardStatus)
-    //  ..dispose();
+    if (_clipboardStatus != null) {
+      _clipboardStatus!
+        ..removeListener(_onChangedClipboardStatus)
+        ..dispose();
+    }
     super.dispose();
   }
 

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -97,7 +97,7 @@ class QuillRawEditorState extends EditorState
   String get pastePlainText => _pastePlainText;
   String _pastePlainText = '';
 
-  final ClipboardStatusNotifier _clipboardStatus = ClipboardStatusNotifier();
+  ClipboardStatusNotifier? _clipboardStatus;
   final LayerLink _toolbarLayerLink = LayerLink();
   final LayerLink _startHandleLayerLink = LayerLink();
   final LayerLink _endHandleLayerLink = LayerLink();
@@ -319,7 +319,8 @@ class QuillRawEditorState extends EditorState
   /// Copied from [EditableTextState].
   List<ContextMenuButtonItem> get contextMenuButtonItems {
     return EditableText.getEditableButtonItems(
-      clipboardStatus: _clipboardStatus.value,
+//      clipboardStatus: _clipboardStatus.value,
+      clipboardStatus: null,
       onCopy: copyEnabled
           ? () => copySelection(SelectionChangedCause.toolbar)
           : null,
@@ -521,6 +522,10 @@ class QuillRawEditorState extends EditorState
         ),
       ),
     );
+
+    if (!widget.configurations.disableClipboard) {
+      _clipboardStatus = ClipboardStatusNotifier();
+    }
 
     if (widget.configurations.scrollable) {
       /// Since [SingleChildScrollView] does not implement
@@ -1117,7 +1122,7 @@ class QuillRawEditorState extends EditorState
   void initState() {
     super.initState();
 
-    _clipboardStatus.addListener(_onChangedClipboardStatus);
+//    _clipboardStatus.addListener(_onChangedClipboardStatus);
 
     controller.addListener(_didChangeTextEditingValueListener);
 
@@ -1271,9 +1276,9 @@ class QuillRawEditorState extends EditorState
     controller.removeListener(_didChangeTextEditingValueListener);
     widget.configurations.focusNode.removeListener(_handleFocusChanged);
     _cursorCont.dispose();
-    _clipboardStatus
-      ..removeListener(_onChangedClipboardStatus)
-      ..dispose();
+    //_clipboardStatus
+    //  ..removeListener(_onChangedClipboardStatus)
+    //  ..dispose();
     super.dispose();
   }
 
@@ -1371,7 +1376,7 @@ class QuillRawEditorState extends EditorState
         renderObject: renderEditor,
         selectionCtrls: widget.configurations.selectionCtrls,
         selectionDelegate: this,
-        clipboardStatus: _clipboardStatus,
+        //clipboardStatus: _clipboardStatus,
         contextMenuBuilder: widget.configurations.contextMenuBuilder == null
             ? null
             : (context) =>

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -1121,7 +1121,7 @@ class QuillRawEditorState extends EditorState
   @override
   void initState() {
     super.initState();
-    if (clipboardStatus != null) {
+    if (_clipboardStatus != null) {
       _clipboardStatus!.addListener(_onChangedClipboardStatus);
     }
 
@@ -1379,7 +1379,7 @@ class QuillRawEditorState extends EditorState
         renderObject: renderEditor,
         selectionCtrls: widget.configurations.selectionCtrls,
         selectionDelegate: this,
-        //clipboardStatus: _clipboardStatus,
+        clipboardStatus: _clipboardStatus,
         contextMenuBuilder: widget.configurations.contextMenuBuilder == null
             ? null
             : (context) =>


### PR DESCRIPTION
## Description

This PR adds the option to disable super_clipboard functionality. On Web using the clipboard functions starts a popup asking for site permissions. `disableClipboard` disables super_clipboard functionality and removes this popup.

## Related Issues
- *Fix: #1714*

## Features
- added `disableClipboard` to `QuillEditorConfigurations` with default to `false` to maintain default behaviour

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.