### PR TITLE
fix: removed misleading parameters

### DIFF
--- a/flutter_quill_extensions/lib/embeds/image/toolbar/image_button.dart
+++ b/flutter_quill_extensions/lib/embeds/image/toolbar/image_button.dart
@@ -81,7 +81,6 @@ class QuillToolbarImageButton extends StatelessWidget {
           iconSize: iconSize,
           iconButtonFactor: iconButtonFactor,
           dialogTheme: options.dialogTheme,
-          fillColor: options.fillColor,
           iconTheme: options.iconTheme,
           linkRegExp: options.linkRegExp,
           tooltip: options.tooltip,

--- a/flutter_quill_extensions/lib/embeds/others/camera_button/camera_button.dart
+++ b/flutter_quill_extensions/lib/embeds/others/camera_button/camera_button.dart
@@ -87,7 +87,6 @@ class QuillToolbarCameraButton extends StatelessWidget {
         QuillToolbarCameraButtonOptions(
           afterButtonPressed: _afterButtonPressed(context),
           iconData: options.iconData,
-          fillColor: options.fillColor,
           iconSize: options.iconSize,
           iconButtonFactor: iconButtonFactor,
           iconTheme: options.iconTheme,

--- a/flutter_quill_extensions/lib/models/config/camera/camera_configurations.dart
+++ b/flutter_quill_extensions/lib/models/config/camera/camera_configurations.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/widgets.dart' show Color;
 import 'package:flutter_quill/flutter_quill.dart';
 
 import '../../../embeds/others/camera_button/camera_types.dart';

--- a/flutter_quill_extensions/lib/models/config/camera/camera_configurations.dart
+++ b/flutter_quill_extensions/lib/models/config/camera/camera_configurations.dart
@@ -18,15 +18,12 @@ class QuillToolbarCameraButtonOptions extends QuillToolbarBaseButtonOptions<
     this.cameraConfigurations = const QuillToolbarCameraConfigurations(),
     super.iconSize,
     super.iconButtonFactor,
-    this.fillColor,
     super.iconData,
     super.afterButtonPressed,
     super.tooltip,
     super.iconTheme,
     super.childBuilder,
   });
-
-  final Color? fillColor;
 
   final QuillToolbarCameraConfigurations cameraConfigurations;
 }

--- a/flutter_quill_extensions/lib/models/config/formula/formula_configurations.dart
+++ b/flutter_quill_extensions/lib/models/config/formula/formula_configurations.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/widgets.dart' show Color;
 import 'package:flutter_quill/flutter_quill.dart';
 
 class QuillToolbarFormulaButtonExtraOptions

--- a/flutter_quill_extensions/lib/models/config/formula/formula_configurations.dart
+++ b/flutter_quill_extensions/lib/models/config/formula/formula_configurations.dart
@@ -18,10 +18,7 @@ class QuillToolbarFormulaButtonOptions extends QuillToolbarBaseButtonOptions<
     super.iconTheme,
     super.afterButtonPressed,
     super.childBuilder,
-    this.fillColor,
     super.iconSize,
     super.iconButtonFactor,
   });
-
-  final Color? fillColor;
 }

--- a/flutter_quill_extensions/lib/models/config/image/toolbar/image_configurations.dart
+++ b/flutter_quill_extensions/lib/models/config/image/toolbar/image_configurations.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/widgets.dart' show Color;
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:meta/meta.dart' show immutable;
 

--- a/flutter_quill_extensions/lib/models/config/image/toolbar/image_configurations.dart
+++ b/flutter_quill_extensions/lib/models/config/image/toolbar/image_configurations.dart
@@ -26,13 +26,10 @@ class QuillToolbarImageButtonOptions extends QuillToolbarBaseButtonOptions<
     super.afterButtonPressed,
     super.childBuilder,
     super.iconTheme,
-    this.fillColor,
     this.dialogTheme,
     this.linkRegExp,
     this.imageButtonConfigurations = const QuillToolbarImageConfigurations(),
   });
