### PR TITLE
Web `embedBuilder` error message typo

### DIFF
--- a/flutter_quill_extensions/lib/flutter_quill_embeds.dart
+++ b/flutter_quill_extensions/lib/flutter_quill_embeds.dart
@@ -48,7 +48,7 @@ class FlutterQuillEmbeds {
   }) {
     if (kIsWeb) {
       throw UnsupportedError(
-        'The editorBuilders() is not for web, please use editorBuilders() '
+        'The editorBuilders() is not for web, please use editorWebBuilders() '
         'instead',
       );
     }


### PR DESCRIPTION
## Description
A simple typo fix of error message, when using `embedBuilders` on web, which is not intended. Should be used `editorWebBuilders`.

```diff
-throw UnsupportedError(
-  'The editorBuilders() is not for web, please use editorBuilders() '
-  'instead',
-);
+throw UnsupportedError(
+  'The editorBuilders() is not for web, please use editorWebBuilders() '
+  'instead',
+);
```

Resolves the issue #1754.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.