### PR TITLE
fix: search dialog throw an exception due to missing FlutterQuillLocalizations.delegate in the editor

### DIFF
--- a/lib/src/l10n/extensions/localizations.dart
+++ b/lib/src/l10n/extensions/localizations.dart
@@ -15,7 +15,7 @@ extension LocalizationsExt on BuildContext {
           ' required, please make sure you wrapping the current widget with '
           'FlutterQuillLocalizationsWidget or add '
           'FlutterQuillLocalizations.delegate to the localizationsDelegates '
-          'in your App widget, please consider report this in GitHub as a bug',
+          'in your App widget, please consider reporting this as a bug',
         ));
   }
 }

--- a/lib/src/l10n/widgets/localizations.dart
+++ b/lib/src/l10n/widgets/localizations.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 import '../../extensions/quill_configurations_ext.dart';
 import '../extensions/localizations.dart';
 
+/// A widget that check if [FlutterQuillLocalizations.delegate] is provided
+/// in the widgets app (e.g, [MaterialApp] or [WidgetsApp]).
+///
+/// If not, will provide in the [child] to access it in the widget tree.
 class FlutterQuillLocalizationsWidget extends StatelessWidget {
   const FlutterQuillLocalizationsWidget({
     required this.child,

--- a/lib/src/widgets/raw_editor/raw_editor_actions.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_actions.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../translations.dart';
 import '../../models/documents/attribute.dart';
 import '../editor/editor.dart';
 import '../toolbar/buttons/link_style2_button.dart';
@@ -460,8 +461,10 @@ class QuillEditorOpenSearchAction extends ContextAction<OpenSearchIntent> {
     }
     await showDialog<String>(
       context: context,
-      builder: (_) => QuillToolbarSearchDialog(
-        controller: state.controller,
+      builder: (_) => FlutterQuillLocalizationsWidget(
+        child: QuillToolbarSearchDialog(
+          controller: state.controller,
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Description

*When using the shortcut for showing the search dialog in the editor, you will get an exception due to missing FlutterQuillLocalizations.delegate.*

## Related Issues

it also seems that the option for `SearchButtonType` in:

```dart
QuillToolbar.simple(
    configurations: QuillSimpleToolbarConfigurations(
      searchButtonType: SearchButtonType.legacy,
    ),
  )
```
Will be ignored when showing the search dialog using a shortcut and will always use `QuillToolbarSearchDialog`.

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.