### PR TITLE
chore: remove dependency html converter

### DIFF
--- a/quill_html_converter/pubspec.yaml
+++ b/quill_html_converter/pubspec.yaml
@@ -20,7 +20,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  vsc_quill_delta_to_html: ^1.0.4
+  vsc_quill_delta_to_html: ^1.0.5
   markdown: ^7.2.2
   charcode: ^1.3.1
   collection: ^1.18.0

--- a/quill_html_converter/pubspec.yaml
+++ b/quill_html_converter/pubspec.yaml
@@ -21,7 +21,6 @@ dependencies:
   flutter:
     sdk: flutter
   vsc_quill_delta_to_html: ^1.0.4
-  html2md: ^1.3.1
   markdown: ^7.2.2
   charcode: ^1.3.1
   collection: ^1.18.0


### PR DESCRIPTION
Remove `html2md`, require `1.0.5` as the minimum version of the `vsc_quill_delta_to_html` package as it has a bug fix (See [vsc_quill_delta_to_html PR #21](https://github.com/VisualSystemsCorp/vsc_quill_delta_to_html/pull/21)).

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully
 
## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.