### PR TITLE
Fix safari clipboard bug

### DIFF
--- a/lib/src/widgets/others/text_selection.dart
+++ b/lib/src/widgets/others/text_selection.dart
@@ -82,7 +82,12 @@ class EditorTextSelectionOverlay {
     // our listener being created
     // we won't know the status unless there is forced update
     // i.e. occasionally no paste
-    clipboardStatus.update();
+    if (!kIsWeb) {
+      // Web - esp Safari Mac/iOS has security measures in place that restrict
+      // cliboard status checks w/o direct user interaction. So skip this
+      // for web
+      clipboardStatus.update();
+    }
   }
 
   TextEditingValue value;

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -4,7 +4,7 @@ import 'dart:math' as math;
 import 'dart:ui' as ui hide TextStyle;
 
 import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart' show defaultTargetPlatform;
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show RenderAbstractViewport;
 import 'package:flutter/scheduler.dart' show SchedulerBinding;
@@ -97,7 +97,12 @@ class QuillRawEditorState extends EditorState
   String get pastePlainText => _pastePlainText;
   String _pastePlainText = '';
 
-  final ClipboardStatusNotifier _clipboardStatus = ClipboardStatusNotifier();
+  // Web - esp Safari Mac/iOS has security measures in place that restrict
+  // cliboard status checks w/o direct user interaction. Initializing the
+  // ClipboardStatusNotifier with a default value of unknown will cause the
+  // clipboard status to be checked w/o user interaction which fails.
+  final ClipboardStatusNotifier _clipboardStatus = ClipboardStatusNotifier(
+      value: kIsWeb ? ClipboardStatus.notPasteable : ClipboardStatus.unknown);
   final LayerLink _toolbarLayerLink = LayerLink();
   final LayerLink _startHandleLayerLink = LayerLink();
   final LayerLink _endHandleLayerLink = LayerLink();

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -100,9 +100,10 @@ class QuillRawEditorState extends EditorState
   // Web - esp Safari Mac/iOS has security measures in place that restrict
   // cliboard status checks w/o direct user interaction. Initializing the
   // ClipboardStatusNotifier with a default value of unknown will cause the
-  // clipboard status to be checked w/o user interaction which fails.
+  // clipboard status to be checked w/o user interaction which fails. Default
+  // to pasteable for web.
   final ClipboardStatusNotifier _clipboardStatus = ClipboardStatusNotifier(
-      value: kIsWeb ? ClipboardStatus.notPasteable : ClipboardStatus.unknown);
+      value: kIsWeb ? ClipboardStatus.pasteable : ClipboardStatus.unknown);
   final LayerLink _toolbarLayerLink = LayerLink();
   final LayerLink _startHandleLayerLink = LayerLink();
   final LayerLink _endHandleLayerLink = LayerLink();


### PR DESCRIPTION
With Safari 17.2.1 on Desktop and iOS 17 Safari - performing Clipboard status checks causes a "Paste" menu to be displayed and stops user input. The status checks were initialized by ClipboardStatusNotifier when a default value of "unknown" was used in it's constructor as well as each time the editor content changed. This PR gives the web a default value of ClipboardStatus.pasteable and doesn't force update calls when content change on web.

Related Issues
Fix Editor for web app keeps showing "paste" dialog everytime in a read only content page from IOS web browser  #1567

Suggestions
Cut/Copy/Paste with keyboard shortcuts work on web, but right click menu items cut/copy/paste do not work correctly. This PR does not address this existing issue.

Breaking Change
Does your PR require plugin users to manually update their apps to accommodate your change?

[ x] No, this is not a breaking change.