### PR TITLE
fix: selection handles behaviour and unnessesary style assert

### DIFF
--- a/lib/src/models/documents/nodes/leaf.dart
+++ b/lib/src/models/documents/nodes/leaf.dart
@@ -27,13 +27,6 @@ abstract base class Leaf extends Node {
   Object _value;
 
   @override
-  void applyStyle(Style value) {
-    assert(value.isInline || value.isIgnored || value.isEmpty,
-        'Unable to apply Style to leaf: $value');
-    super.applyStyle(value);
-  }
-
-  @override
   Line? get parent => super.parent as Line?;
 
   @override

--- a/lib/src/widgets/others/text_selection.dart
+++ b/lib/src/widgets/others/text_selection.dart
@@ -308,10 +308,13 @@ class EditorTextSelectionOverlay {
           )
         : null;
 
+    update(value.copyWith(
+      selection: currSelection,
+      composing: TextRange.empty,
+    ));
+
     selectionDelegate
-      ..userUpdateTextEditingValue(
-          value.copyWith(selection: currSelection, composing: TextRange.empty),
-          SelectionChangedCause.drag)
+      ..userUpdateTextEditingValue(value, SelectionChangedCause.drag)
       ..bringIntoView(textPosition);
   }
 

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -133,6 +133,7 @@ class QuillRawEditorState extends EditorState
 
     if (cause == SelectionChangedCause.toolbar) {
       bringIntoView(textEditingValue.selection.extent);
+      hideToolbar();
 
       // Collapse the selection and hide the toolbar and handles.
       userUpdateTextEditingValue(


### PR DESCRIPTION
## Description

## Related Issues

- *Fix #1630*
- *Fix #1406*

## Comments
Dubious `applyStyle assert` mentioned in 1406 does not allow you to embed some custom nodes/attributes/styles which is often necessary.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [X] No, this is *not* a breaking change.