### PR TITLE
fix: common link is detected as a video link

### DIFF
--- a/lib/src/utils/delta_x_utils.dart
+++ b/lib/src/utils/delta_x_utils.dart
@@ -20,7 +20,7 @@ class UnderlineSyntax extends md.DelimiterSyntax {
 class VideoSyntax extends md.LinkSyntax {
   VideoSyntax({super.linkResolver})
       : super(
-          pattern: r'\[',
+          pattern: r'\[!\[',
           startCharacter: _$lbracket,
         );
 
@@ -60,13 +60,13 @@ final videoRule = hmd.Rule('video', filters: ['iframe', 'video'],
       if (!_youtubeVideoUrlValidator.hasMatch(src ?? '')) {
         return '<video>${child.outerHTML}</video>';
       }
-      return '[$content]($src)';
+      return '[![$content]($src)';
     }
     final src = node.getAttribute('src');
     if (src == null || !_youtubeVideoUrlValidator.hasMatch(src)) {
       return node.outerHTML;
     }
-    return '[$content]($src)';
+    return '[![$content]($src)';
   }
   //by now, we can only access to src
   final src = node.getAttribute('src');
@@ -76,5 +76,5 @@ final videoRule = hmd.Rule('video', filters: ['iframe', 'video'],
     return node.outerHTML;
   }
   final title = node.getAttribute('title');
-  return '[$title]($src)';
+  return '[![$title]($src)';
 });

--- a/test/utils/delta_x_test.dart
+++ b/test/utils/delta_x_test.dart
@@ -3,9 +3,11 @@ import 'package:flutter_quill/src/models/documents/delta_x.dart';
 import 'package:test/test.dart';
 
 void main() {
-  const htmlWithEmp = '<p>This is a normal sentence, and this section has greater emp<em>hasis.</em></p>';
+  const htmlWithEmp =
+      '<p>This is a normal sentence, and this section has greater emp<em>hasis.</em></p>';
 
-  const htmlWithUnderline = '<p>This is a normal sentence, and this section has greater <u>underline</u>';
+  const htmlWithUnderline =
+      '<p>This is a normal sentence, and this section has greater <u>underline</u>';
 
   const htmlWithIframeVideo =
       '<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="YouTube video player"></iframe>';
@@ -17,13 +19,15 @@ void main() {
       '<a href="https://www.macrumors.com/" type="text/html">fdsfsd</a><br><video src="https://www.youtube.com/embed/dQw4w9WgXcQ">Your browser does not support the video tag.</video>';
 
   final expectedDeltaEmp = Delta.fromOperations([
-    Operation.insert('This is a normal sentence, and this section has greater emp'),
+    Operation.insert(
+        'This is a normal sentence, and this section has greater emp'),
     Operation.insert('hasis.', {'italic': true}),
     Operation.insert('\n'),
   ]);
 
   final expectedDeltaUnderline = Delta.fromOperations([
-    Operation.insert('This is a normal sentence, and this section has greater '),
+    Operation.insert(
+        'This is a normal sentence, and this section has greater '),
     Operation.insert('underline', {'underline': true}),
     Operation.insert('\n'),
   ]);

--- a/test/utils/delta_x_test.dart
+++ b/test/utils/delta_x_test.dart
@@ -3,33 +3,39 @@ import 'package:flutter_quill/src/models/documents/delta_x.dart';
 import 'package:test/test.dart';
 
 void main() {
-  const htmlWithEmp =
-      '<p>This is a normal sentence, and this section has greater emp<em>hasis.</em></p>';
+  const htmlWithEmp = '<p>This is a normal sentence, and this section has greater emp<em>hasis.</em></p>';
 
-  const htmlWithUnderline =
-      '<p>This is a normal sentence, and this section has greater <u>underline</u>';
+  const htmlWithUnderline = '<p>This is a normal sentence, and this section has greater <u>underline</u>';
 
   const htmlWithIframeVideo =
       '<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="YouTube video player"></iframe>';
 
   const htmlWithVideoTag =
-      '''<video src="https://www.youtube.com/embed/dQw4w9WgXcQ">Your browser does not support the video tag.</video> 
-''';
+      '<video src="https://www.youtube.com/embed/dQw4w9WgXcQ">Your browser does not support the video tag.</video>';
+
+  const htmlWithNormalLinkAndVideo =
+      '<a href="https://www.macrumors.com/" type="text/html">fdsfsd</a><br><video src="https://www.youtube.com/embed/dQw4w9WgXcQ">Your browser does not support the video tag.</video>';
+
   final expectedDeltaEmp = Delta.fromOperations([
-    Operation.insert(
-        'This is a normal sentence, and this section has greater emp'),
+    Operation.insert('This is a normal sentence, and this section has greater emp'),
     Operation.insert('hasis.', {'italic': true}),
     Operation.insert('\n'),
   ]);
 
   final expectedDeltaUnderline = Delta.fromOperations([
-    Operation.insert(
-        'This is a normal sentence, and this section has greater '),
+    Operation.insert('This is a normal sentence, and this section has greater '),
     Operation.insert('underline', {'underline': true}),
     Operation.insert('\n'),
   ]);
 
   final expectedDeltaVideo = Delta.fromOperations([
+    Operation.insert({'video': 'https://www.youtube.com/embed/dQw4w9WgXcQ'}),
+    Operation.insert('\n'),
+  ]);
+
+  final expectedDeltaLinkAndVideoLink = Delta.fromOperations([
+    Operation.insert('fdsfsd', {'link': 'https://www.macrumors.com/'}),
+    Operation.insert('\n\n'),
     Operation.insert({'video': 'https://www.youtube.com/embed/dQw4w9WgXcQ'}),
     Operation.insert('\n'),
   ]);
@@ -52,5 +58,10 @@ void main() {
   test('should detect video and parse correctly', () {
     final delta = DeltaX.fromHtml(htmlWithVideoTag);
     expect(delta, expectedDeltaVideo);
+  });
+
+  test('should detect by different way normal link and video link', () {
+    final delta = DeltaX.fromHtml(htmlWithNormalLinkAndVideo);
+    expect(delta, expectedDeltaLinkAndVideoLink);
   });
 }


### PR DESCRIPTION
## Description

html link as "https://www.google.com" is converted to a video block at the `Delta` result instead just a normal link to a website. 

HTML used: 

```html
<a href="https://www.google.com" type="text/html">fdsfsd</a>
```

Current result at `Flutter Quill` version (9.5.5):

```dart
 [{"insert": {'video': 'https://www.google.com'}]
```

Expected:

```dart
 [{"insert":"fdsfsd","attributes":{'link': 'https://www.google.com'}}]
```

## Related Issues

*Fix  #1977*

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.