### PR TITLE
MOB-1992: Keyboard jumps when switching between thread title and message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ pubspec_overrides.yaml
 
 # A directory where you put all of your local things that you don't want to push
 .flutter-quill
+
+# FVM Version Cache
+.fvm/

--- a/flutter_quill_extensions/pubspec.yaml
+++ b/flutter_quill_extensions/pubspec.yaml
@@ -35,7 +35,10 @@ dependencies:
   universal_html: ^2.2.4
   cross_file: ^0.3.3+6
 
-  flutter_quill: ^9.3.4
+  flutter_quill:
+   git:
+    url: 'git@github.com:joylabs/flutter-quill.git'
+    ref: master
   photo_view: ^0.14.0
 
   # Plugins

--- a/lib/src/widgets/others/text_selection.dart
+++ b/lib/src/widgets/others/text_selection.dart
@@ -463,13 +463,24 @@ class _TextSelectionHandleOverlayState
 
   void _handleDragUpdate(DragUpdateDetails details) {
     _dragPosition += details.delta;
-    final position =
-        widget.renderObject.getPositionForOffset(details.globalPosition);
     if (widget.selection.isCollapsed) {
+      final position = widget.renderObject.getPositionForOffset(
+        details.globalPosition,
+      );
       widget.onSelectionHandleChanged(TextSelection.fromPosition(position));
       return;
     }
-
+    final textPosition = switch (widget.position) {
+      _TextSelectionHandlePosition.start => widget.selection.base,
+      _TextSelectionHandlePosition.end => widget.selection.extent,
+    };
+    final lineHeight = widget.renderObject.preferredLineHeight(textPosition);
+    final position = widget.renderObject.getPositionForOffset(
+      details.globalPosition.translate(0, switch (widget.position) {
+        _TextSelectionHandlePosition.start => lineHeight,
+        _TextSelectionHandlePosition.end => -lineHeight,
+      }),
+    );
     final isNormalized =
         widget.selection.extentOffset >= widget.selection.baseOffset;
     TextSelection newSelection;

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -1429,6 +1429,7 @@ class QuillRawEditorState extends EditorState
 
   void _handleFocusChanged() {
     if (dirty) {
+      requestKeyboard();
       SchedulerBinding.instance
           .addPostFrameCallback((_) => _handleFocusChanged());
       return;


### PR DESCRIPTION
## Description

When user switches focus from a TextField to QuillEditor keyboards "jumps". This happens, because _handleFocusChanged is called in a postFrameCallback if the state is dirty. So there's time to start hiding keyboard animation and the show it again.

This fixes it by requesting keyboard prior to calling _handleFocusChanged in a postFrameCallback.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/singerdmx/flutter-quill/issues). Indicate, which of these issues are resolved or fixed by this PR.*

*e.g.*
- *Fix #1779*
- *Related #1256*

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.