### PR TITLE
feat: Add options to style the text color of the dropdown menu items

### DIFF
--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -216,7 +216,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/lib/src/models/config/toolbar/buttons/font_family_configurations.dart
+++ b/lib/src/models/config/toolbar/buttons/font_family_configurations.dart
@@ -48,6 +48,7 @@ class QuillToolbarFontFamilyButtonOptions extends QuillToolbarBaseButtonOptions<
     this.itemHeight,
     this.itemPadding,
     this.defaultItemColor = Colors.red,
+    this.dropdownTextColor,
     this.renderFontFamilies = true,
     super.iconSize,
     super.iconButtonFactor,
@@ -70,6 +71,7 @@ class QuillToolbarFontFamilyButtonOptions extends QuillToolbarBaseButtonOptions<
   final double? itemHeight;
   final EdgeInsets? itemPadding;
   final Color? defaultItemColor;
+  final Color? dropdownTextColor;
   final String? defaultDisplayText;
 
   QuillToolbarFontFamilyButtonOptions copyWith({

--- a/lib/src/models/config/toolbar/buttons/font_size_configurations.dart
+++ b/lib/src/models/config/toolbar/buttons/font_size_configurations.dart
@@ -48,6 +48,7 @@ class QuillToolbarFontSizeButtonOptions extends QuillToolbarBaseButtonOptions<
     this.itemHeight,
     this.itemPadding,
     this.defaultItemColor = Colors.red,
+    this.dropdownTextColor,
     super.childBuilder,
     this.shape,
     this.defaultDisplayText,
@@ -70,6 +71,7 @@ class QuillToolbarFontSizeButtonOptions extends QuillToolbarBaseButtonOptions<
   @Deprecated('No longer used')
   final EdgeInsets? itemPadding;
   final Color? defaultItemColor;
+  final Color? dropdownTextColor;
   final String? defaultDisplayText;
 
   QuillToolbarFontSizeButtonOptions copyWith({

--- a/lib/src/models/config/toolbar/buttons/select_header_style_dropdown_button_configurations.dart
+++ b/lib/src/models/config/toolbar/buttons/select_header_style_dropdown_button_configurations.dart
@@ -28,6 +28,7 @@ class QuillToolbarSelectHeaderStyleDropdownButtonOptions
     super.iconSize,
     super.iconButtonFactor,
     this.textStyle,
+    this.dropdownTextStyle,
     super.iconData,
     this.attributes,
     this.defaultDisplayText,
@@ -35,6 +36,7 @@ class QuillToolbarSelectHeaderStyleDropdownButtonOptions
   });
 
   final TextStyle? textStyle;
+  final TextStyle? dropdownTextStyle;
 
   /// Header attributes, defaults to:
   /// ```dart

--- a/lib/src/widgets/toolbar/buttons/font_family_button.dart
+++ b/lib/src/widgets/toolbar/buttons/font_family_button.dart
@@ -217,7 +217,7 @@ class QuillToolbarFontFamilyButtonState
                       options.renderFontFamilies ? fontFamily.value : null,
                   color: fontFamily.value == 'Clear'
                       ? options.defaultItemColor
-                      : null,
+                      : options.dropdownTextColor,
                 ),
               ),
             ),

--- a/lib/src/widgets/toolbar/buttons/font_size_button.dart
+++ b/lib/src/widgets/toolbar/buttons/font_size_button.dart
@@ -186,7 +186,9 @@ class QuillToolbarFontSizeButtonState
           child: Text(
             fontSize.key.toString(),
             style: TextStyle(
-              color: fontSize.value == '0' ? options.defaultItemColor : null,
+              color: fontSize.value == '0'
+                  ? options.defaultItemColor
+                  : options.dropdownTextColor,
             ),
           ),
         );

--- a/lib/src/widgets/toolbar/buttons/hearder_style/select_header_style_dropdown_button.dart
+++ b/lib/src/widgets/toolbar/buttons/hearder_style/select_header_style_dropdown_button.dart
@@ -164,7 +164,7 @@ class _QuillToolbarSelectHeaderStyleDropdownButtonState
               onPressed: () {
                 _onPressed(e);
               },
-              child: Text(_label(e)),
+              child: Text(_label(e), style: widget.options.dropdownTextStyle),
             ),
           )
           .toList(),


### PR DESCRIPTION
## Description

With the current implementation, it is not possible to explicitly style the dropdown menu items for Toolbar items like the FontFamily, FontSize, and HeaderStyle menu items. Depending on the dark mode theme colors, this can make those items hard to read. This PR makes it possible to customize the colors of those so dark mode implementations can look complete.

## Related Issues

N/A

## Improvements
<!-- Optional -->

## Features
<!-- Optional -->

## Additional notes
<!-- Optional -->

## Suggestions
<!-- Optional -->

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.