### PR TITLE
Toolbar button styling to reflect cursor position when running on desktops with keyboard to move caret.

### DIFF
--- a/example/lib/screens/quill/my_quill_toolbar.dart
+++ b/example/lib/screens/quill/my_quill_toolbar.dart
@@ -223,24 +223,24 @@ class MyQuillToolbar extends StatelessWidget {
               '40': '40.0'
             },
             // headerStyleType: HeaderStyleType.buttons,
-            buttonOptions: QuillSimpleToolbarButtonOptions(
-              base: QuillToolbarBaseButtonOptions(
-                afterButtonPressed: focusNode.requestFocus,
-                // iconSize: 20,
-                //     iconTheme: QuillIconTheme(
-                //       iconButtonSelectedData: IconButtonData(
-                //         style: IconButton.styleFrom(
-                //           foregroundColor: Colors.blue,
-                //         ),
-                //       ),
-                //       iconButtonUnselectedData: IconButtonData(
-                //         style: IconButton.styleFrom(
-                //           foregroundColor: Colors.red,
-                //         ),
-                //       ),
-                //     ),
-              ),
-            ),
+            // buttonOptions: QuillSimpleToolbarButtonOptions(
+            //   base: QuillToolbarBaseButtonOptions(
+            //     afterButtonPressed: focusNode.requestFocus,
+            //     // iconSize: 20,
+            //     iconTheme: QuillIconTheme(
+            //       iconButtonSelectedData: IconButtonData(
+            //         style: IconButton.styleFrom(
+            //           foregroundColor: Colors.blue,
+            //         ),
+            //       ),
+            //       iconButtonUnselectedData: IconButtonData(
+            //         style: IconButton.styleFrom(
+            //           foregroundColor: Colors.red,
+            //         ),
+            //       ),
+            //     ),
+            //   ),
+            // ),
             customButtons: [
               QuillToolbarCustomButtonOptions(
                 icon: const Icon(Icons.add_alarm_rounded),

--- a/example/lib/screens/quill/my_quill_toolbar.dart
+++ b/example/lib/screens/quill/my_quill_toolbar.dart
@@ -223,24 +223,24 @@ class MyQuillToolbar extends StatelessWidget {
               '40': '40.0'
             },
             // headerStyleType: HeaderStyleType.buttons,
-            // buttonOptions: QuillSimpleToolbarButtonOptions(
-            //   base: QuillToolbarBaseButtonOptions(
-            //     afterButtonPressed: focusNode.requestFocus,
-            //     // iconSize: 20,
-            //     iconTheme: QuillIconTheme(
-            //       iconButtonSelectedData: IconButtonData(
-            //         style: IconButton.styleFrom(
-            //           foregroundColor: Colors.blue,
-            //         ),
-            //       ),
-            //       iconButtonUnselectedData: IconButtonData(
-            //         style: IconButton.styleFrom(
-            //           foregroundColor: Colors.red,
-            //         ),
-            //       ),
-            //     ),
-            //   ),
-            // ),
+            buttonOptions: QuillSimpleToolbarButtonOptions(
+              base: QuillToolbarBaseButtonOptions(
+                afterButtonPressed: focusNode.requestFocus,
+                // iconSize: 20,
+                //     iconTheme: QuillIconTheme(
+                //       iconButtonSelectedData: IconButtonData(
+                //         style: IconButton.styleFrom(
+                //           foregroundColor: Colors.blue,
+                //         ),
+                //       ),
+                //       iconButtonUnselectedData: IconButtonData(
+                //         style: IconButton.styleFrom(
+                //           foregroundColor: Colors.red,
+                //         ),
+                //       ),
+                //     ),
+              ),
+            ),
             customButtons: [
               QuillToolbarCustomButtonOptions(
                 icon: const Icon(Icons.add_alarm_rounded),

--- a/lib/src/models/documents/document.dart
+++ b/lib/src/models/documents/document.dart
@@ -184,11 +184,12 @@ class Document {
       return (res.node as Line).collectStyle(res.offset, len);
     }
     if (res.offset == 0) {
-      rangeStyle = (res.node as Line).collectStyle(res.offset, len);
-      return rangeStyle.removeAll({
-        for (final attr in rangeStyle.values)
-          if (attr.isInline) attr
-      });
+      return rangeStyle = (res.node as Line).collectStyle(res.offset, len);
+//COMMENT: Selecting the start of a line, user expects the style to be the visible style of the line including inline styles
+//      return rangeStyle.removeAll({
+//        for (final attr in rangeStyle.values)
+//          if (attr.isInline) attr
+//      });
     }
     rangeStyle = (res.node as Line).collectStyle(res.offset - 1, len);
     final linkAttribute = rangeStyle.attributes[Attribute.link.key];

--- a/lib/src/models/documents/document.dart
+++ b/lib/src/models/documents/document.dart
@@ -185,11 +185,6 @@ class Document {
     }
     if (res.offset == 0) {
       return rangeStyle = (res.node as Line).collectStyle(res.offset, len);
-//COMMENT: Selecting the start of a line, user expects the style to be the visible style of the line including inline styles
-//      return rangeStyle.removeAll({
-//        for (final attr in rangeStyle.values)
-//          if (attr.isInline) attr
-//      });
     }
     rangeStyle = (res.node as Line).collectStyle(res.offset - 1, len);
     final linkAttribute = rangeStyle.attributes[Attribute.link.key];

--- a/lib/src/models/rules/insert.dart
+++ b/lib/src/models/rules/insert.dart
@@ -559,10 +559,16 @@ class PreserveInlineStylesRule extends InsertRule {
     }
 
     final itr = DeltaIterator(document);
-    final prev = itr.skip(len == 0 ? index : index + 1);
+    var prev = itr.skip(len == 0 ? index : index + 1);
+    //
+    //  Inserting at start of line should use style for first character on the line
+    //
     if (prev == null ||
-        prev.data is! String ||
-        (prev.data as String).contains('\n')) {
+        (prev.data is String && (prev.data as String).endsWith('\n'))) {
+      prev = itr.next();
+    }
+
+    if (prev.data is! String) {
       return null;
     }
 

--- a/lib/src/models/rules/insert.dart
+++ b/lib/src/models/rules/insert.dart
@@ -560,9 +560,6 @@ class PreserveInlineStylesRule extends InsertRule {
 
     final itr = DeltaIterator(document);
     var prev = itr.skip(len == 0 ? index : index + 1);
-    //
-    //  Inserting at start of line should use style for first character on the line
-    //
     if (prev == null ||
         (prev.data is String && (prev.data as String).endsWith('\n'))) {
       prev = itr.next();

--- a/lib/src/widgets/quill/quill_controller.dart
+++ b/lib/src/widgets/quill/quill_controller.dart
@@ -478,7 +478,8 @@ class QuillController extends ChangeNotifier {
     super.dispose();
   }
 
-  void _updateSelection(TextSelection textSelection, {bool insertNewline = false}) {
+  void _updateSelection(TextSelection textSelection,
+      {bool insertNewline = false}) {
     _selection = textSelection;
     final end = document.length - 1;
     _selection = selection.copyWith(

--- a/lib/src/widgets/quill/quill_controller.dart
+++ b/lib/src/widgets/quill/quill_controller.dart
@@ -478,24 +478,13 @@ class QuillController extends ChangeNotifier {
     super.dispose();
   }
 
-  /// Comments:
-  /// Removed param:
-  ///   'ChangeSource source' as not used within this function!
-  /// Added param:
-  ///   insertNewline is non-null when user makes an editing change, true when newline is inserted to allow style to be maintained
   void _updateSelection(TextSelection textSelection, {bool insertNewline = false}) {
     _selection = textSelection;
     final end = document.length - 1;
     _selection = selection.copyWith(
         baseOffset: math.min(selection.baseOffset, end),
         extentOffset: math.min(selection.extentOffset, end));
-    //
     if (keepStyleOnNewLine) {
-      //
-      //  Update toggledStyle:
-      //    if insertNewline: gets style from preceding/last character entered (if any)
-      //    else clears so style will be style of selection
-      //
       if (insertNewline && selection.start > 0) {
         final style = document.collectStyle(selection.start - 1, 0);
         final ignoredStyles = style.attributes.values.where(
@@ -508,7 +497,6 @@ class QuillController extends ChangeNotifier {
     } else {
       toggledStyle = const Style();
     }
-    //
     onSelectionChanged?.call(textSelection);
   }
 

--- a/lib/src/widgets/quill/quill_controller.dart
+++ b/lib/src/widgets/quill/quill_controller.dart
@@ -327,7 +327,7 @@ class QuillController extends ChangeNotifier {
 
     if (textSelection != null) {
       if (delta == null || delta.isEmpty) {
-        _updateSelection(textSelection, ChangeSource.local);
+        _updateSelection(textSelection);
       } else {
         final user = Delta()
           ..retain(index)
@@ -335,12 +335,11 @@ class QuillController extends ChangeNotifier {
           ..delete(len);
         final positionDelta = getPositionDelta(user, delta);
         _updateSelection(
-          textSelection.copyWith(
-            baseOffset: textSelection.baseOffset + positionDelta,
-            extentOffset: textSelection.extentOffset + positionDelta,
-          ),
-          ChangeSource.local,
-        );
+            textSelection.copyWith(
+              baseOffset: textSelection.baseOffset + positionDelta,
+              extentOffset: textSelection.extentOffset + positionDelta,
+            ),
+            insertNewline: data == '\n');
       }
     }
 
@@ -389,7 +388,7 @@ class QuillController extends ChangeNotifier {
         baseOffset: change.transformPosition(selection.baseOffset),
         extentOffset: change.transformPosition(selection.extentOffset));
     if (selection != adjustedSelection) {
-      _updateSelection(adjustedSelection, ChangeSource.local);
+      _updateSelection(adjustedSelection);
     }
     if (shouldNotifyListeners) {
       notifyListeners();
@@ -428,7 +427,7 @@ class QuillController extends ChangeNotifier {
   }
 
   void updateSelection(TextSelection textSelection, ChangeSource source) {
-    _updateSelection(textSelection, source);
+    _updateSelection(textSelection);
     notifyListeners();
   }
 
@@ -445,7 +444,7 @@ class QuillController extends ChangeNotifier {
       ),
     );
     if (selection != textSelection) {
-      _updateSelection(textSelection, source);
+      _updateSelection(textSelection);
     }
 
     notifyListeners();
@@ -479,21 +478,37 @@ class QuillController extends ChangeNotifier {
     super.dispose();
   }
 
-  void _updateSelection(TextSelection textSelection, ChangeSource source) {
+  /// Comments:
+  /// Removed param:
+  ///   'ChangeSource source' as not used within this function!
+  /// Added param:
+  ///   insertNewline is non-null when user makes an editing change, true when newline is inserted to allow style to be maintained
+  void _updateSelection(TextSelection textSelection, {bool insertNewline = false}) {
     _selection = textSelection;
     final end = document.length - 1;
     _selection = selection.copyWith(
         baseOffset: math.min(selection.baseOffset, end),
         extentOffset: math.min(selection.extentOffset, end));
+    //
     if (keepStyleOnNewLine) {
-      final style = getSelectionStyle();
-      final ignoredStyles = style.attributes.values.where(
-        (s) => !s.isInline || s.key == Attribute.link.key,
-      );
-      toggledStyle = style.removeAll(ignoredStyles.toSet());
+      //
+      //  Update toggledStyle:
+      //    if insertNewline: gets style from preceding/last character entered (if any)
+      //    else clears so style will be style of selection
+      //
+      if (insertNewline && selection.start > 0) {
+        final style = document.collectStyle(selection.start - 1, 0);
+        final ignoredStyles = style.attributes.values.where(
+          (s) => !s.isInline || s.key == Attribute.link.key,
+        );
+        toggledStyle = style.removeAll(ignoredStyles.toSet());
+      } else {
+        toggledStyle = const Style();
+      }
     } else {
       toggledStyle = const Style();
     }
+    //
     onSelectionChanged?.call(textSelection);
   }
 

--- a/lib/src/widgets/toolbar/buttons/color/color_button.dart
+++ b/lib/src/widgets/toolbar/buttons/color/color_button.dart
@@ -191,6 +191,7 @@ class QuillToolbarColorButtonState extends State<QuillToolbarColorButton> {
         size: iconSize * iconButtonFactor,
       ),
       onPressed: _showColorPicker,
+      afterPressed: afterButtonPressed,
     );
   }
 

--- a/lib/src/widgets/toolbar/buttons/quill_icon_button.dart
+++ b/lib/src/widgets/toolbar/buttons/quill_icon_button.dart
@@ -26,7 +26,12 @@ class QuillToolbarIconButton extends StatelessWidget {
     if (isSelected) {
       return IconButton.filled(
         tooltip: tooltip,
-        onPressed: onPressed,
+        onPressed: onPressed != null
+            ? () {
+                onPressed?.call();
+                afterPressed?.call();
+              }
+            : null,
         icon: icon,
         style: iconTheme?.iconButtonSelectedData?.style,
         visualDensity: iconTheme?.iconButtonSelectedData?.visualDensity,

--- a/lib/src/widgets/toolbar/buttons/toggle_style_button.dart
+++ b/lib/src/widgets/toolbar/buttons/toggle_style_button.dart
@@ -148,7 +148,7 @@ class QuillToolbarToggleStyleButtonState
 
   void _onPressed() {
     _toggleAttribute();
-    options.afterButtonPressed?.call();
+    afterButtonPressed?.call();
   }
 
   @override
@@ -175,7 +175,7 @@ class QuillToolbarToggleStyleButtonState
         options.fillColor,
         _isToggled,
         _toggleAttribute,
-        options.afterButtonPressed,
+        afterButtonPressed,
         iconSize,
         iconButtonFactor,
         iconTheme,


### PR DESCRIPTION
## Description

Proposed changes make the toolbar buttons selection state reflect the styling as the cursor is moved. Using desktop (Windows) keyboard cursor keys to move the caret position (without selecting text).

- Fix inline style tracking: When cursor is moved into a region of bold, the bold style is correctly recognized and reflected in the toolbar status. Problem: When the cursor keys move the caret out of the bold region, the bold style is not cleared and cannot be removed.

- Fix: toggle_style_button failed to call default afterButtonPressed in base button settings. Constructor called options.afterButtonPressed rather than the class function afterButtonPressed that defaults to a call to QuillToolbarBaseButtonOptions.

- Fix: quill_icon_button build when isSelected did not call afterButtonPressed (expected same action as when not selected).

- Fix: QuillController _updateSelection removed param=source because not used; added new param insertNewline to recognize when a newline entered and maintain the correct inline style by correctly setting toggledStyle; updated replaceText to call _updateSelection for newline.

- Fix: document.dart collectStyle:  Click at the start of a line (of bold text), user would expect the style to be the visible style of the line including inline styles. Also requires updating insert.dart PreserveInlineStylesRule to recognize if inserting text at start of line and use attributes from the first char on line

- Fix: color_button : Add afterPressed param to QuillToolbarIconButton

## Related Issues

- *Fix #1786*  QuillToolbarBaseButtonOptions now called

- *Fix #1775*  Toolbar bold button now tracks cursor position

## Improvements
<!-- Optional -->

## Features
<!-- Optional -->

## Additional notes
<!-- Optional -->

## Suggestions
QuillController (public function) updateSelection also does not use the ChangeSource parameter.
ChangeSource enum does not appear to be used anywhere - is this deprecated or am I missing something?

## Checklist

- [X] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [X] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [X] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [X] All existing and new tests are passing.
- [X] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [X] No, this is *not* a breaking change.