### PR TITLE
feat: Add checkBoxReadOnly property which can override readOnly for checkbox

### DIFF
--- a/lib/src/models/config/editor/editor_configurations.dart
+++ b/lib/src/models/config/editor/editor_configurations.dart
@@ -33,6 +33,7 @@ class QuillEditorConfigurations extends Equatable {
     this.expands = false,
     this.placeholder,
     this.readOnly = false,
+    this.checkBoxReadOnly,
     this.disableClipboard = false,
     this.textSelectionThemeData,
     this.showCursor,
@@ -96,6 +97,15 @@ class QuillEditorConfigurations extends Equatable {
   ///
   /// Defaults to `false`. Must not be `null`.
   final bool readOnly;
+
+  /// Override [readOnly] for checkbox.
+  ///
+  /// When this is set to `false`, the checkbox can be checked
+  /// or unchecked while [readOnly] is set to `true`.
+  /// When this is set to `null`, the [readOnly] value is used.
+  ///
+  /// Defaults to `null`.
+  final bool? checkBoxReadOnly;
 
   /// Disable Clipboard features
   ///
@@ -369,6 +379,7 @@ class QuillEditorConfigurations extends Equatable {
     QuillController? controller,
     String? placeholder,
     bool? readOnly,
+    bool? checkBoxReadOnly,
     bool? disableClipboard,
     bool? scrollable,
     double? scrollBottomInset,
@@ -421,6 +432,7 @@ class QuillEditorConfigurations extends Equatable {
       controller: controller ?? this.controller,
       placeholder: placeholder ?? this.placeholder,
       readOnly: readOnly ?? this.readOnly,
+      checkBoxReadOnly: checkBoxReadOnly ?? this.checkBoxReadOnly,
       disableClipboard: disableClipboard ?? this.disableClipboard,
       scrollable: scrollable ?? this.scrollable,
       scrollBottomInset: scrollBottomInset ?? this.scrollBottomInset,

--- a/lib/src/models/config/raw_editor/raw_editor_configurations.dart
+++ b/lib/src/models/config/raw_editor/raw_editor_configurations.dart
@@ -50,6 +50,7 @@ class QuillRawEditorConfigurations extends Equatable {
     this.scrollable = true,
     this.padding = EdgeInsets.zero,
     this.readOnly = false,
+    this.checkBoxReadOnly,
     this.disableClipboard = false,
     this.placeholder,
     this.onLaunchUrl,
@@ -103,6 +104,15 @@ class QuillRawEditorConfigurations extends Equatable {
   ///
   /// Defaults to false. Must not be null.
   final bool readOnly;
+
+  /// Override readOnly for checkbox.
+  ///
+  /// When this is set to false, the checkbox can be checked
+  /// or unchecked while readOnly is set to true.
+  /// When this is set to null, the readOnly value is used.
+  ///
+  /// Defaults to null.
+  final bool? checkBoxReadOnly;
 
   /// Disable Clipboard features
   ///

--- a/lib/src/widgets/editor/editor.dart
+++ b/lib/src/widgets/editor/editor.dart
@@ -235,6 +235,7 @@ class QuillEditorState extends State<QuillEditor>
               scrollBottomInset: configurations.scrollBottomInset,
               padding: configurations.padding,
               readOnly: configurations.readOnly,
+              checkBoxReadOnly: configurations.checkBoxReadOnly,
               disableClipboard: configurations.disableClipboard,
               placeholder: configurations.placeholder,
               onLaunchUrl: configurations.onLaunchUrl,

--- a/lib/src/widgets/quill/text_block.dart
+++ b/lib/src/widgets/quill/text_block.dart
@@ -74,6 +74,7 @@ class EditableTextBlock extends StatelessWidget {
     required this.clearIndents,
     required this.onCheckboxTap,
     required this.readOnly,
+    this.checkBoxReadOnly,
     this.onLaunchUrl,
     this.customStyleBuilder,
     this.customLinkPrefixes = const <String>[],
@@ -100,6 +101,7 @@ class EditableTextBlock extends StatelessWidget {
   final bool clearIndents;
   final Function(int, bool) onCheckboxTap;
   final bool readOnly;
+  final bool? checkBoxReadOnly;
   final List<String> customLinkPrefixes;
 
   @override
@@ -279,7 +281,7 @@ class EditableTextBlock extends StatelessWidget {
       return QuillEditorCheckboxPoint(
         size: fontSize,
         value: attrs[Attribute.list.key] == Attribute.checked,
-        enabled: !readOnly,
+        enabled: !(checkBoxReadOnly ?? readOnly),
         onChanged: (checked) => onCheckboxTap(line.documentOffset, checked),
         uiBuilder: defaultStyles.lists?.checkboxUIBuilder,
       );

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -998,7 +998,8 @@ class QuillRawEditorState extends EditorState
   void _handleCheckboxTap(int offset, bool value) {
     final requestKeyboardFocusOnCheckListChanged =
         widget.configurations.requestKeyboardFocusOnCheckListChanged;
-    if (!widget.configurations.readOnly) {
+    if (!(widget.configurations.checkBoxReadOnly ??
+        widget.configurations.readOnly)) {
       _disableScrollControllerAnimateOnce = true;
       final currentSelection = controller.selection.copyWith();
       final attribute = value ? Attribute.checked : Attribute.unchecked;
@@ -1074,6 +1075,7 @@ class QuillRawEditorState extends EditorState
           clearIndents: clearIndents,
           onCheckboxTap: _handleCheckboxTap,
           readOnly: widget.configurations.readOnly,
+          checkBoxReadOnly: widget.configurations.checkBoxReadOnly,
           customStyleBuilder: widget.configurations.customStyleBuilder,
           customLinkPrefixes: widget.configurations.customLinkPrefixes,
         );


### PR DESCRIPTION
## Description

This PR add `checkBoxReadOnly` property, which can override `readOnly` for checkbox. This allow checkbox to be checked or unchecked while `readOnly` is set to `true`.

## Related Issues

- *Related #1088*

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.