### PR TITLE
Fix: setState() called after dispose(): QuillToolbarClipboardButtonState #1895

### DIFF
--- a/lib/src/widgets/toolbar/base_button/base_value_button.dart
+++ b/lib/src/widgets/toolbar/base_button/base_value_button.dart
@@ -84,6 +84,7 @@ abstract class QuillToolbarBaseButtonState<
   }
 
   void didChangeEditingValue() {
+    if (!mounted) return;
     setState(() => currentValue = currentStateValue);
   }
 


### PR DESCRIPTION

## Description
1. put below code int PageView
```
Container(
  width: double.infinity,
  decoration: BoxDecoration(
    color: AppTheme.editorToolbarColor,
    borderRadius: BorderRadius.vertical(top: Radius.circular(5.ss)),
  ),
  child: QuillToolbar.simple(
    configurations: QuillSimpleToolbarConfigurations(
      controller: controller.quillController,
      sharedConfigurations: const QuillSharedConfigurations(),
      toolbarIconAlignment: WrapAlignment.start,
      fontSizesValues: controller.fontSizesMap,
      // color: AppStyle.cTextLight,
      // sectionDividerColor: AppStyle.cTextLight,
    ),
  ),
),
DecoratedBox(
  decoration: BoxDecoration(
    color: AppTheme.editorBgColor,
    borderRadius: BorderRadius.vertical(bottom: Radius.circular(5.ss)),
  ),
  child: QuillEditor.basic(
    configurations: QuillEditorConfigurations(
      controller: controller.quillController,
      sharedConfigurations: const QuillSharedConfigurations(
        locale: Locale('zh'),
      ),
      padding: EdgeInsets.all(20.ss),
      minHeight: 400.ss,
      maxHeight: 1000.ss,
      customStyles:
          DefaultStyles.getInstance(Go.context!).merge(defaultStyles),
    ),
  ),
),
```
2. switch PageView to another view, then back to quil view.
report error 
```
flutter: │ setState() called after dispose(): QuillToolbarClipboardButtonState#52b68(lifecycle state: defunct, not mounted)
flutter: │ This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback.
flutter: │ The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
flutter: │ This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().
flutter: 
flutter: │ #0   State.setState.<anonymous closure> (package:flutter/src/widgets/framework.dart:1167:9)
flutter: │ #1   State.setState (package:flutter/src/widgets/framework.dart:1202:6)
flutter: │ #2   QuillToolbarBaseButtonState.didChangeEditingValue (package:flutter_quill/src/widgets/toolbar/base_button/base_value_button.dart:88:5)
flutter: │ #3   QuillToolbarClipboardButtonState._listenClipboardStatus (package:flutter_quill/src/widgets/toolbar/buttons/clipboard_button.dart:68:36)
flutter: │ #4   ClipboardMonitor._update (package:flutter_quill/src/widgets/toolbar/buttons/clipboard_button.dart:33:15)
flutter: │ #5   <asynchronous suspension>
```

## Related Issues

- *Fix #1895

## Improvements
<!-- Optional -->

## Features
<!-- Optional -->

## Additional notes
<!-- Optional -->

## Suggestions
<!-- Optional -->

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.