### PR TITLE
feat: move cursor after inserting video/image

### DIFF
--- a/flutter_quill_extensions/lib/extensions/controller_ext.dart
+++ b/flutter_quill_extensions/lib/extensions/controller_ext.dart
@@ -24,7 +24,8 @@ extension QuillControllerExt on QuillController {
         length,
         BlockEmbed.image(imageSource),
         null,
-      );
+      )
+      ..moveCursorToPosition(index + 1);
   }
 
   /// Insert video embed block, it requires the [videoUrl]
@@ -39,6 +40,7 @@ extension QuillControllerExt on QuillController {
   }) {
     this
       ..skipRequestKeyboard = true
-      ..replaceText(index, length, BlockEmbed.video(videoUrl), null);
+      ..replaceText(index, length, BlockEmbed.video(videoUrl), null)
+      ..moveCursorToPosition(index + 1);
   }
 }


### PR DESCRIPTION
## Description

After video/image was inserted, move the cursor position


## Related Issues

https://github.com/singerdmx/flutter-quill/issues/1554


## Improvements
<!-- Optional -->

## Features
<!-- Optional -->

## Additional notes
<!-- Optional -->

## Suggestions
<!-- Optional -->

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.