### PR TITLE
Respect autofocus, closes #1923

### DIFF
--- a/lib/src/widgets/editor/editor.dart
+++ b/lib/src/widgets/editor/editor.dart
@@ -173,7 +173,9 @@ class QuillEditorState extends State<QuillEditor>
   void initState() {
     super.initState();
     widget.configurations.controller.editorFocusNode ??= widget.focusNode;
-    widget.configurations.controller.editorFocusNode?.requestFocus();
+    if (configurations.autoFocus) {
+      widget.configurations.controller.editorFocusNode?.requestFocus();
+    }
     _editorKey = configurations.editorKey ?? GlobalKey<EditorState>();
     _selectionGestureDetectorBuilder =
         _QuillEditorSelectionGestureDetectorBuilder(


### PR DESCRIPTION
## Description

With this change, the autofocus property in the configuration is respected.

## Related Issues

- *Fix #1923*

## Checklist

- [X] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [X] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [X] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [X] All existing and new tests are passing.
- [X] I have run the commands in `./scripts/before_push.sh` and it all passed successfully
## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [X] No, this is *not* a breaking change.