-
-  final Color? fillColor;
 
   final QuillDialogTheme? dialogTheme;
 

--- a/flutter_quill_extensions/lib/models/config/media/media_button_configurations.dart
+++ b/flutter_quill_extensions/lib/models/config/media/media_button_configurations.dart
@@ -24,7 +24,6 @@ class QuillToolbarMediaButtonOptions extends QuillToolbarBaseButtonOptions<
     this.childrenSpacing = 16.0,
     this.autovalidateMode = AutovalidateMode.disabled,
     super.iconSize,
-    this.fillColor,
     this.dialogTheme,
     this.labelText,
     this.hintText,
@@ -40,7 +39,6 @@ class QuillToolbarMediaButtonOptions extends QuillToolbarBaseButtonOptions<
     super.childBuilder,
   });
 
-  final Color? fillColor;
   final QuillMediaType type;
   final QuillDialogTheme? dialogTheme;
   final MediaFilePicker? mediaFilePicker;

--- a/flutter_quill_extensions/lib/models/config/video/toolbar/video_configurations.dart
+++ b/flutter_quill_extensions/lib/models/config/video/toolbar/video_configurations.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/widgets.dart' show Color;
 import 'package:flutter_quill/flutter_quill.dart';
 
 import '../../../../embeds/video/video.dart';

--- a/flutter_quill_extensions/lib/models/config/video/toolbar/video_configurations.dart
+++ b/flutter_quill_extensions/lib/models/config/video/toolbar/video_configurations.dart
@@ -17,7 +17,6 @@ class QuillToolbarVideoButtonOptions extends QuillToolbarBaseButtonOptions<
   const QuillToolbarVideoButtonOptions({
     this.linkRegExp,
     this.dialogTheme,
-    this.fillColor,
     super.iconSize,
     super.iconButtonFactor,
     super.iconData,
@@ -31,6 +30,4 @@ class QuillToolbarVideoButtonOptions extends QuillToolbarBaseButtonOptions<
   final RegExp? linkRegExp;
   final QuillDialogTheme? dialogTheme;
   final QuillToolbarVideoConfigurations videoConfigurations;
-
-  final Color? fillColor;
 }

--- a/lib/src/models/config/toolbar/buttons/font_size_configurations.dart
+++ b/lib/src/models/config/toolbar/buttons/font_size_configurations.dart
@@ -75,7 +75,6 @@ class QuillToolbarFontSizeButtonOptions extends QuillToolbarBaseButtonOptions<
   QuillToolbarFontSizeButtonOptions copyWith({
     double? iconSize,
     double? iconButtonFactor,
-    Color? fillColor,
     double? hoverElevation,
     double? highlightElevation,
     List<PopupMenuEntry<String>>? items,

--- a/lib/src/models/config/toolbar/buttons/search_configurations.dart
+++ b/lib/src/models/config/toolbar/buttons/search_configurations.dart
@@ -23,7 +23,6 @@ class QuillToolbarSearchButtonOptions extends QuillToolbarBaseButtonOptions<
     super.iconSize,
     super.iconButtonFactor,
     this.dialogBarrierColor,
-    this.fillColor,
     this.customOnPressedCallback,
   });
 
@@ -31,8 +30,6 @@ class QuillToolbarSearchButtonOptions extends QuillToolbarBaseButtonOptions<
 
   /// By default will be [dialogBarrierColor] from [QuillSharedConfigurations]
   final Color? dialogBarrierColor;
-
-  final Color? fillColor;
 
   /// By default we will show simple search dialog ui
   /// you can pass value to this callback to change this

--- a/lib/src/models/config/toolbar/buttons/toggle_check_list_configurations.dart
+++ b/lib/src/models/config/toolbar/buttons/toggle_check_list_configurations.dart
@@ -23,7 +23,6 @@ class QuillToolbarToggleCheckListButtonOptions
   const QuillToolbarToggleCheckListButtonOptions({
     super.iconSize,
     super.iconButtonFactor,
-    this.fillColor,
     this.attribute = Attribute.unchecked,
     this.isShouldRequestKeyboard = false,
     super.iconTheme,
@@ -32,8 +31,6 @@ class QuillToolbarToggleCheckListButtonOptions
     super.afterButtonPressed,
     super.childBuilder,
   });
-
-  final Color? fillColor;
 
   final Attribute attribute;
 

--- a/lib/src/models/config/toolbar/buttons/toggle_check_list_configurations.dart
+++ b/lib/src/models/config/toolbar/buttons/toggle_check_list_configurations.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart' show immutable;
-import 'package:flutter/widgets.dart' show Color;
 
 import '../../../documents/attribute.dart';
 import '../../quill_configurations.dart';

--- a/lib/src/models/config/toolbar/buttons/toggle_style_configurations.dart
+++ b/lib/src/models/config/toolbar/buttons/toggle_style_configurations.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'package:flutter/foundation.dart' show immutable;
-import 'package:flutter/widgets.dart' show Color;
 
 import '../base_button_configurations.dart';
 

--- a/lib/src/models/config/toolbar/buttons/toggle_style_configurations.dart
+++ b/lib/src/models/config/toolbar/buttons/toggle_style_configurations.dart
@@ -26,12 +26,9 @@ class QuillToolbarToggleStyleButtonOptions
     super.iconData,
     super.iconSize,
     super.iconButtonFactor,
-    this.fillColor,
     super.tooltip,
     super.afterButtonPressed,
     super.iconTheme,
     super.childBuilder,
   });
