### PR TITLE
Apple pencil

### DIFF
--- a/lib/src/models/config/editor/editor_configurations.dart
+++ b/lib/src/models/config/editor/editor_configurations.dart
@@ -76,6 +76,9 @@ class QuillEditorConfigurations extends Equatable {
     this.builder,
     this.magnifierConfiguration,
     this.textInputAction = TextInputAction.newline,
+    this.enableScribble = false,
+    this.onScribbleActivated,
+    this.scribbleAreaInsets,
   });
 
   final QuillSharedConfigurations sharedConfigurations;
@@ -336,6 +339,15 @@ class QuillEditorConfigurations extends Equatable {
   /// Default to [TextInputAction.newline]
   final TextInputAction textInputAction;
 
+  /// Enable Scribble? Currently Apple Pencil only, defaults to false.
+  final bool enableScribble;
+
+  /// Called when Scribble is activated.
+  final void Function()? onScribbleActivated;
+
+  /// Optional insets for the scribble area.
+  final EdgeInsets? scribbleAreaInsets;
+
   @override
   List<Object?> get props => [
         placeholder,
@@ -393,6 +405,9 @@ class QuillEditorConfigurations extends Equatable {
     QuillEditorBuilder? builder,
     TextMagnifierConfiguration? magnifierConfiguration,
     TextInputAction? textInputAction,
+    bool? enableScribble,
+    void Function()? onScribbleActivated,
+    EdgeInsets? scribbleAreaInsets,
   }) {
     return QuillEditorConfigurations(
       sharedConfigurations: sharedConfigurations ?? this.sharedConfigurations,
@@ -453,6 +468,9 @@ class QuillEditorConfigurations extends Equatable {
       magnifierConfiguration:
           magnifierConfiguration ?? this.magnifierConfiguration,
       textInputAction: textInputAction ?? this.textInputAction,
+      enableScribble: enableScribble ?? this.enableScribble,
+      onScribbleActivated: onScribbleActivated ?? this.onScribbleActivated,
+      scribbleAreaInsets: scribbleAreaInsets ?? this.scribbleAreaInsets,
     );
   }
 }

--- a/lib/src/models/config/raw_editor/raw_editor_configurations.dart
+++ b/lib/src/models/config/raw_editor/raw_editor_configurations.dart
@@ -78,6 +78,9 @@ class QuillRawEditorConfigurations extends Equatable {
     this.contentInsertionConfiguration,
     this.textInputAction = TextInputAction.newline,
     this.requestKeyboardFocusOnCheckListChanged = false,
+    this.enableScribble = false,
+    this.onScribbleActivated,
+    this.scribbleAreaInsets,
   });
 
   /// Controls the document being edited.
@@ -302,6 +305,15 @@ class QuillRawEditorConfigurations extends Equatable {
   final bool requestKeyboardFocusOnCheckListChanged;
 
   final TextInputAction textInputAction;
+
+  /// Enable Scribble? Currently Apple Pencil only, defaults to false.
+  final bool enableScribble;
+
+  /// Called when Scribble is activated.
+  final void Function()? onScribbleActivated;
+
+  /// Optional insets for the scribble area.
+  final EdgeInsets? scribbleAreaInsets;
 
   @override
   List<Object?> get props => [

--- a/lib/src/widgets/editor/editor.dart
+++ b/lib/src/widgets/editor/editor.dart
@@ -285,6 +285,9 @@ class QuillEditorState extends State<QuillEditor>
               dialogTheme: configurations.dialogTheme,
               contentInsertionConfiguration:
                   configurations.contentInsertionConfiguration,
+              enableScribble: configurations.enableScribble,
+              onScribbleActivated: configurations.onScribbleActivated,
+              scribbleAreaInsets: configurations.scribbleAreaInsets,
             ),
           ),
         ),

--- a/lib/src/widgets/raw_editor/scribble_focusable.dart
+++ b/lib/src/widgets/raw_editor/scribble_focusable.dart
@@ -25,8 +25,10 @@ class ScribbleFocusable extends StatefulWidget {
   _ScribbleFocusableState createState() => _ScribbleFocusableState();
 }
 
