### PR TITLE
Fix typo in QuillHtmlConverter

### DIFF
--- a/quill_html_converter/lib/quill_html_converter.dart
+++ b/quill_html_converter/lib/quill_html_converter.dart
@@ -2,9 +2,9 @@ library quill_html_converter;
 
 import 'package:dart_quill_delta/dart_quill_delta.dart';
 import 'package:vsc_quill_delta_to_html/vsc_quill_delta_to_html.dart'
-    as conventer show ConverterOptions, QuillDeltaToHtmlConverter;
+    as converter show ConverterOptions, QuillDeltaToHtmlConverter;
 
-typedef ConverterOptions = conventer.ConverterOptions;
+typedef ConverterOptions = converter.ConverterOptions;
 
 /// A extension for [Delta] which comes from `flutter_quill` to extends
 /// the functionality of it to support converting the [Delta] to/from HTML
@@ -19,7 +19,7 @@ extension DeltaHtmlExt on Delta {
   /// that designed specifically for converting the quill delta to html
   String toHtml({ConverterOptions? options}) {
     final json = toJson();
-    final html = conventer.QuillDeltaToHtmlConverter(
+    final html = converter.QuillDeltaToHtmlConverter(
       List.castFrom(json),
       options,
     ).convert();


### PR DESCRIPTION
## Description

Fixes the typo in import of quill_html_converter.dart mentioned in [#1854](https://github.com/singerdmx/flutter-quill/issues/1854).

## Related Issues

- *Fix #1854*

## Checklist

- [X] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [X] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [X] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [X] All existing and new tests are passing.
- [X] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [X] No, this is *not* a breaking change.