### PR TITLE
fix(typo): fix typo ClipboardServiceProvider.instacne

### DIFF
--- a/flutter_quill_extensions/lib/flutter_quill_extensions.dart
+++ b/flutter_quill_extensions/lib/flutter_quill_extensions.dart
@@ -42,7 +42,7 @@ export 'utils/utils.dart';
 class FlutterQuillExtensions {
   const FlutterQuillExtensions._();
 
-  /// Override default implementation of [ClipboardServiceProvider.instacne]
+  /// Override default implementation of [ClipboardServiceProvider.instance]
   /// to allow `flutter_quill` package to use `super_clipboard` plugin
   /// to support rich text features, gif and images.
   static void useSuperClipboardPlugin() {

--- a/lib/src/services/clipboard/clipboard_service_provider.dart
+++ b/lib/src/services/clipboard/clipboard_service_provider.dart
@@ -7,7 +7,10 @@ import 'default_clipboard_service.dart';
 class ClipboardServiceProvider {
   const ClipboardServiceProvider._();
   static ClipboardService _instance = DefaultClipboardService();
-  static ClipboardService get instacne => _instance;
+
+  static ClipboardService get instance => _instance;
+  @Deprecated('instacne is a typo, instance instead.')
+  static ClipboardService get instacne => instance;
 
   static void setInstance(ClipboardService service) {
     _instance = service;

--- a/lib/src/services/clipboard/clipboard_service_provider.dart
+++ b/lib/src/services/clipboard/clipboard_service_provider.dart
@@ -9,7 +9,8 @@ class ClipboardServiceProvider {
   static ClipboardService _instance = DefaultClipboardService();
 
   static ClipboardService get instance => _instance;
-  @Deprecated('instacne is a typo, instance instead.')
+
+  @Deprecated('instacne is a typo, use instance instead.')
   static ClipboardService get instacne => instance;
 
   static void setInstance(ClipboardService service) {

--- a/lib/src/widgets/quill/quill_controller.dart
+++ b/lib/src/widgets/quill/quill_controller.dart
@@ -568,7 +568,7 @@ class QuillController extends ChangeNotifier {
 
   /// Return true if can paste using HTML
   Future<bool> _pasteHTML() async {
-    final clipboardService = ClipboardServiceProvider.instacne;
+    final clipboardService = ClipboardServiceProvider.instance;
 
     Future<String?> getHTML() async {
       if (await clipboardService.canProvideHtmlTextFromFile()) {
@@ -594,7 +594,7 @@ class QuillController extends ChangeNotifier {
 
   /// Return true if can paste using Markdown
   Future<bool> _pasteMarkdown() async {
-    final clipboardService = ClipboardServiceProvider.instacne;
+    final clipboardService = ClipboardServiceProvider.instance;
 
     Future<String?> getMarkdown() async {
       if (await clipboardService.canProvideMarkdownTextFromFile()) {

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -184,7 +184,7 @@ class QuillRawEditorState extends EditorState
       return;
     }
 
-    final clipboardService = ClipboardServiceProvider.instacne;
+    final clipboardService = ClipboardServiceProvider.instance;
 
     final onImagePaste = widget.configurations.onImagePaste;
     if (onImagePaste != null) {

--- a/lib/src/widgets/toolbar/buttons/clipboard_button.dart
+++ b/lib/src/widgets/toolbar/buttons/clipboard_button.dart
@@ -27,7 +27,7 @@ class ClipboardMonitor {
   }
 
   Future<void> _update(void Function() listener) async {
-    final clipboardService = ClipboardServiceProvider.instacne;
+    final clipboardService = ClipboardServiceProvider.instance;
     if (await clipboardService.canPaste()) {
       _canPaste = true;
       listener();


### PR DESCRIPTION
**Deprecate `ClipboardServiceProvider.instacne` as it's a typo, add `ClipboardServiceProvider.instance` and update usages**

The class `ClipboardServiceProvider` introduced in `9.4.0` and is not exported and developers would have to explicitly import it with the relative path with `src` and then ignore a warning, so removing the old property should not be considered as a breaking change, I deprecated it instead just in case.

## Related Issues

This typo is caught by comment [2212361659](https://github.com/singerdmx/flutter-quill/issues/1946#issuecomment-2212361659).

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.