### PR TITLE
Ci/update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,9 @@ jobs:
   publish:
     permissions:
       id-token: write
-      contents: write # For uploading to the release assets
+      # Give the default GITHUB_TOKEN write permission to commit and push the changed files to the repository.
+      # Also required for uploading files to the Release assets
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,6 +43,24 @@ jobs:
       ## dart-lang/setup-dart/.github/workflows/publish.yml@v1
       # - name: Update the authorization requests to "https://pub.dev" to use the environment variable "PUB_TOKEN".
       #   run: dart pub token add https://pub.dev --env-var PUB_TOKEN
+
+      # TODO: We might automate updating the CHANGELOG.md for all the packages too
+      # Before publishing the new packages, update the version for all the packages first
+
+      # Extract version from the tag (handles optional 'v' prefix)
+      - name: Extract version
+        id: extract_version
+        run: |
+          version=$(echo ${GITHUB_REF} | sed 's/^refs\/tags\/\(.*\)$/\1/')
+          echo ::set-output name=VERSION::${version}
+
+      - name: Update the version for all the packages
+        run: ./scripts/regenerate_versions.dart ${{ steps.extract_version.outputs.VERSION }}
+
+      - name: Commit the changes of updating version for all the packages
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore(version): update to version ${{ steps.extract_version.outputs.VERSION }}"
 
       - name: Publish flutter_quill
         run: flutter pub publish --force

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
       # - name: Update the authorization requests to "https://pub.dev" to use the environment variable "PUB_TOKEN".
       #   run: dart pub token add https://pub.dev --env-var PUB_TOKEN
 
-      # TODO: We might automate updating the CHANGELOG.md for all the packages too (update development_notes.md too if you did)
+      # TODO: We might automate updating the CHANGELOG.md for all the packages too (update Development notes too if you did)
       # Before publishing the new packages, update the version for all the packages first
 
       # Extract version from the tag (handles optional 'v' prefix)
@@ -57,7 +57,7 @@ jobs:
       - name: Update the version & CHANGELOG for all the packages
         run: ./scripts/regenerate_versions.dart ${{ steps.extract_version.outputs.VERSION }}
 
-      - name: Commit the changes of updating version & CHANGELOG for all the packages
+      - name: Commit the changes of the updated version & CHANGELOG for all the packages
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore(version): update to version ${{ steps.extract_version.outputs.VERSION }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
       # - name: Update the authorization requests to "https://pub.dev" to use the environment variable "PUB_TOKEN".
       #   run: dart pub token add https://pub.dev --env-var PUB_TOKEN
 
-      # TODO: We might automate updating the CHANGELOG.md for all the packages too
+      # TODO: We might automate updating the CHANGELOG.md for all the packages too (update development_notes.md too if you did)
       # Before publishing the new packages, update the version for all the packages first
 
       # Extract version from the tag (handles optional 'v' prefix)
@@ -54,10 +54,10 @@ jobs:
           version=$(echo ${GITHUB_REF} | sed 's/^refs\/tags\/\(.*\)$/\1/')
           echo ::set-output name=VERSION::${version}
 
-      - name: Update the version for all the packages
+      - name: Update the version & CHANGELOG for all the packages
         run: ./scripts/regenerate_versions.dart ${{ steps.extract_version.outputs.VERSION }}
 
-      - name: Commit the changes of updating version for all the packages
+      - name: Commit the changes of updating version & CHANGELOG for all the packages
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore(version): update to version ${{ steps.extract_version.outputs.VERSION }}"

--- a/doc/development_notes.md
+++ b/doc/development_notes.md
@@ -1,9 +1,8 @@
 # Development notes
 
 - When updating the translations or localizations in the app, please take a look at the [Translation](./translation.md) page as it has important notes in order to work, if you also add a feature that adds new localizations then you need to the instructions of it in order for the translations to take effect
-- Only update the `version.dart` and `CHANGELOG.md` at the root folder of the repo, then run the script:
+- We use the same package version and `CHANGELOG.md` for all the packages, for more [details](https://github.com/singerdmx/flutter-quill/pull/1878), the process is automated. We have a script that will do the followings:
+    1. Copy the contents of the root `CHANGELOG.md` file into all the `CHANGELOG.md` of the packages (overwrite), you need to mention the changes of all the packages in the `CHANGELOG.md` of the root folder as it will be copied, we still have to mention the new changes in the `CHANGELOG.md` and update it as it's not automated yet.
+    2. The script require the new version as an argument, you don't need to run the script manually, when a maintainer create a new tag and publish a new GitHub release, the publish workflow will extract the new version from the tag name, run the script (pass the extracted version as an argument), commit the changes and push them into the repository, the script will update the `version` property for all the packages so the `flutter pub publish` will use the new version for each package correctly.
 
-    ```console
-    dart ./scripts/regenerate_versions.dart
-    ```
-    You must mention the changes of the other packages in the repo in the root `CHANGELOG.md` only and the script will replace the `CHANGELOG.md` in the other packages with the root one, and change the version in `pubspec.yaml` with the one in `version.dart` in the root folder
+    the script will be used the CI and no need to run it manually

--- a/version.dart
+++ b/version.dart
@@ -1,1 +1,0 @@
-const version = '9.3.13';


### PR DESCRIPTION
## Description

Since we split some of the code into different packages instead of one package, we had to update the way we publish the packages and automate it when possible, previously we had a different version for both `flutter_quill` and `flutter_quill_extensions`, while this approach gives us more flexibility, it's not clear which version of `flutter_quill_extensions` is compatible with a specific version of `flutter_quill` so we need a table for the compatible versions in the `README.md` or somewhere else, using a different version for each package will also require a different Github repository for each package to automate the publishing with Github releases, the solution we use instead is to have one universal version and `CHANGELOG.md` for all the packages which make things easier but require a little bit more setup from the maintainers side, before this PR, we have to update the version in the `version.dart` file, run a script which will update all the version and CHANGELOG (will use the root CHANGELOG.md file for all the packages) for all the packages we have, while there are other solutions and CLI tools but it require the maintainers and contributors to install them using dart pub command globally, so we had to do it in more quick and manual way, this PR make things a little bit easier:

- The script that is used to update the version no longer needs `version.dart`, it will require the version in the argument and it's no longer needed to run the script by the maintainers and commit the changes and push them before releasing a new version, the `publish.yml` workflow will automate that process by running the script and pass the version from the version that is used in GitHub releases (from the tag name and not the release name), so the script is only needed from the GitHub `publish.yml` workflow
- At the moment, the script or the CI will not automate the process of generating the `CHANGELOG.md` changes (it's possible but that would require all the developers who send PRs to use a descriptive title for the PR since it will be used for the CHANGELOG files), we still have to do it manually but only for the `CHANGELOG.md` at the root folder, the script that is used in the CI will also copy the contents of the `CHANGELOG.md` file and overwrite them into the sub-packages (`flutter_quill_extensions`, `flutter_quill_test`), we might update in the future

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.