### PR TITLE
fix: QuillIconTheme changes for FontFamily and FontSize buttons are not applied

### DIFF
--- a/lib/src/widgets/toolbar/buttons/font_family_button.dart
+++ b/lib/src/widgets/toolbar/buttons/font_family_button.dart
@@ -233,14 +233,7 @@ class QuillToolbarFontFamilyButtonState
             }
             return QuillToolbarIconButton(
               isSelected: false,
-              iconTheme: iconTheme?.copyWith(
-                iconButtonSelectedData: const IconButtonData(
-                  visualDensity: VisualDensity.compact,
-                ),
-                iconButtonUnselectedData: const IconButtonData(
-                  visualDensity: VisualDensity.compact,
-                ),
-              ),
+              iconTheme: iconTheme,
               onPressed: _onPressed,
               icon: _buildContent(context),
             );

--- a/lib/src/widgets/toolbar/buttons/font_size_button.dart
+++ b/lib/src/widgets/toolbar/buttons/font_size_button.dart
@@ -203,14 +203,7 @@ class QuillToolbarFontSizeButtonState
           return QuillToolbarIconButton(
             tooltip: tooltip,
             isSelected: false,
-            iconTheme: iconTheme?.copyWith(
-              iconButtonSelectedData: const IconButtonData(
-                visualDensity: VisualDensity.compact,
-              ),
-              iconButtonUnselectedData: const IconButtonData(
-                visualDensity: VisualDensity.compact,
-              ),
-            ),
+            iconTheme: iconTheme,
             onPressed: _onDropdownButtonPressed,
             icon: _buildContent(context),
           );


### PR DESCRIPTION
## Description

This PR removes the interfering copyWith for QuillIconTheme in the build method of QuillToolbarFontSizeButton and QuillToolbarFontFamilyButton to fix the bug #1797

## Related Issues

Fix #1797

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.