### PR TITLE
fix dispose of text painter

### DIFF
--- a/lib/src/widgets/others/proxy.dart
+++ b/lib/src/widgets/others/proxy.dart
@@ -299,4 +299,10 @@ class RenderParagraphProxy extends RenderProxyBox
     _prototypePainter.layout(
         minWidth: constraints.minWidth, maxWidth: constraints.maxWidth);
   }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _prototypePainter.dispose();
+  }
 }

--- a/lib/src/widgets/others/proxy.dart
+++ b/lib/src/widgets/others/proxy.dart
@@ -75,6 +75,12 @@ class RenderBaselineProxy extends RenderProxyBox {
     super.performLayout();
     _prototypePainter.layout();
   }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _prototypePainter.dispose();
+  }
 }
 
 class EmbedProxy extends SingleChildRenderObjectWidget {


### PR DESCRIPTION

This fixes a leak of text painters in the RenderBaselineProxy
