### PR TITLE
fix: multiline styling stuck/not working properly

### DIFF
--- a/lib/src/models/documents/nodes/line.dart
+++ b/lib/src/models/documents/nodes/line.dart
@@ -362,7 +362,7 @@ base class Line extends QuillContainer<Leaf?> {
     void handle(Style style) {
       for (final attr in result.values) {
         if (!style.containsKey(attr.key) ||
-            (style.attributes[attr.key] != attr.value)) {
+            (style.attributes[attr.key]?.value != attr.value)) {
           excluded.add(attr);
         }
       }

--- a/lib/src/models/documents/nodes/line.dart
+++ b/lib/src/models/documents/nodes/line.dart
@@ -390,6 +390,7 @@ base class Line extends QuillContainer<Leaf?> {
     final remaining = len - local;
     if (remaining > 0 && nextLine != null) {
       final rest = nextLine!.collectStyle(0, remaining);
+      result = result.mergeAll(rest);
       handle(rest);
     }
 


### PR DESCRIPTION
## Description

This PR fixes the bug mentioned in #1550 , where doing styling in multiple lines at the same time doesn't change the toggle. This bug makes the editor so unintuitive.

## Related Issues

Fix #1550 

## Improvements
This change enables us to do styling to multiple line at once without breaking the style toggle, (see #1550 for examples)

## Additional notes
The issue was at lib\src\models\documents\nodes\line.dart at line 364-367, it compares `style.attributes[attr.key] != attr.value` when it should actually compare `style.attributes[attr.key]?.value != attr.value`. At the issue you can see that @li3317 cannot reproduce it, it might be because in some version of dart `anything == (bool)true` while in some version only `(bool)true == (bool)true`

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.