### PR TITLE
feat: Add `readOnlyMouseCursor` to config mouse cursor type

### DIFF
--- a/lib/src/models/config/raw_editor/raw_editor_configurations.dart
+++ b/lib/src/models/config/raw_editor/raw_editor_configurations.dart
@@ -22,7 +22,8 @@ import 'package:flutter/widgets.dart'
         TextFieldTapRegion,
         TextSelectionControls,
         ValueChanged,
-        Widget;
+        Widget,
+        MouseCursor;
 import 'package:meta/meta.dart' show immutable;
 
 import '../../../widgets/others/cursor.dart';
@@ -173,6 +174,9 @@ class QuillRawEditorConfigurations extends Equatable {
 
   /// The style to be used for the editing cursor.
   final CursorStyle cursorStyle;
+
+  /// The [readOnlyMouseCursor] is used for Windows, macOS when [readOnly] is [true]
+  final MouseCursor readOnlyMouseCursor = SystemMouseCursors.text;
 
   /// Configures how the platform keyboard will select an uppercase or
   /// lowercase keyboard.

--- a/lib/src/models/config/raw_editor/raw_editor_configurations.dart
+++ b/lib/src/models/config/raw_editor/raw_editor_configurations.dart
@@ -23,7 +23,8 @@ import 'package:flutter/widgets.dart'
         TextSelectionControls,
         ValueChanged,
         Widget,
-        MouseCursor;
+        MouseCursor,
+        SystemMouseCursors;
 import 'package:meta/meta.dart' show immutable;
 
 import '../../../widgets/others/cursor.dart';

--- a/lib/src/widgets/raw_editor/raw_editor_render_object.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_render_object.dart
@@ -5,8 +5,9 @@ import '../../models/documents/document.dart';
 import '../editor/editor.dart';
 import '../others/cursor.dart';
 
-class QuilRawEditorMultiChildRenderObject extends MultiChildRenderObjectWidget {
-  const QuilRawEditorMultiChildRenderObject({
+class QuillRawEditorMultiChildRenderObject
+    extends MultiChildRenderObjectWidget {
+  const QuillRawEditorMultiChildRenderObject({
     required super.children,
     required this.document,
     required this.textDirection,

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -483,8 +483,10 @@ class QuillRawEditorState extends EditorState
             viewportBuilder: (_, offset) => CompositedTransformTarget(
               link: _toolbarLayerLink,
               child: MouseRegion(
-                cursor: SystemMouseCursors.text,
-                child: QuilRawEditorMultiChildRenderObject(
+                cursor: widget.configurations.readOnly
+                    ? widget.configurations.readOnlyMouseCursor
+                    : SystemMouseCursors.text,
+                child: QuillRawEditorMultiChildRenderObject(
                   key: _editorKey,
                   offset: offset,
                   document: doc,
@@ -515,8 +517,10 @@ class QuillRawEditorState extends EditorState
           link: _toolbarLayerLink,
           child: Semantics(
             child: MouseRegion(
-              cursor: SystemMouseCursors.text,
-              child: QuilRawEditorMultiChildRenderObject(
+              cursor: widget.configurations.readOnly
+                  ? widget.configurations.readOnlyMouseCursor
+                  : SystemMouseCursors.text,
+              child: QuillRawEditorMultiChildRenderObject(
                 key: _editorKey,
                 document: doc,
                 selection: controller.selection,


### PR DESCRIPTION
## Description

See #1752.

## Related Issues

Fix [Bug] Mouse cursor is still text insertion type when `readOnly` is `false` #1752

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.