### PR TITLE
replace base64 regex string

### DIFF
--- a/flutter_quill_extensions/lib/utils/patterns.dart
+++ b/flutter_quill_extensions/lib/utils/patterns.dart
@@ -1,5 +1,7 @@
 RegExp base64RegExp = RegExp(
-  r'^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$',
+  // Change the Regex String due to app crash on relase mode when the base64 string is too long
+  // r'^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$',
+    r'^(?:[A-Za-z0-9+\/][A-Za-z0-9+\/][A-Za-z0-9+\/][A-Za-z0-9+\/])*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$',
 );
 
 final imageRegExp = RegExp(

--- a/flutter_quill_extensions/lib/utils/patterns.dart
+++ b/flutter_quill_extensions/lib/utils/patterns.dart
@@ -1,7 +1,5 @@
 RegExp base64RegExp = RegExp(
-  // Change the Regex String due to app crash on relase mode when the base64 string is too long
-  // r'^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$',
-    r'^(?:[A-Za-z0-9+\/][A-Za-z0-9+\/][A-Za-z0-9+\/][A-Za-z0-9+\/])*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$',
+  r'^(?:[A-Za-z0-9+\/][A-Za-z0-9+\/][A-Za-z0-9+\/][A-Za-z0-9+\/])*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$',
 );
 
 final imageRegExp = RegExp(


### PR DESCRIPTION
Update Base64 Regex Pattern for Improved Stability: This pull request addresses a critical issue where the application crashes in release mode during base64 string validation. By modifying the Base64 regex pattern from 
r'^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$' 
to 
r'^(?:[A-Za-z0-9+\/][A-Za-z0-9+\/][A-Za-z0-9+\/][A-Za-z0-9+\/])*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$', 
I ensure a more robust validation process. This adjustment prevents the application from crashing while performing base64 string validation in release mode, enhancing overall stability. Make sure to review and approve this change promptly to avoid any further disruptions in production.