### PR TITLE
fix: color picker hex unfocus on web

### DIFF
--- a/lib/src/widgets/toolbar/buttons/color/color_dialog.dart
+++ b/lib/src/widgets/toolbar/buttons/color/color_dialog.dart
@@ -54,6 +54,7 @@ class ColorPickerDialogState extends State<ColorPickerDialog> {
       actions: [
         TextButton(
             onPressed: () {
+              widget.onRequestChangeColor(context, selectedColor);
               Navigator.of(context).pop();
             },
             child: Text(context.loc.ok)),
@@ -123,8 +124,6 @@ class ColorPickerDialogState extends State<ColorPickerDialog> {
                         controller: hexController,
                         onChanged: (value) {
                           selectedColor = hexToColor(value);
-                          widget.onRequestChangeColor(context, selectedColor);
-
                           colorBoxSetState(() {});
                         },
                         decoration: InputDecoration(


### PR DESCRIPTION
## Description

#1894  In Web, the Hex field that is shown in the color picker dialog isn't working properly.

## Related Issues

Fix #1894 


## Improvements
<!-- Optional -->

## Features
<!-- Optional -->

## Additional notes
<!-- Optional -->

## Suggestions
<!-- Optional -->

## Checklist

- [ ] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ ] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [ ] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.