### PR TITLE
feat: Make the arrow_drop_down icons in the QuillToolbar the same size for all MenuAnchor buttons

### DIFF
--- a/lib/src/widgets/toolbar/buttons/font_family_button.dart
+++ b/lib/src/widgets/toolbar/buttons/font_family_button.dart
@@ -120,6 +120,13 @@ class QuillToolbarFontFamilyButtonState
     return iconSize ?? baseFontSize ?? kDefaultIconSize;
   }
 
+  double get iconButtonFactor {
+    final baseIconFactor =
+        context.quillToolbarBaseButtonOptions?.iconButtonFactor;
+    final iconButtonFactor = widget.options.iconButtonFactor;
+    return iconButtonFactor ?? baseIconFactor ?? kDefaultIconButtonFactor;
+  }
+
   VoidCallback? get afterButtonPressed {
     return options.afterButtonPressed ??
         context.quillToolbarBaseButtonOptions?.afterButtonPressed;
@@ -273,10 +280,9 @@ class QuillToolbarFontFamilyButtonState
                   ),
             ),
           ),
-          const SizedBox(width: 3),
           Icon(
             Icons.arrow_drop_down,
-            size: iconSize / 1.15,
+            size: iconSize * iconButtonFactor,
             // color: iconTheme?.iconUnselectedFillColor ?? theme.iconTheme.color,
           )
         ],

--- a/lib/src/widgets/toolbar/buttons/font_size_button.dart
+++ b/lib/src/widgets/toolbar/buttons/font_size_button.dart
@@ -241,10 +241,9 @@ class QuillToolbarFontSizeButtonState
                   ),
             ),
           ),
-          const SizedBox(width: 3),
           Icon(
             Icons.arrow_drop_down,
-            size: iconSize / 1.15,
+            size: iconSize * iconButtonFactor,
           )
         ],
       ),


### PR DESCRIPTION
## Description

This PR unifies the size of the arrow_drop_down icon for MenuAnchor buttons in the QuillToolbar as suggested in #1799

## Related Issues

Feat #1799

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.