### PR TITLE
fix: Enabled link regex to be overridden

### DIFF
--- a/lib/src/models/rules/insert.dart
+++ b/lib/src/models/rules/insert.dart
@@ -371,18 +371,18 @@ class AutoFormatMultipleLinksRule extends InsertRule {
       r'https?:\/\/[\w\-]+(\.[\w\-]+)*(:\d+)?(\/[^\s]*)?';
 
   /// It requires a valid link in one link
-  static final oneLineLinkRegExp = RegExp(
+  RegExp get oneLineLinkRegExp => RegExp(
     _oneLineLinkPattern,
     caseSensitive: false,
   );
 
   /// It detect if there is a link in the text whatever if it in the middle etc
   // Used to solve bug https://github.com/singerdmx/flutter-quill/issues/1432
-  static final detectLinkRegExp = RegExp(
+  RegExp get detectLinkRegExp => RegExp(
     _detectLinkPattern,
     caseSensitive: false,
   );
-  static final linkRegExp = oneLineLinkRegExp;
+  RegExp get linkRegExp => oneLineLinkRegExp;
 
   @override
   Delta? applyRule(

--- a/lib/src/models/rules/insert.dart
+++ b/lib/src/models/rules/insert.dart
@@ -372,16 +372,16 @@ class AutoFormatMultipleLinksRule extends InsertRule {
 
   /// It requires a valid link in one link
   RegExp get oneLineLinkRegExp => RegExp(
-    _oneLineLinkPattern,
-    caseSensitive: false,
-  );
+        _oneLineLinkPattern,
+        caseSensitive: false,
+      );
 
   /// It detect if there is a link in the text whatever if it in the middle etc
   // Used to solve bug https://github.com/singerdmx/flutter-quill/issues/1432
   RegExp get detectLinkRegExp => RegExp(
-    _detectLinkPattern,
-    caseSensitive: false,
-  );
+        _detectLinkPattern,
+        caseSensitive: false,
+      );
   RegExp get linkRegExp => oneLineLinkRegExp;
 
   @override

--- a/lib/src/widgets/toolbar/buttons/link_style2_button.dart
+++ b/lib/src/widgets/toolbar/buttons/link_style2_button.dart
@@ -413,7 +413,9 @@ class _LinkStyleDialogState extends State<LinkStyleDialog> {
 
   String? _validateLink(String? value) {
     if ((value?.isEmpty ?? false) ||
-        !const AutoFormatMultipleLinksRule().oneLineLinkRegExp.hasMatch(value!)) {
+        !const AutoFormatMultipleLinksRule()
+            .oneLineLinkRegExp
+            .hasMatch(value!)) {
       return widget.validationMessage ?? 'That is not a valid URL';
     }
 

--- a/lib/src/widgets/toolbar/buttons/link_style2_button.dart
+++ b/lib/src/widgets/toolbar/buttons/link_style2_button.dart
@@ -413,7 +413,7 @@ class _LinkStyleDialogState extends State<LinkStyleDialog> {
 
   String? _validateLink(String? value) {
     if ((value?.isEmpty ?? false) ||
-        !AutoFormatMultipleLinksRule.oneLineLinkRegExp.hasMatch(value!)) {
+        !const AutoFormatMultipleLinksRule().oneLineLinkRegExp.hasMatch(value!)) {
       return widget.validationMessage ?? 'That is not a valid URL';
     }
 

--- a/lib/src/widgets/toolbar/buttons/link_style_button.dart
+++ b/lib/src/widgets/toolbar/buttons/link_style_button.dart
@@ -196,7 +196,7 @@ class _LinkDialogState extends State<_LinkDialog> {
   late String _text;
 
   RegExp get linkRegExp {
-    return widget.linkRegExp ?? AutoFormatMultipleLinksRule.oneLineLinkRegExp;
+    return widget.linkRegExp ?? const AutoFormatMultipleLinksRule().oneLineLinkRegExp;
   }
 
   late TextEditingController _linkController;

--- a/lib/src/widgets/toolbar/buttons/link_style_button.dart
+++ b/lib/src/widgets/toolbar/buttons/link_style_button.dart
@@ -196,7 +196,8 @@ class _LinkDialogState extends State<_LinkDialog> {
   late String _text;
 
   RegExp get linkRegExp {
-    return widget.linkRegExp ?? const AutoFormatMultipleLinksRule().oneLineLinkRegExp;
+    return widget.linkRegExp ??
+        const AutoFormatMultipleLinksRule().oneLineLinkRegExp;
   }
 
   late TextEditingController _linkController;


### PR DESCRIPTION
## Description

In response to [issue #1860](https://github.com/singerdmx/flutter-quill/issues/1860), I would like the ability to override the regex in AutoFormatMultipleLinksRule. This would allow me to add a custom rule using document.setCustomRules and keep the logic from AutoFormatMultipleLinksRule.

## Related Issues

https://github.com/singerdmx/flutter-quill/issues/1860.

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.