### PR TITLE
fix: MD Parsing for multi space

### DIFF
--- a/lib/src/packages/quill_markdown/markdown_to_delta.dart
+++ b/lib/src/packages/quill_markdown/markdown_to_delta.dart
@@ -21,7 +21,8 @@ typedef ElementToEmbeddableConvertor = Embeddable Function(
 );
 
 /// Convertor from Markdown string to quill [Delta].
-class MarkdownToDelta extends Converter<String, Delta> implements md.NodeVisitor {
+class MarkdownToDelta extends Converter<String, Delta>
+    implements md.NodeVisitor {
   ///
   MarkdownToDelta({
     required this.markdownDocument,
@@ -143,7 +144,9 @@ class MarkdownToDelta extends Converter<String, Delta> implements md.NodeVisitor
     if (_isInBlockQuote) {
       renderedText = text.text;
     } else if (_isInCodeblock) {
-      renderedText = text.text.endsWith('\n') ? text.text.substring(0, text.text.length - 1) : text.text;
+      renderedText = text.text.endsWith('\n')
+          ? text.text.substring(0, text.text.length - 1)
+          : text.text;
     } else {
       renderedText = _trimTextToMdSpec(text.text);
     }
@@ -245,7 +248,9 @@ class MarkdownToDelta extends Converter<String, Delta> implements md.NodeVisitor
   }
 
   void _insertNewLineBeforeElementIfNeeded(md.Element element) {
-    if (!_isInBlockQuote && _lastTag == 'blockquote' && element.tag == 'blockquote') {
+    if (!_isInBlockQuote &&
+        _lastTag == 'blockquote' &&
+        element.tag == 'blockquote') {
       _insertNewLine();
       return;
     }
@@ -283,7 +288,10 @@ class MarkdownToDelta extends Converter<String, Delta> implements md.NodeVisitor
       return;
     }
 
-    if (!_justPreviousBlockExit && (_isTopLevelNode(element) || _haveBlockAttrs(element) || element.tag == 'li')) {
+    if (!_justPreviousBlockExit &&
+        (_isTopLevelNode(element) ||
+            _haveBlockAttrs(element) ||
+            element.tag == 'li')) {
       _justPreviousBlockExit = true;
       _insertNewLine();
       return;
@@ -368,7 +376,8 @@ class MarkdownToDelta extends Converter<String, Delta> implements md.NodeVisitor
       result = _effectiveElementToInlineAttr()[element.tag]?.call(element);
     }
     if (result == null) {
-      throw Exception('Element $element cannot be converted to inline attribute');
+      throw Exception(
+          'Element $element cannot be converted to inline attribute');
     }
     return result;
   }
@@ -387,7 +396,8 @@ class MarkdownToDelta extends Converter<String, Delta> implements md.NodeVisitor
   List<Attribute<dynamic>> _toBlockAttributes(md.Element element) {
     final result = _effectiveElementToBlockAttr()[element.tag]?.call(element);
     if (result == null) {
-      throw Exception('Element $element cannot be converted to block attribute');
+      throw Exception(
+          'Element $element cannot be converted to block attribute');
     }
     return result;
   }
@@ -399,10 +409,12 @@ class MarkdownToDelta extends Converter<String, Delta> implements md.NodeVisitor
     };
   }
 
-  bool _isEmbedElement(md.Element element) => _effectiveElementToEmbed().containsKey(element.tag);
+  bool _isEmbedElement(md.Element element) =>
+      _effectiveElementToEmbed().containsKey(element.tag);
 
   Embeddable _toEmbeddable(md.Element element) {
-    final result = _effectiveElementToEmbed()[element.tag]?.call(element.attributes);
+    final result =
+        _effectiveElementToEmbed()[element.tag]?.call(element.attributes);
     if (result == null) {
       throw Exception('Element $element cannot be converted to Embeddable');
     }

--- a/lib/src/packages/quill_markdown/markdown_to_delta.dart
+++ b/lib/src/packages/quill_markdown/markdown_to_delta.dart
@@ -21,8 +21,7 @@ typedef ElementToEmbeddableConvertor = Embeddable Function(
 );
 
 /// Convertor from Markdown string to quill [Delta].
-class MarkdownToDelta extends Converter<String, Delta>
-    implements md.NodeVisitor {
+class MarkdownToDelta extends Converter<String, Delta> implements md.NodeVisitor {
   ///
   MarkdownToDelta({
     required this.markdownDocument,
@@ -117,9 +116,7 @@ class MarkdownToDelta extends Converter<String, Delta>
     _justPreviousBlockExit = false;
     _listItemIndent = -1;
 
-    final lines = const LineSplitter().convert(input);
-    final mdNodes = markdownDocument.parseLines(lines);
-
+    final mdNodes = markdownDocument.parseInline(input);
     _topLevelNodes.addAll(mdNodes);
 
     for (final node in mdNodes) {
@@ -146,9 +143,7 @@ class MarkdownToDelta extends Converter<String, Delta>
     if (_isInBlockQuote) {
       renderedText = text.text;
     } else if (_isInCodeblock) {
-      renderedText = text.text.endsWith('\n')
-          ? text.text.substring(0, text.text.length - 1)
-          : text.text;
+      renderedText = text.text.endsWith('\n') ? text.text.substring(0, text.text.length - 1) : text.text;
     } else {
       renderedText = _trimTextToMdSpec(text.text);
     }
@@ -250,9 +245,7 @@ class MarkdownToDelta extends Converter<String, Delta>
   }
 
   void _insertNewLineBeforeElementIfNeeded(md.Element element) {
-    if (!_isInBlockQuote &&
-        _lastTag == 'blockquote' &&
-        element.tag == 'blockquote') {
+    if (!_isInBlockQuote && _lastTag == 'blockquote' && element.tag == 'blockquote') {
       _insertNewLine();
       return;
     }
@@ -290,10 +283,7 @@ class MarkdownToDelta extends Converter<String, Delta>
       return;
     }
 
-    if (!_justPreviousBlockExit &&
-        (_isTopLevelNode(element) ||
-            _haveBlockAttrs(element) ||
-            element.tag == 'li')) {
+    if (!_justPreviousBlockExit && (_isTopLevelNode(element) || _haveBlockAttrs(element) || element.tag == 'li')) {
       _justPreviousBlockExit = true;
       _insertNewLine();
       return;
@@ -378,8 +368,7 @@ class MarkdownToDelta extends Converter<String, Delta>
       result = _effectiveElementToInlineAttr()[element.tag]?.call(element);
     }
     if (result == null) {
-      throw Exception(
-          'Element $element cannot be converted to inline attribute');
+      throw Exception('Element $element cannot be converted to inline attribute');
     }
     return result;
   }
@@ -398,8 +387,7 @@ class MarkdownToDelta extends Converter<String, Delta>
   List<Attribute<dynamic>> _toBlockAttributes(md.Element element) {
     final result = _effectiveElementToBlockAttr()[element.tag]?.call(element);
     if (result == null) {
-      throw Exception(
-          'Element $element cannot be converted to block attribute');
+      throw Exception('Element $element cannot be converted to block attribute');
     }
     return result;
   }
@@ -411,12 +399,10 @@ class MarkdownToDelta extends Converter<String, Delta>
     };
   }
 
-  bool _isEmbedElement(md.Element element) =>
-      _effectiveElementToEmbed().containsKey(element.tag);
+  bool _isEmbedElement(md.Element element) => _effectiveElementToEmbed().containsKey(element.tag);
 
   Embeddable _toEmbeddable(md.Element element) {
-    final result =
-        _effectiveElementToEmbed()[element.tag]?.call(element.attributes);
+    final result = _effectiveElementToEmbed()[element.tag]?.call(element.attributes);
     if (result == null) {
       throw Exception('Element $element cannot be converted to Embeddable');
     }


### PR DESCRIPTION
## Description

Parse lines will not return anything on a blank line, Parse inline will return everything, including elements for blank lines. This fixes the issue reference in 1528

## Related Issues
Fix - #1528 

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.