### PR TITLE
fix(editor): implement editor shortcut action for home and end keys to fix exception about unimplemented ScrollToDocumentBoundaryIntent

### DIFF
--- a/lib/src/widgets/raw_editor/raw_editor_actions.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_actions.dart
@@ -578,9 +578,9 @@ class QuillEditorInsertEmbedIntent extends Intent {
   final Attribute type;
 }
 
-class QuillEditorUpdateCursorLocationAction
+class UpdateCursorLocationAction
     extends ContextAction<ScrollToDocumentBoundaryIntent> {
-  QuillEditorUpdateCursorLocationAction(this.state);
+  UpdateCursorLocationAction(this.state);
 
   final QuillRawEditorState state;
 

--- a/lib/src/widgets/raw_editor/raw_editor_actions.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_actions.dart
@@ -578,9 +578,9 @@ class QuillEditorInsertEmbedIntent extends Intent {
   final Attribute type;
 }
 
-class UpdateCursorLocationAction
+class NavigateToDocumentBoundaryAction
     extends ContextAction<ScrollToDocumentBoundaryIntent> {
-  UpdateCursorLocationAction(this.state);
+  NavigateToDocumentBoundaryAction(this.state);
 
   final QuillRawEditorState state;
 

--- a/lib/src/widgets/raw_editor/raw_editor_actions.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_actions.dart
@@ -577,3 +577,35 @@ class QuillEditorInsertEmbedIntent extends Intent {
 
   final Attribute type;
 }
+
+class QuillEditorUpdateCursorLocationAction
+    extends ContextAction<ScrollToDocumentBoundaryIntent> {
+  QuillEditorUpdateCursorLocationAction(this.state);
+
+  final QuillRawEditorState state;
+
+  @override
+  Object? invoke(ScrollToDocumentBoundaryIntent intent,
+      [BuildContext? context]) {
+    if (intent.forward) {
+      return Actions.invoke(
+        context!,
+        UpdateSelectionIntent(
+          state.textEditingValue,
+          TextSelection.collapsed(
+            offset: state.controller.plainTextEditingValue.text.length,
+          ),
+          SelectionChangedCause.keyboard,
+        ),
+      );
+    }
+    return Actions.invoke(
+      context!,
+      UpdateSelectionIntent(
+        state.textEditingValue,
+        const TextSelection.collapsed(offset: 0),
+        SelectionChangedCause.keyboard,
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/raw_editor/raw_editor_actions.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_actions.dart
@@ -585,25 +585,19 @@ class QuillEditorUpdateCursorLocationAction
   final QuillRawEditorState state;
 
   @override
-  Object? invoke(ScrollToDocumentBoundaryIntent intent,
-      [BuildContext? context]) {
-    if (intent.forward) {
-      return Actions.invoke(
-        context!,
-        UpdateSelectionIntent(
-          state.textEditingValue,
-          TextSelection.collapsed(
-            offset: state.controller.plainTextEditingValue.text.length,
-          ),
-          SelectionChangedCause.keyboard,
-        ),
-      );
-    }
+  Object? invoke(
+    ScrollToDocumentBoundaryIntent intent, [
+    BuildContext? context,
+  ]) {
     return Actions.invoke(
       context!,
       UpdateSelectionIntent(
         state.textEditingValue,
-        const TextSelection.collapsed(offset: 0),
+        intent.forward
+            ? TextSelection.collapsed(
+                offset: state.controller.plainTextEditingValue.text.length,
+              )
+            : const TextSelection.collapsed(offset: 0),
         SelectionChangedCause.keyboard,
       ),
     );

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -1687,7 +1687,7 @@ class QuillRawEditorState extends EditorState
     QuillEditorApplyHeaderIntent: _applyHeaderAction,
     QuillEditorApplyCheckListIntent: _applyCheckListAction,
     QuillEditorApplyLinkIntent: QuillEditorApplyLinkAction(this),
-    ScrollToDocumentBoundaryIntent: UpdateCursorLocationAction(this)
+    ScrollToDocumentBoundaryIntent: NavigateToDocumentBoundaryAction(this)
   };
 
   @override

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -701,6 +701,18 @@ class QuillRawEditorState extends EditorState
               control: !isDesktopMacOS,
               meta: isDesktopMacOS,
             ): const OpenSearchIntent(),
+
+            // Navigate to the start or end of the document
+            SingleActivator(
+              LogicalKeyboardKey.home,
+              control: !isDesktopMacOS,
+              meta: isDesktopMacOS,
+            ): const ScrollToDocumentBoundaryIntent(forward: false),
+            SingleActivator(
+              LogicalKeyboardKey.end,
+              control: !isDesktopMacOS,
+              meta: isDesktopMacOS,
+            ): const ScrollToDocumentBoundaryIntent(forward: true),
           }, {
             ...?widget.configurations.customShortcuts
           }),
@@ -1674,7 +1686,8 @@ class QuillRawEditorState extends EditorState
     IndentSelectionIntent: _indentSelectionAction,
     QuillEditorApplyHeaderIntent: _applyHeaderAction,
     QuillEditorApplyCheckListIntent: _applyCheckListAction,
-    QuillEditorApplyLinkIntent: QuillEditorApplyLinkAction(this)
+    QuillEditorApplyLinkIntent: QuillEditorApplyLinkAction(this),
+    ScrollToDocumentBoundaryIntent: QuillEditorUpdateCursorLocationAction(this)
   };
 
   @override

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -1687,7 +1687,7 @@ class QuillRawEditorState extends EditorState
     QuillEditorApplyHeaderIntent: _applyHeaderAction,
     QuillEditorApplyCheckListIntent: _applyCheckListAction,
     QuillEditorApplyLinkIntent: QuillEditorApplyLinkAction(this),
-    ScrollToDocumentBoundaryIntent: QuillEditorUpdateCursorLocationAction(this)
+    ScrollToDocumentBoundaryIntent: UpdateCursorLocationAction(this)
   };
 
   @override


### PR DESCRIPTION
## Description

*Implement home and end keyboard shortcuts.*

Before implementing this feature, I clicked `Home` and `End` keys in **Linux** and **macOS** you will get this exception:

```console
════════ Exception caught by services library ══════════════════════════════════
Unable to find an action for an Intent with type ScrollToDocumentBoundaryIntent in an Actions widget in the given context.
```

<details>
<summary>Stacktrace</summary>

```console

════════ Exception caught by services library ══════════════════════════════════
The following assertion was thrown during method call TextInputClient.performSelectors:
Unable to find an action for an Intent with type ScrollToDocumentBoundaryIntent in an Actions widget in the given context.
Actions.invoke() was unable to find an Actions widget that contained a mapping for the given intent, or the intent type isn't the same as the type argument to invoke (which is Intent - try supplying a type argument to invoke if one was not given)
The context used was:
Focus(focusNode: FocusNode#f5fe7([PRIMARY FOCUS]), dependencies: [_ActionsScope, _FocusInheritedScope, _InheritedTheme, _LocalizationsScope-[GlobalKey#fa1ef]], state: _FocusState#e49c4)
The intent type requested was:
ScrollToDocumentBoundaryIntent

When the exception was thrown, this was the stack:
#0      Actions.invoke.<anonymous closure> (package:flutter/src/widgets/actions.dart:973:9)
#1      Actions.invoke (package:flutter/src/widgets/actions.dart:987:6)
#2      QuillRawEditorState.performSelector (package:flutter_quill/src/widgets/raw_editor/raw_editor_state.dart:1707:17)
#3      ListBase.forEach (dart:collection/list.dart:51:13)
#4      TextInput._handleTextInputInvocation (package:flutter/src/services/text_input.dart:1916:19)
#5      TextInput._loudlyHandleTextInputInvocation (package:flutter/src/services/text_input.dart:1794:20)
#6      MethodChannel._handleAsMethodCall (package:flutter/src/services/platform_channel.dart:571:55)
#7      MethodChannel.setMethodCallHandler.<anonymous closure> (package:flutter/src/services/platform_channel.dart:564:34)
#8      _DefaultBinaryMessenger.setMessageHandler.<anonymous closure> (package:flutter/src/services/binding.dart:581:35)
#9      _invoke2 (dart:ui/hooks.dart:344:13)
#10     _ChannelCallbackRecord.invoke (dart:ui/channel_buffers.dart:45:5)
#11     _Channel.push (dart:ui/channel_buffers.dart:135:31)
#12     ChannelBuffers.push (dart:ui/channel_buffers.dart:343:17)
#13     PlatformDispatcher._dispatchPlatformMessage (dart:ui/platform_dispatcher.dart:750:22)
#14     _dispatchPlatformMessage (dart:ui/hooks.dart:257:31)

call: MethodCall(TextInputClient.performSelectors, [24, [scrollToBeginningOfDocument:]])
════════════════════════════════════════════════════════════════════════════════


```

</details>

I'm not sure where is `ScrollToDocumentBoundaryIntent` used in this project, I saw actions that have similar behavior. We might use something that already registers it as a default.

**A few unrelated issues**:

1. The file [raw_editor_actions.dart](https://github.com/singerdmx/flutter-quill/blob/master/lib/src/widgets/raw_editor/raw_editor_actions.dart) has actions and intents while the name indicates it has actions.
2. Some intents or actions start with `QuillEditor` like `QuillEditorApplyHeaderIntent` others do not like `IndentSelectionIntent`, this PR adds `QuillEditorUpdateCursorLocationAction` yet we have not decided if we should add `QuillEditor` at the start, we might remove `QuillEditor`
3. The order of the classes in `raw_editor_actions.dart` is not `consistent` with [raw_editor_state.dart](https://github.com/singerdmx/flutter-quill/blob/master/lib/src/widgets/raw_editor/raw_editor_state.dart), one way to solve this is by creating a folder for anything related to keyboard or shortcuts, and have different files or categories, and each one has both intents and actions
4. There are intents that are already in flutter `ScrollToDocumentBoundaryIntent`.
5. The code `context!` doesn't handle null safety. Generally, I prefer to avoid using the `!` operator in Dart. Since it's already being used in the codebase, I decided to use it as well to maintain consistency.

This change might be considered as behavior-breaking as some developers don't expect this feature or prefer to disable it.

## Related Issues

- *Fix #1933*

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.