### PR TITLE
feat(clipboard): allow pasting markdown and html files from the system to the editor

### DIFF
--- a/flutter_quill_extensions/lib/services/clipboard/super_clipboard_service.dart
+++ b/flutter_quill_extensions/lib/services/clipboard/super_clipboard_service.dart
@@ -34,8 +34,9 @@ class SuperClipboardService implements ClipboardService {
     return reader.canProvide(format);
   }
 
-  Future<Uint8List> _provideFileAsBytes(
-      {required SimpleFileFormat format}) async {
+  Future<Uint8List> _provideFileAsBytes({
+    required SimpleFileFormat format,
+  }) async {
     final clipboard = _getSuperClipboardOrThrow();
     final reader = await clipboard.read();
     final completer = Completer<Uint8List>();

--- a/flutter_quill_extensions/lib/services/clipboard/super_clipboard_service.dart
+++ b/flutter_quill_extensions/lib/services/clipboard/super_clipboard_service.dart
@@ -41,10 +41,14 @@ class SuperClipboardService implements ClipboardService {
     final reader = await clipboard.read();
     final completer = Completer<Uint8List>();
 
-    reader.getFile(format, (file) async {
-      final bytes = await file.readAll();
-      completer.complete(bytes);
-    });
+    reader.getFile(
+      format,
+      (file) async {
+        final bytes = await file.readAll();
+        completer.complete(bytes);
+      },
+      onError: completer.completeError,
+    );
     final bytes = await completer.future;
     return bytes;
   }

--- a/flutter_quill_extensions/lib/services/clipboard/super_clipboard_service.dart
+++ b/flutter_quill_extensions/lib/services/clipboard/super_clipboard_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async' show Completer;
+import 'dart:convert' show utf8;
 
 import 'package:flutter/foundation.dart';
 // ignore: implementation_imports
@@ -13,6 +14,17 @@ class SuperClipboardService implements ClipboardService {
     return SystemClipboard.instance;
   }
 
+  SystemClipboard _getSuperClipboardOrThrow() {
+    final clipboard = _getSuperClipboard();
+    if (clipboard == null) {
+      // To avoid getting this exception, use _canProvide()
+      throw UnsupportedError(
+        'Clipboard API is not supported on this platform.',
+      );
+    }
+    return clipboard;
+  }
+
   Future<bool> _canProvide({required DataFormat format}) async {
     final clipboard = _getSuperClipboard();
     if (clipboard == null) {
@@ -22,14 +34,9 @@ class SuperClipboardService implements ClipboardService {
     return reader.canProvide(format);
   }
 
-  Future<Uint8List> _provideFileAsBytes({required FileFormat format}) async {
-    final clipboard = _getSuperClipboard();
-    if (clipboard == null) {
-      // To avoid getting this exception, use _canProvide()
-      throw UnsupportedError(
-        'Clipboard API is not supported on this platform.',
-      );
-    }
+  Future<Uint8List> _provideFileAsBytes(
+      {required SimpleFileFormat format}) async {
+    final clipboard = _getSuperClipboardOrThrow();
     final reader = await clipboard.read();
     final completer = Completer<Uint8List>();
 
@@ -41,21 +48,79 @@ class SuperClipboardService implements ClipboardService {
     return bytes;
   }
 
+  Future<String> _provideFileAsString({
+    required SimpleFileFormat format,
+  }) async {
+    final fileBytes = await _provideFileAsBytes(format: format);
+    final fileText = utf8.decode(fileBytes);
+    return fileText;
+  }
+
   /// According to super_clipboard docs, will return `null` if the value
   /// is not available or the data is virtual (macOS and Windows)
   Future<String?> _provideSimpleValueFormatAsString({
     required SimpleValueFormat<String> format,
   }) async {
-    final clipboard = _getSuperClipboard();
-    if (clipboard == null) {
-      // To avoid getting this exception, use _canProvide()
-      throw UnsupportedError(
-        'Clipboard API is not supported on this platform.',
-      );
-    }
+    final clipboard = _getSuperClipboardOrThrow();
     final reader = await clipboard.read();
     final value = await reader.readValue<String>(format);
     return value;
+  }
+
+  @override
+  Future<bool> canProvideHtmlText() {
+    return _canProvide(format: Formats.htmlText);
+  }
+
+  @override
+  Future<String?> getHtmlText() {
+    return _provideSimpleValueFormatAsString(format: Formats.htmlText);
+  }
+
+  @override
+  Future<bool> canProvideHtmlTextFromFile() {
+    return _canProvide(format: Formats.htmlFile);
+  }
+
+  @override
+  Future<String?> getHtmlTextFromFile() {
+    return _provideFileAsString(format: Formats.htmlFile);
+  }
+
+  @override
+  Future<bool> canProvideMarkdownText() async {
+    // Formats.markdownText or Formats.mdText does not exist yet in super_clipboard
+    return false;
+  }
+
+  @override
+  Future<String?> getMarkdownText() async {
+    // Formats.markdownText or Formats.mdText does not exist yet in super_clipboard
+    throw UnsupportedError(
+      'SuperClipboardService does not support retrieving image files.',
+    );
+  }
+
+  @override
+  Future<bool> canProvideMarkdownTextFromFile() async {
+    // Formats.md is for markdown files
+    return _canProvide(format: Formats.md);
+  }
+
+  @override
+  Future<String?> getMarkdownTextFromFile() async {
+    // Formats.md is for markdown files
+    return _provideFileAsString(format: Formats.md);
+  }
+
+  @override
+  Future<bool> canProvidePlainText() {
+    return _canProvide(format: Formats.plainText);
+  }
+
+  @override
+  Future<String?> getPlainText() {
+    return _provideSimpleValueFormatAsString(format: Formats.plainText);
   }
 
   /// This will need to be updated if [getImageFileAsBytes] updated.
@@ -82,26 +147,6 @@ class SuperClipboardService implements ClipboardService {
       return _provideFileAsBytes(format: Formats.png);
     }
     return _provideFileAsBytes(format: Formats.jpeg);
-  }
-
-  @override
-  Future<bool> canProvidePlainText() {
-    return _canProvide(format: Formats.plainText);
-  }
-
-  @override
-  Future<String?> getPlainText() {
-    return _provideSimpleValueFormatAsString(format: Formats.plainText);
-  }
-
-  @override
-  Future<bool> canProvideHtmlText() {
-    return _canProvide(format: Formats.htmlText);
-  }
-
-  @override
-  Future<String?> getHtmlText() {
-    return _provideSimpleValueFormatAsString(format: Formats.htmlText);
   }
 
   @override

--- a/lib/src/models/documents/delta_x.dart
+++ b/lib/src/models/documents/delta_x.dart
@@ -6,43 +6,35 @@ import '../../../markdown_quill.dart';
 import '../../../quill_delta.dart';
 
 @immutable
+@experimental
 class DeltaX {
+  const DeltaX._();
+
+  /// Convert Markdown text to [Delta]
+  ///
+  /// This api is **experimental** and designed to be used **internally** and shouldn't
+  /// used for **production applications**.
+  @experimental
+  static Delta fromMarkdown(String markdownText) {
+    final mdDocument = md.Document(encodeHtml: false);
+    final mdToDelta = MarkdownToDelta(markdownDocument: mdDocument);
+    return mdToDelta.convert(markdownText);
+  }
+
   /// Convert the HTML Raw string to [Delta]
   ///
   /// It will run using the following steps:
   ///
   /// 1. Convert the html to markdown string using `html2md` package
-  /// 2. Convert the markdown string to quill delta json string
-  /// 3. Decode the delta json string to [Delta]
+  /// 2. Convert the markdown string to [Delta] using [fromMarkdown]
   ///
-  /// for more [info](https://github.com/singerdmx/flutter-quill/issues/1100)
-  ///
-  /// Please notice that this api is designed to be used internally and shouldn't
-  /// used for real world applications
+  /// This api is **experimental** and designed to be used **internally** and shouldn't
+  /// used for **production applications**.
   ///
   @experimental
-  static Delta fromHtml(String html) {
-    final markdown = html2md
-        .convert(
-          html,
-        )
-        .replaceAll('unsafe:', '');
+  static Delta fromHtml(String htmlText) {
+    final markdownText = html2md.convert(htmlText).replaceAll('unsafe:', '');
 
-    final mdDocument = md.Document(encodeHtml: false);
-
-    final mdToDelta = MarkdownToDelta(markdownDocument: mdDocument);
-
-    return mdToDelta.convert(markdown);
-
-    // final deltaJsonString = markdownToDelta(markdown);
-    // final deltaJson = jsonDecode(deltaJsonString);
-    // if (deltaJson is! List) {
-    //   throw ArgumentError(
-    //     'The delta json string should be of type list when jsonDecode() it',
-    //   );
-    // }
-    // return Delta.fromJson(
-    //   deltaJson,
-    // );
+    return fromMarkdown(markdownText);
   }
 }

--- a/lib/src/services/clipboard/clipboard_service.dart
+++ b/lib/src/services/clipboard/clipboard_service.dart
@@ -4,7 +4,32 @@ import 'package:flutter/foundation.dart';
 @immutable
 abstract class ClipboardService {
   Future<bool> canProvideHtmlText();
+
+  /// Get Clipboard content as Html Text, this is platform specific and not the
+  /// same as [getPlainText] for two reasons:
+  /// 1. The user might want to paste Html text
+  /// 2. Copying Html text from other apps and use [getPlainText] will ignore
+  /// the Html content and provide it as text
   Future<String?> getHtmlText();
+
+  Future<bool> canProvideHtmlTextFromFile();
+
+  /// Get the Html file in the Clipboard from the system
+  Future<String?> getHtmlTextFromFile();
+
+  Future<bool> canProvideMarkdownText();
+
+  /// Get Clipboard content as Markdown Text, this is platform specific and not the
+  /// same as [getPlainText] for two reasons:
+  /// 1. The user might want to paste Markdown text
+  /// 2. Copying Markdown text from other apps and use [getPlainText] will ignore
+  /// the Markdown content and provide it as text
+  Future<String?> getMarkdownText();
+
+  Future<bool> canProvideMarkdownTextFromFile();
+
+  /// Get the Markdown file in the Clipboard from the system
+  Future<String?> getMarkdownTextFromFile();
 
   Future<bool> canProvidePlainText();
   Future<String?> getPlainText();

--- a/lib/src/services/clipboard/default_clipboard_service.dart
+++ b/lib/src/services/clipboard/default_clipboard_service.dart
@@ -5,31 +5,8 @@ import 'clipboard_service.dart';
 /// Default implementation using only internal flutter plugins
 class DefaultClipboardService implements ClipboardService {
   @override
-  Future<bool> canProvideGifFile() async {
-    return false;
-  }
-
-  @override
   Future<bool> canProvideHtmlText() async {
     return false;
-  }
-
-  @override
-  Future<bool> canProvideImageFile() async {
-    return false;
-  }
-
-  @override
-  Future<bool> canProvidePlainText() async {
-    final plainText = (await Clipboard.getData(Clipboard.kTextPlain))?.text;
-    return plainText == null;
-  }
-
-  @override
-  Future<Uint8List> getGifFileAsBytes() {
-    throw UnsupportedError(
-      'DefaultClipboardService does not support retrieving GIF files.',
-    );
   }
 
   @override
@@ -40,6 +17,59 @@ class DefaultClipboardService implements ClipboardService {
   }
 
   @override
+  Future<bool> canProvideHtmlTextFromFile() async {
+    return false;
+  }
+
+  @override
+  Future<String?> getHtmlTextFromFile() {
+    throw UnsupportedError(
+      'DefaultClipboardService does not support retrieving HTML files.',
+    );
+  }
+
+  @override
+  Future<bool> canProvideMarkdownText() async {
+    return false;
+  }
+
+  @override
+  Future<String?> getMarkdownText() {
+    throw UnsupportedError(
+      'DefaultClipboardService does not support retrieving HTML files.',
+    );
+  }
+
+  @override
+  Future<bool> canProvideMarkdownTextFromFile() async {
+    return false;
+  }
+
+  @override
+  Future<String?> getMarkdownTextFromFile() {
+    throw UnsupportedError(
+      'DefaultClipboardService does not support retrieving Markdown text.',
+    );
+  }
+
+  @override
+  Future<bool> canProvidePlainText() async {
+    final plainText = (await Clipboard.getData(Clipboard.kTextPlain))?.text;
+    return plainText == null;
+  }
+
+  @override
+  Future<String?> getPlainText() async {
+    final plainText = (await Clipboard.getData(Clipboard.kTextPlain))?.text;
+    return plainText;
+  }
+
+  @override
+  Future<bool> canProvideImageFile() async {
+    return false;
+  }
+
+  @override
   Future<Uint8List> getImageFileAsBytes() {
     throw UnsupportedError(
       'DefaultClipboardService does not support retrieving image files.',
@@ -47,9 +77,15 @@ class DefaultClipboardService implements ClipboardService {
   }
 
   @override
-  Future<String?> getPlainText() async {
-    final plainText = (await Clipboard.getData(Clipboard.kTextPlain))?.text;
-    return plainText;
+  Future<bool> canProvideGifFile() async {
+    return false;
+  }
+
+  @override
+  Future<Uint8List> getGifFileAsBytes() {
+    throw UnsupportedError(
+      'DefaultClipboardService does not support retrieving GIF files.',
+    );
   }
 
   @override

--- a/lib/src/widgets/quill/quill_controller.dart
+++ b/lib/src/widgets/quill/quill_controller.dart
@@ -507,12 +507,14 @@ class QuillController extends ChangeNotifier {
   Future<bool> clipboardPaste({void Function()? updateEditor}) async {
     if (readOnly || !selection.isValid) return true;
 
-    if (await _pasteHTML()) {
+    final pasteUsingHtmlSuccess = await _pasteHTML();
+    if (pasteUsingHtmlSuccess) {
       updateEditor?.call();
       return true;
     }
 
-    if (await _pasteMarkdown()) {
+    final pasteUsingMarkdownSuccess = await _pasteMarkdown();
+    if (pasteUsingMarkdownSuccess) {
       updateEditor?.call();
       return true;
     }


### PR DESCRIPTION
## Description

*Allow pasting markdown and HTML files into the editor from the system files.*

At the moment, if you try to copy a file from the system on the desktop, and paste it into the editor, you will get the file name, this PR aims to use `super_clipboard` and existing Markdown & HTML converting functionality

Even though this is not directly related to this PR, Markdown, and HTML converting from and to Delta are **currently far from perfect**, the current implementation could improved a lot however **it will likely not work like expected**, due to differences between Html and Delta, see this [comment](https://github.com/slab/quill/issues/1551#issuecomment-311458570) for more info.

If the Markdown and HTML implementation improved or changed, no changes are required to `QuillController`

The following example for copying Markdown file:

<details>
<summary>Before</summary>

![image](https://github.com/singerdmx/flutter-quill/assets/73608287/03f5ae20-796c-4e8b-8668-09a994211c1e)

</details>

<details>
<summary>After</summary>

![image](https://github.com/singerdmx/flutter-quill/assets/73608287/7e3a1987-36e7-4665-944a-add87d24e788)

</details>

This PR also includes changes that are not related such as the use of `onError` callback from `super_clipboard` in `SuperClipboardService` implementation

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.