### PR TITLE
restore insert check for blocked keys

### DIFF
--- a/lib/src/models/rules/insert.dart
+++ b/lib/src/models/rules/insert.dart
@@ -565,8 +565,9 @@ class PreserveInlineStylesRule extends InsertRule {
 
     if ((prev.data as String).endsWith('\n')) {
       if (prev.attributes != null) {
-        for (final value in prev.attributes!.values) {
-          if (!(value as Attribute).isInline) {
+        for (final key in prev.attributes!.keys) {
+          if (Attribute.blockKeys.contains(key) ||
+              !(prev.attributes![key] as Attribute).isInline) {
             return null;
           }
         }


### PR DESCRIPTION
## Description

A previous check in introduced an error when inserting text into a list on the 2nd (and subsequent) line of the list.  It is incorrectly assuming previous attributes are of type Attribute, where some are of type String.

This is *not* a breaking change.