### PR TITLE
feat: pass hintStyle to TextFormFields in LinkDialog

### DIFF
--- a/lib/src/widgets/toolbar/buttons/link_style_button.dart
+++ b/lib/src/widgets/toolbar/buttons/link_style_button.dart
@@ -265,6 +265,9 @@ class _LinkDialogState extends State<_LinkDialog> {
               decoration: InputDecoration(
                 labelText: context.loc.text,
                 hintText: context.loc.pleaseEnterTextForYourLink,
+                hintStyle: widget.dialogTheme?.inputTextStyle?.copyWith(
+                    color: widget.dialogTheme?.inputTextStyle?.color
+                        ?.withOpacity(0.65)),
                 labelStyle: widget.dialogTheme?.labelTextStyle,
                 floatingLabelStyle: widget.dialogTheme?.labelTextStyle,
               ),
@@ -284,6 +287,9 @@ class _LinkDialogState extends State<_LinkDialog> {
               decoration: InputDecoration(
                 labelText: context.loc.link,
                 hintText: context.loc.pleaseEnterTheLinkURL,
+                hintStyle: widget.dialogTheme?.inputTextStyle?.copyWith(
+                    color: widget.dialogTheme?.inputTextStyle?.color
+                        ?.withOpacity(0.65)),
                 labelStyle: widget.dialogTheme?.labelTextStyle,
                 floatingLabelStyle: widget.dialogTheme?.labelTextStyle,
               ),


### PR DESCRIPTION

## Description

This PR passes the hintStyle to TextFormFields in LinkDialog so the placeholder text can be styled and doesn't have a "random" color. It chooses uses the styles from DialogTheme.inputTextStyle if available and overrides the color with a lower opacity so it looks similar but greyed out to indicate it is placeholder text.

## Related Issues
N/A


## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.