### PR TITLE
Fix for keyboard jumping when switching focus from a TextField

### DIFF
--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -1452,12 +1452,12 @@ class QuillRawEditorState extends EditorState
   }
 
   void _handleFocusChanged() {
+    openOrCloseConnection();
     if (dirty) {
       SchedulerBinding.instance
           .addPostFrameCallback((_) => _handleFocusChanged());
       return;
     }
-    openOrCloseConnection();
     _cursorCont.startOrStopCursorTimerIfNeeded(_hasFocus, controller.selection);
     _updateOrDisposeSelectionOverlayIfNeeded();
     if (_hasFocus) {

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -1452,12 +1452,13 @@ class QuillRawEditorState extends EditorState
   }
 
   void _handleFocusChanged() {
-    openOrCloseConnection();
     if (dirty) {
+      requestKeyboard();
       SchedulerBinding.instance
           .addPostFrameCallback((_) => _handleFocusChanged());
       return;
     }
+    openOrCloseConnection();
     _cursorCont.startOrStopCursorTimerIfNeeded(_hasFocus, controller.selection);
     _updateOrDisposeSelectionOverlayIfNeeded();
     if (_hasFocus) {


### PR DESCRIPTION
## Description

When user switches focus from a TextField to QuillEditor keyboards "jumps". This happens, because `_handleFocusChanged` is called in a postFrameCallback if the state is `dirty`. So there's time to start hiding keyboard animation and the show it again.

This fixes it by requesting keyboard prior to calling `_handleFocusChanged` in a postFrameCallback.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/singerdmx/flutter-quill/issues). Indicate, which of these issues are resolved or fixed by this PR.*

*e.g.*
- *Fix #1779*
- *Related #1256 *

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.