### PR TITLE
fix: Fixed passing textStyle to formula embed

### DIFF
--- a/lib/src/widgets/quill/text_line.dart
+++ b/lib/src/widgets/quill/text_line.dart
@@ -198,7 +198,7 @@ class _TextLineState extends State<TextLine> {
           child = Embed(CustomBlockEmbed.fromJsonString(child.value.data))
             ..applyStyle(child.style);
         }
-        
+
         if (child.value.type == BlockEmbed.formulaType) {
           lineStyle = lineStyle.merge(_getInlineTextStyle(
             child.style,
@@ -387,8 +387,8 @@ class _TextLineState extends State<TextLine> {
     final isLink = nodeStyle.containsKey(Attribute.link.key) &&
         nodeStyle.attributes[Attribute.link.key]!.value != null;
 
-    final style = _getInlineTextStyle(
-        nodeStyle, defaultStyles, lineStyle, isLink);
+    final style =
+        _getInlineTextStyle(nodeStyle, defaultStyles, lineStyle, isLink);
 
     if (widget.controller.configurations.requireScriptFontFeatures == false &&
         textNode.value.isNotEmpty) {
@@ -410,11 +410,8 @@ class _TextLineState extends State<TextLine> {
     );
   }
 
-  TextStyle _getInlineTextStyle(
-      Style nodeStyle,
-      DefaultStyles defaultStyles,
-      Style lineStyle,
-      bool isLink) {
+  TextStyle _getInlineTextStyle(Style nodeStyle, DefaultStyles defaultStyles,
+      Style lineStyle, bool isLink) {
     var res = const TextStyle(); // This is inline text style
     final color = nodeStyle.attributes[Attribute.color.key];
 

--- a/lib/src/widgets/quill/text_line.dart
+++ b/lib/src/widgets/quill/text_line.dart
@@ -178,7 +178,7 @@ class _TextLineState extends State<TextLine> {
   }
 
   InlineSpan _getTextSpanForWholeLine() {
-    final lineStyle = _getLineStyle(widget.styles);
+    var lineStyle = _getLineStyle(widget.styles);
     if (!widget.line.hasEmbed) {
       return _buildTextSpan(widget.styles, widget.line.children, lineStyle);
     }
@@ -198,6 +198,16 @@ class _TextLineState extends State<TextLine> {
           child = Embed(CustomBlockEmbed.fromJsonString(child.value.data))
             ..applyStyle(child.style);
         }
+        
+        if (child.value.type == BlockEmbed.formulaType) {
+          lineStyle = lineStyle.merge(_getInlineTextStyle(
+            child.style,
+            widget.styles,
+            widget.line.style,
+            false,
+          ));
+        }
+
         final embedBuilder = widget.embedBuilder(child);
         final embedWidget = EmbedProxy(
           embedBuilder.build(
@@ -378,7 +388,7 @@ class _TextLineState extends State<TextLine> {
         nodeStyle.attributes[Attribute.link.key]!.value != null;
 
     final style = _getInlineTextStyle(
-        textNode, defaultStyles, nodeStyle, lineStyle, isLink);
+        nodeStyle, defaultStyles, lineStyle, isLink);
 
     if (widget.controller.configurations.requireScriptFontFeatures == false &&
         textNode.value.isNotEmpty) {
@@ -401,13 +411,12 @@ class _TextLineState extends State<TextLine> {
   }
 
   TextStyle _getInlineTextStyle(
-      leaf.QuillText textNode,
-      DefaultStyles defaultStyles,
       Style nodeStyle,
+      DefaultStyles defaultStyles,
       Style lineStyle,
       bool isLink) {
     var res = const TextStyle(); // This is inline text style
-    final color = textNode.style.attributes[Attribute.color.key];
+    final color = nodeStyle.attributes[Attribute.color.key];
 
     <String, TextStyle?>{
       Attribute.bold.key: defaultStyles.bold,
@@ -446,12 +455,12 @@ class _TextLineState extends State<TextLine> {
       res = _merge(res, defaultStyles.inlineCode!.styleFor(lineStyle));
     }
 
-    final font = textNode.style.attributes[Attribute.font.key];
+    final font = nodeStyle.attributes[Attribute.font.key];
     if (font != null && font.value != null) {
       res = res.merge(TextStyle(fontFamily: font.value));
     }
 
-    final size = textNode.style.attributes[Attribute.size.key];
+    final size = nodeStyle.attributes[Attribute.size.key];
     if (size != null && size.value != null) {
       switch (size.value) {
         case 'small':
@@ -482,13 +491,13 @@ class _TextLineState extends State<TextLine> {
       }
     }
 
-    final background = textNode.style.attributes[Attribute.background.key];
+    final background = nodeStyle.attributes[Attribute.background.key];
     if (background != null && background.value != null) {
       final backgroundColor = stringToColor(background.value);
       res = res.merge(TextStyle(backgroundColor: backgroundColor));
     }
 
-    res = _applyCustomAttributes(res, textNode.style.attributes);
+    res = _applyCustomAttributes(res, nodeStyle.attributes);
     return res;
   }
 


### PR DESCRIPTION
## Description

Pass text style to formula embed builder

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?
No

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.