### PR TITLE
fix: `readOnlyMouseCursor` losing in construction function

### DIFF
--- a/lib/src/models/config/editor/editor_configurations.dart
+++ b/lib/src/models/config/editor/editor_configurations.dart
@@ -80,6 +80,7 @@ class QuillEditorConfigurations extends Equatable {
     this.enableScribble = false,
     this.onScribbleActivated,
     this.scribbleAreaInsets,
+    this.readOnlyMouseCursor = SystemMouseCursors.text,
   });
 
   final QuillSharedConfigurations sharedConfigurations;
@@ -156,6 +157,9 @@ class QuillEditorConfigurations extends Equatable {
   /// The cursor refers to the blinking caret when the editor is focused.
   final bool? showCursor;
   final bool? paintCursorAboveText;
+
+  /// The [readOnlyMouseCursor] is used for Windows, macOS when [readOnly] is [true]
+  final MouseCursor readOnlyMouseCursor;
 
   /// Whether to enable user interface affordances for changing the
   /// text selection.

--- a/lib/src/models/config/raw_editor/raw_editor_configurations.dart
+++ b/lib/src/models/config/raw_editor/raw_editor_configurations.dart
@@ -85,6 +85,7 @@ class QuillRawEditorConfigurations extends Equatable {
     this.enableScribble = false,
     this.onScribbleActivated,
     this.scribbleAreaInsets,
+    this.readOnlyMouseCursor = SystemMouseCursors.text,
   });
 
   /// Controls the document being edited.
@@ -177,7 +178,7 @@ class QuillRawEditorConfigurations extends Equatable {
   final CursorStyle cursorStyle;
 
   /// The [readOnlyMouseCursor] is used for Windows, macOS when [readOnly] is [true]
-  final MouseCursor readOnlyMouseCursor = SystemMouseCursors.text;
+  final MouseCursor readOnlyMouseCursor;
 
   /// Configures how the platform keyboard will select an uppercase or
   /// lowercase keyboard.

--- a/lib/src/widgets/editor/editor.dart
+++ b/lib/src/widgets/editor/editor.dart
@@ -290,6 +290,7 @@ class QuillEditorState extends State<QuillEditor>
               enableScribble: configurations.enableScribble,
               onScribbleActivated: configurations.onScribbleActivated,
               scribbleAreaInsets: configurations.scribbleAreaInsets,
+              readOnlyMouseCursor: configurations.readOnlyMouseCursor,
             ),
           ),
         ),


### PR DESCRIPTION
## Description

Fix `readOnlyMouseCursor` losing in construction function

## Related Issues

- Related #1873

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.