### PR TITLE
feat: Display the current font size

### DIFF
--- a/lib/src/widgets/toolbar/buttons/font_size_button.dart
+++ b/lib/src/widgets/toolbar/buttons/font_size_button.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_quill/flutter_quill.dart';
 
 import '../../../../extensions.dart';
 
+import '../../../../flutter_quill.dart';
 import '../../../extensions/quill_configurations_ext.dart';
 import '../../../l10n/extensions/localizations.dart';
 import '../../../models/documents/attribute.dart';

--- a/lib/src/widgets/toolbar/buttons/font_size_button.dart
+++ b/lib/src/widgets/toolbar/buttons/font_size_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_quill/flutter_quill.dart';
 
 import '../../../../extensions.dart';
 
@@ -37,6 +38,7 @@ class QuillToolbarFontSizeButton extends StatefulWidget {
 class QuillToolbarFontSizeButtonState
     extends State<QuillToolbarFontSizeButton> {
   final _menuController = MenuController();
+  Style get _selectionStyle => controller.getSelectionStyle();
   String _currentValue = '';
 
   QuillToolbarFontSizeButtonOptions get options {
@@ -79,7 +81,43 @@ class QuillToolbarFontSizeButtonState
   }
 
   @override
+  void didUpdateWidget(covariant QuillToolbarFontSizeButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != controller) {
+      oldWidget.controller.removeListener(_didChangeEditingValue);
+      controller.addListener(_didChangeEditingValue);
+      _currentValue = _defaultDisplayText;
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    controller.addListener(_didChangeEditingValue);
+  }
+
+  void _didChangeEditingValue() {
+    final selectedFontSize =
+        _selectionStyle.attributes[Attribute.size.key]?.value;
+
+    if (selectedFontSize == null) {
+      setState(() {
+        _currentValue = _defaultDisplayText;
+      });
+
+      return;
+    }
+
+    setState(() {
+      _currentValue = selectedFontSize is double
+          ? selectedFontSize.toInt().toString()
+          : selectedFontSize;
+    });
+  }
+
+  @override
   void dispose() {
+    controller.removeListener(_didChangeEditingValue);
     super.dispose();
   }
 
@@ -224,9 +262,7 @@ class QuillToolbarFontSizeButtonState
             enabled: hasFinalWidth,
             wrapper: (child) => Expanded(child: child),
             child: Text(
-              getLabel(widget.controller.selectedFontSize?.key) ??
-                  getLabel(_currentValue) ??
-                  '',
+              getLabel(_currentValue) ?? '',
               overflow: options.labelOverflow,
               style: options.style ??
                   TextStyle(


### PR DESCRIPTION
## Description

If I change the text size in a certain segment, and then switch to another paragraph the font size value doesn't change. I recorded a video with a demonstration.

https://github.com/singerdmx/flutter-quill/assets/25247802/d3d36c3f-3ba2-402d-8afd-f2467d081556

Now, the value in the selector corresponds to the selected size of the particular text.

https://github.com/singerdmx/flutter-quill/assets/25247802/8743cdc7-bc45-447b-8153-297a76777809

If this change is accepted, I will make the same pr for Font Family.

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.