### PR TITLE
fix: assertion failure for swipe typing and undo on Android

### DIFF
--- a/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -141,8 +141,10 @@ mixin RawEditorStateTextInputClientMixin on EditorState
     // with the last known remote value.
     // It is important to prevent excessive remote updates as it can cause
     // race conditions.
+    final composingRange = _lastKnownRemoteTextEditingValue!.composing;
     final actualValue = value.copyWith(
-      composing: _lastKnownRemoteTextEditingValue!.composing,
+      // Ignore last known composing range if it exceeds current text length.
+      composing: composingRange.end > value.text.length ? null : composingRange,
     );
 
     if (actualValue == _lastKnownRemoteTextEditingValue) {


### PR DESCRIPTION
## Description

This PR fixes issue #1884.

## Related Issues

- Fix #1884

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.