-class _ScribbleFocusableState extends State<ScribbleFocusable> implements ScribbleClient {
-  _ScribbleFocusableState() : _elementIdentifier = 'quill-scribble-${_nextElementIdentifier++}';
+class _ScribbleFocusableState extends State<ScribbleFocusable>
+    implements ScribbleClient {
+  _ScribbleFocusableState()
+      : _elementIdentifier = 'quill-scribble-${_nextElementIdentifier++}';
 
   @override
   void initState() {
@@ -87,9 +89,11 @@ class _ScribbleFocusableState extends State<ScribbleFocusable> implements Scribb
     }
     final intersection = calculatedBounds.intersect(rect);
     final result = HitTestResult();
-    WidgetsBinding.instance.hitTestInView(result, intersection.center, View.of(context).viewId);
-    return result.path
-        .any((entry) => entry.target == _renderBoxForEditor || entry.target == _renderBoxForBounds);
+    WidgetsBinding.instance
+        .hitTestInView(result, intersection.center, View.of(context).viewId);
+    return result.path.any((entry) =>
+        entry.target == _renderBoxForEditor ||
+        entry.target == _renderBoxForBounds);
   }
 
   @override

--- a/lib/src/widgets/raw_editor/scribble_focusable.dart
+++ b/lib/src/widgets/raw_editor/scribble_focusable.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+
+class ScribbleFocusable extends StatefulWidget {
+  const ScribbleFocusable({
+    required this.child,
+    required this.editorKey,
+    required this.renderBoxForBounds,
+    required this.onScribbleFocus,
+    required this.enabled,
+    required this.scribbleAreaInsets,
+    super.key,
+  });
+
+  final Widget child;
+  final GlobalKey editorKey;
+  final RenderBox? Function() renderBoxForBounds;
+  final void Function(Offset offset) onScribbleFocus;
+  final bool enabled;
+  final EdgeInsets? scribbleAreaInsets;
+
+  @override
+  // ignore: library_private_types_in_public_api
+  _ScribbleFocusableState createState() => _ScribbleFocusableState();
+}
+
+class _ScribbleFocusableState extends State<ScribbleFocusable> implements ScribbleClient {
+  _ScribbleFocusableState() : _elementIdentifier = 'quill-scribble-${_nextElementIdentifier++}';
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.enabled) {
+      TextInput.registerScribbleElement(elementIdentifier, this);
+    }
+  }
+
+  @override
+  void didUpdateWidget(ScribbleFocusable oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!oldWidget.enabled && widget.enabled) {
+      TextInput.registerScribbleElement(elementIdentifier, this);
+    }
+
+    if (oldWidget.enabled && !widget.enabled) {
+      TextInput.unregisterScribbleElement(elementIdentifier);
+    }
+  }
+
+  @override
+  void dispose() {
+    TextInput.unregisterScribbleElement(elementIdentifier);
+    super.dispose();
+  }
+
+  RenderBox? get _renderBoxForEditor =>
+      widget.editorKey.currentContext?.findRenderObject() as RenderBox?;
+
+  RenderBox? get _renderBoxForBounds {
+    final box = widget.renderBoxForBounds();
+    if (box == null || !mounted || !box.attached) {
+      return null;
+    }
+    return box;
+  }
+
+  static int _nextElementIdentifier = 1;
+  final String _elementIdentifier;
+
+  @override
+  String get elementIdentifier => _elementIdentifier;
+
+  @override
+  void onScribbleFocus(Offset offset) {
+    widget.onScribbleFocus(offset);
+  }
+
+  @override
+  bool isInScribbleRect(Rect rect) {
+    final calculatedBounds = bounds;
+    if (calculatedBounds == Rect.zero) {
+      return false;
+    }
+    if (!calculatedBounds.overlaps(rect)) {
+      return false;
+    }
+    final intersection = calculatedBounds.intersect(rect);
+    final result = HitTestResult();
+    WidgetsBinding.instance.hitTestInView(result, intersection.center, View.of(context).viewId);
+    return result.path
+        .any((entry) => entry.target == _renderBoxForEditor || entry.target == _renderBoxForBounds);
+  }
+
+  @override
+  Rect get bounds {
+    final box = context.findRenderObject() as RenderBox?;
+    if (box == null || !mounted || !box.attached) {
+      return Rect.zero;
+    }
+    final transform = box.getTransformTo(null);
+    final size = _renderBoxForBounds?.size ?? box.size;
+    return MatrixUtils.transformRect(
+        transform,
+        Rect.fromLTWH(
+          0 + (widget.scribbleAreaInsets?.left ?? 0),
+          0 + (widget.scribbleAreaInsets?.top ?? 0),
+          size.width -
+              (widget.scribbleAreaInsets?.left ?? 0) -
+              (widget.scribbleAreaInsets?.right ?? 0),
+          size.height -
+              (widget.scribbleAreaInsets?.top ?? 0) -
+              (widget.scribbleAreaInsets?.bottom ?? 0),
+        ));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}


### PR DESCRIPTION
Added ScribbleFocusable widget to use as a parent widget for QuilRawEditorMultiChildRenderObject.  Doing so will allow pencil drawing to text (currently Flutter is supporting this with Apple Pencil, when Flutter support S-Pen that will also work with this addition) in the bounds of the editor.  

There are three associated configuration options:

/* Enable Scribble? Currently Apple Pencil only, defaults to false. */
bool enableScribble

/* Optional insets for the scribble area. If you have overlaying buttons / toolbar, you can exclude that area from scribble bounds so that taps work */
EdgeInsets? scribbleAreaInsets

/* Called when Scribble is activated.  Example use - add toolbar item (Pencil icon) that would toggle enableScribble to move back / forth between scribble and tap modes. */
void Function()? onScribbleActivated

## Breaking Change

- No, this is *not* a breaking change.