### PR TITLE
fixed #1953 italic detection error

### DIFF
--- a/lib/src/models/documents/delta_x.dart
+++ b/lib/src/models/documents/delta_x.dart
@@ -1,7 +1,6 @@
 import 'package:html2md/html2md.dart' as html2md;
 import 'package:markdown/markdown.dart' as md;
 import 'package:meta/meta.dart';
-
 import '../../../markdown_quill.dart';
 import '../../../quill_delta.dart';
 
@@ -15,9 +14,20 @@ class DeltaX {
   /// This api is **experimental** and designed to be used **internally** and shouldn't
   /// used for **production applications**.
   @experimental
-  static Delta fromMarkdown(String markdownText) {
+  static Delta fromMarkdown(
+    String markdownText, {
+    Md2DeltaConfigs md2DeltaConfigs = const Md2DeltaConfigs(),
+  }) {
     final mdDocument = md.Document(encodeHtml: false);
-    final mdToDelta = MarkdownToDelta(markdownDocument: mdDocument);
+    final mdToDelta = MarkdownToDelta(
+      markdownDocument: mdDocument,
+      customElementToBlockAttribute:
+          md2DeltaConfigs.customElementToBlockAttribute,
+      customElementToEmbeddable: md2DeltaConfigs.customElementToEmbeddable,
+      customElementToInlineAttribute:
+          md2DeltaConfigs.customElementToInlineAttribute,
+      softLineBreak: md2DeltaConfigs.softLineBreak,
+    );
     return mdToDelta.convert(markdownText);
   }
 
@@ -32,9 +42,72 @@ class DeltaX {
   /// used for **production applications**.
   ///
   @experimental
-  static Delta fromHtml(String htmlText) {
-    final markdownText = html2md.convert(htmlText).replaceAll('unsafe:', '');
-
+  static Delta fromHtml(String htmlText, {Html2MdConfigs? configs}) {
+    final markdownText = html2md
+        .convert(
+          htmlText,
+          rules: configs?.customRules,
+          ignore: configs?.ignoreIf,
+          rootTag: configs?.rootTag,
+          imageBaseUrl: configs?.imageBaseUrl,
+          styleOptions: configs?.styleOptions,
+        )
+        .replaceAll(
+          'unsafe:',
+          '',
+        );
     return fromMarkdown(markdownText);
   }
+}
+
+@immutable
+@experimental
+class Md2DeltaConfigs {
+  const Md2DeltaConfigs({
+    this.customElementToInlineAttribute = const {},
+    this.customElementToBlockAttribute = const {},
+    this.customElementToEmbeddable = const {},
+    this.softLineBreak = false,
+  });
+  final Map<String, ElementToAttributeConvertor> customElementToInlineAttribute;
+  final Map<String, ElementToAttributeConvertor> customElementToBlockAttribute;
+  final Map<String, ElementToEmbeddableConvertor> customElementToEmbeddable;
+  final bool softLineBreak;
+}
+
+@immutable
+@experimental
+class Html2MdConfigs {
+  const Html2MdConfigs({
+    this.customRules,
+    this.ignoreIf,
+    this.rootTag,
+    this.imageBaseUrl,
+    this.styleOptions = const {'emDelimiter': '*'},
+    //emDelimiter set em to be "*" instead a "_"
+  });
+
+  /// The [rules] parameter can be used to customize element processing.
+  final List<html2md.Rule>? customRules;
+
+  /// Elements list in [ignore] would be ingored.
+  final List<String>? ignoreIf;
+
+  final String? rootTag;
+  final String? imageBaseUrl;
+
+  /// The default and available style options:
+  ///
+  /// | Name        | Default           | Options  |
+  /// | ------------- |:-------------:| -----:|
+  /// | headingStyle      | "setext" | "setext", "atx" |
+  /// | hr      | "* * *" | "* * *", "- - -", "_ _ _" |
+  /// | bulletListMarker      | "*" | "*", "-", "_" |
+  /// | codeBlockStyle      | "indented" | "indented", "fenced" |
+  /// | fence      | "\`\`\`" | "\`\`\`", "~~~" |
+  /// | emDelimiter      | "_" | "_", "*" |
+  /// | strongDelimiter      | "**" | "**", "__" |
+  /// | linkStyle      | "inlined" | "inlined", "referenced" |
+  /// | linkReferenceStyle      | "full" | "full", "collapsed", "shortcut" |
+  final Map<String, String>? styleOptions;
 }

--- a/test/utils/delta_x_test.dart
+++ b/test/utils/delta_x_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_quill/quill_delta.dart';
+import 'package:flutter_quill/src/models/documents/delta_x.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const htmlWithEmp =
+      '<p>This is a normal sentence, and this section has greater emp<em>hasis.</em></p>';
+  final expectedDeltaEmp = Delta.fromOperations([
+    Operation.insert(
+        'This is a normal sentence, and this section has greater emp'),
+    Operation.insert('hasis.', {'italic': true}),
+    Operation.insert('\n'),
+  ]);
+
+  test('should detect emphasis and parse correctly', () {
+    final delta = DeltaX.fromHtml(
+      htmlWithEmp,
+      configs: const Html2MdConfigs(),
+    );
+    expect(delta, expectedDeltaEmp);
+  });
+}


### PR DESCRIPTION
## Description

When using `DeltaX.fromHtml,` if you have a `<em>` tag in your html input, the parser will not detect it and will just print "_" instead of applying the style the user wants

## Related Issues

*Fix #1953*

## Improvements

feat: added test for `DeltaX` class
feat: added config classes to `MarkdownToDelta` and `html2md` to allow users set their own styles implementation

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.