-
-  final Color? fillColor;
 }

--- a/lib/src/models/themes/quill_icon_theme.dart
+++ b/lib/src/models/themes/quill_icon_theme.dart
@@ -4,16 +4,9 @@ import 'package:flutter/material.dart';
 @immutable
 class QuillIconTheme {
   const QuillIconTheme({
-    this.iconButtonSelectedStyle,
-    this.iconButtonUnselectedStyle,
     this.iconButtonSelectedData,
     this.iconButtonUnselectedData,
   });
-
-  @Deprecated('Please use iconButtonUnselectedData instead')
-  final ButtonStyle? iconButtonUnselectedStyle;
-  @Deprecated('Please use iconButtonSelectedData instead')
-  final ButtonStyle? iconButtonSelectedStyle;
 
   final IconButtonData? iconButtonUnselectedData;
   final IconButtonData? iconButtonSelectedData;

--- a/lib/src/widgets/toolbar/buttons/toggle_check_list_button.dart
+++ b/lib/src/widgets/toolbar/buttons/toggle_check_list_button.dart
@@ -146,7 +146,6 @@ class QuillToolbarToggleCheckListButtonState
         context,
         Attribute.unchecked,
         iconData,
-        options.fillColor,
         _isToggled,
         _toggleAttribute,
         afterButtonPressed,

--- a/lib/src/widgets/toolbar/buttons/toggle_style_button.dart
+++ b/lib/src/widgets/toolbar/buttons/toggle_style_button.dart
@@ -13,7 +13,6 @@ typedef ToggleStyleButtonBuilder = Widget Function(
   BuildContext context,
   Attribute attribute,
   IconData icon,
-  Color? fillColor,
   bool? isToggled,
   VoidCallback? onPressed,
   VoidCallback? afterPressed, [
@@ -172,7 +171,6 @@ class QuillToolbarToggleStyleButtonState
         context,
         widget.attribute,
         iconData,
-        options.fillColor,
         _isToggled,
         _toggleAttribute,
         afterButtonPressed,
@@ -231,7 +229,6 @@ Widget defaultToggleStyleButtonBuilder(
   BuildContext context,
   Attribute attribute,
   IconData icon,
-  Color? fillColor,
   bool? isToggled,
   VoidCallback? onPressed,
   VoidCallback? afterPressed, [


### PR DESCRIPTION
## Description

There are parameters in the code that don't do anything. This is misleading. In the current pr these parameters have been removed.

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.