### PR TITLE
Update pubspec.yaml to remove html2md

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,7 +56,6 @@ dependencies:
   # For converting HTML to Quill delta
   flutter_quill_delta_from_html: ^1.1.8
   markdown: ^7.2.1
-  html2md: ^1.3.1
   charcode: ^1.3.1
 
   # Plugins


### PR DESCRIPTION
html2md is no longer needed