### PR TITLE
Scribble scroll fix

### DIFF
--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -574,13 +574,13 @@ class QuillRawEditorState extends EditorState
         ),
       );
     } else {
-      child = CompositedTransformTarget(
-        link: _toolbarLayerLink,
-        child: Semantics(
-          child: MouseRegion(
-            cursor: SystemMouseCursors.text,
-            child: _scribbleFocusable(
-              QuilRawEditorMultiChildRenderObject(
+      child = _scribbleFocusable(
+        CompositedTransformTarget(
+          link: _toolbarLayerLink,
+          child: Semantics(
+            child: MouseRegion(
+              cursor: SystemMouseCursors.text,
+              child: QuilRawEditorMultiChildRenderObject(
                 key: _editorKey,
                 document: doc,
                 selection: controller.selection,

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -540,15 +540,15 @@ class QuillRawEditorState extends EditorState
       child = BaselineProxy(
         textStyle: _styles!.paragraph!.style,
         padding: baselinePadding,
-        child: QuillSingleChildScrollView(
-          controller: _scrollController,
-          physics: widget.configurations.scrollPhysics,
-          viewportBuilder: (_, offset) => CompositedTransformTarget(
-            link: _toolbarLayerLink,
-            child: MouseRegion(
-              cursor: SystemMouseCursors.text,
-              child: _scribbleFocusable(
-                QuilRawEditorMultiChildRenderObject(
+        child: _scribbleFocusable(
+          QuillSingleChildScrollView(
+            controller: _scrollController,
+            physics: widget.configurations.scrollPhysics,
+            viewportBuilder: (_, offset) => CompositedTransformTarget(
+              link: _toolbarLayerLink,
+              child: MouseRegion(
+                cursor: SystemMouseCursors.text,
+                child: QuilRawEditorMultiChildRenderObject(
                   key: _editorKey,
                   offset: offset,
                   document: doc,


### PR DESCRIPTION
## Description

The scribble area overlays the editor area.  This fix keeps the scribble area from scrolling as the editor scrolls.  Without this fix, the scribble area can scroll off the screen.

- No, this is *not* a breaking change.