### PR TITLE
Added new default ConverterOptions configurations

### DIFF
--- a/quill_html_converter/lib/quill_html_converter.dart
+++ b/quill_html_converter/lib/quill_html_converter.dart
@@ -2,7 +2,15 @@ library quill_html_converter;
 
 import 'package:dart_quill_delta/dart_quill_delta.dart';
 import 'package:vsc_quill_delta_to_html/vsc_quill_delta_to_html.dart'
-    as converter show ConverterOptions, QuillDeltaToHtmlConverter;
+    as converter
+    show
+        ConverterOptions,
+        QuillDeltaToHtmlConverter,
+        OpAttributeSanitizerOptions,
+        OpConverterOptions,
+        InlineStyles,
+        InlineStyleType,
+        defaultInlineFonts;
 
 typedef ConverterOptions = converter.ConverterOptions;
 
@@ -21,7 +29,66 @@ extension DeltaHtmlExt on Delta {
     final json = toJson();
     final html = converter.QuillDeltaToHtmlConverter(
       List.castFrom(json),
-      options,
+      options ??
+          ConverterOptions(
+            orderedListTag: 'ol',
+            bulletListTag: 'ul',
+            multiLineBlockquote: true,
+            multiLineHeader: true,
+            multiLineCodeblock: true,
+            multiLineParagraph: true,
+            multiLineCustomBlock: true,
+            sanitizerOptions: converter.OpAttributeSanitizerOptions(
+                allow8DigitHexColors: true),
+            converterOptions: converter.OpConverterOptions(
+              customCssStyles: (op) {
+                ///if found line-height apply this as a inline style
+                if (op.attributes['line-height'] != null) {
+                  return ['line-height: ${op.attributes['line-height']}px'];
+                }
+                //here is where us pass the necessary
+                //code to validate if our attributes exist in [DeltaInsertOp]
+                //and return the necessary html style
+                if (op.isImage()) {
+                  // Fit images within restricted parent width.
+                  return ['max-width: 100%', 'object-fit: contain'];
+                }
+                if (op.isBlockquote()) {
+                  return ['border-left: 4px solid #ccc', 'padding-left: 16px'];
+                }
+                return null;
+              },
+              inlineStylesFlag: true, //This let inlineStyles work
+              inlineStyles: converter.InlineStyles(
+                <String, converter.InlineStyleType>{
+                  'font': converter.InlineStyleType(
+                      fn: (value, _) =>
+                          converter.defaultInlineFonts[value] ??
+                          'font-family: $value'),
+                  'size': converter.InlineStyleType(fn: (value, _) {
+                    //default sizes
+                    if (value == 'small') return 'font-size: 0.75em';
+                    if (value == 'large') return 'font-size: 1.5em';
+                    if (value == 'huge') return 'font-size: 2.5em';
+                    //accept any int or double type size
+                    return 'font-size: ${value}px';
+                  }),
+                  'indent': converter.InlineStyleType(fn: (value, op) {
+                    final indentSize =
+                        (double.tryParse(value) ?? double.nan) * 3;
+                    final side =
+                        op.attributes['direction'] == 'rtl' ? 'right' : 'left';
+                    return 'padding-$side:${indentSize}em';
+                  }),
+                  'list': converter.InlineStyleType(map: <String, String>{
+                    'checked': "list-style-type:'\\2611';padding-left: 0.5em;",
+                    'unchecked':
+                        "list-style-type:'\\2610';padding-left: 0.5em;",
+                  }),
+                },
+              ),
+            ),
+          ),
     ).convert();
     return html;
   }

--- a/quill_html_converter/lib/quill_html_converter.dart
+++ b/quill_html_converter/lib/quill_html_converter.dart
@@ -86,10 +86,6 @@ final _defaultConverterOptions = ConverterOptions(
         // Fit images within restricted parent width
         return ['max-width: 100%', 'object-fit: contain'];
       }
-      if (op.isBlockquote()) {
-        // Style for blockquotes
-        return ['border-left: 4px solid #ccc', 'padding-left: 16px'];
-      }
       return null;
     },
     // Enable inline styles

--- a/quill_html_converter/lib/quill_html_converter.dart
+++ b/quill_html_converter/lib/quill_html_converter.dart
@@ -1,7 +1,8 @@
 library quill_html_converter;
 
 import 'package:dart_quill_delta/dart_quill_delta.dart';
-import 'package:vsc_quill_delta_to_html/vsc_quill_delta_to_html.dart' as converter
+import 'package:vsc_quill_delta_to_html/vsc_quill_delta_to_html.dart'
+    as converter
     show
         ConverterOptions,
         QuillDeltaToHtmlConverter,
@@ -64,14 +65,14 @@ final _defaultConverterOptions = ConverterOptions(
     allow8DigitHexColors: true,
   ),
 
-  // This handle specific styles and attributes  
+  // This handle specific styles and attributes
   converterOptions: converter.OpConverterOptions(
     customCssStyles: (op) {
       // Validate if our attributes exist in [DeltaInsertOp]
       // and return the necessary HTML style
       // These lists of attributes, are passed as inline styles
       //
-      // For example, if you have a delta like -> 
+      // For example, if you have a delta like ->
       // [ { "insert": "hello", "attributes": { "line-height": 1.5 }} ]
       //
       // Without the validation below to verify if exist line-height atribute in the Operation, it would be:
@@ -93,7 +94,8 @@ final _defaultConverterOptions = ConverterOptions(
     inlineStyles: converter.InlineStyles(
       <String, converter.InlineStyleType>{
         'font': converter.InlineStyleType(
-          fn: (value, _) => converter.defaultInlineFonts[value] ?? 'font-family: $value',
+          fn: (value, _) =>
+              converter.defaultInlineFonts[value] ?? 'font-family: $value',
         ),
         'size': converter.InlineStyleType(
           fn: (value, _) {

--- a/quill_html_converter/lib/quill_html_converter.dart
+++ b/quill_html_converter/lib/quill_html_converter.dart
@@ -85,7 +85,9 @@ final _defaultConverterOptions = ConverterOptions(
       }
       if (op.isImage()) {
         // Fit images within restricted parent width
-        return ['max-width: 100%', 'object-fit: contain'];
+        final String? styles = op.attributes['style'];
+        final listStyles = styles?.split(';') ?? [];
+        return ['max-width: 100%', 'object-fit: contain', ...listStyles];
       }
       return null;
     },

--- a/quill_html_converter/test/quill_html_converter_test.dart
+++ b/quill_html_converter/test/quill_html_converter_test.dart
@@ -28,15 +28,16 @@ void main() {
       expect(Delta.fromJson(quillDelta).toHtml().trim(), html.trim());
     });
 
-    test('should parse block image embed to html', () {
+    test("should parse block image embed with it's attributes to html", () {
       const html =
-          '<p><img style="max-width: 100%;object-fit: contain" src="https://img.freepik.com/foto-gratis/belleza-otonal-abstracta-patron-venas-hoja-multicolor-generado-ia_188544-9871.jpg"/></p>';
+          '<p><img style="max-width: 100%;object-fit: contain;width: 40vh; height:350px; margin: 20px;" src="https://img.freepik.com/foto-gratis/belleza-otonal-abstracta-patron-venas-hoja-multicolor-generado-ia_188544-9871.jpg"/></p>';
       final quillDelta = [
         {
           'insert': {
             'image':
                 'https://img.freepik.com/foto-gratis/belleza-otonal-abstracta-patron-venas-hoja-multicolor-generado-ia_188544-9871.jpg'
           },
+          'attributes': {'style': 'width: 40vh; height:350px; margin: 20px;'}
         },
         {'insert': '\n'}
       ];

--- a/quill_html_converter/test/quill_html_converter_test.dart
+++ b/quill_html_converter/test/quill_html_converter_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('Quill HTML Converter', () {
-    test('Example of toHtml', () {
+    test('should parser delta heading to html', () {
       const html = '<p><br/></p><h1><br/></h1>';
       final quillDelta = [
         {'insert': '\n'},
@@ -12,6 +12,33 @@ void main() {
           'attributes': {'header': 1},
           'insert': 'Hello'
         }
+      ];
+      expect(Delta.fromJson(quillDelta).toHtml().trim(), html.trim());
+    });
+
+    test('should parse line-height attribute to html', () {
+      const html = '<p><span style="line-height: 1.5px">hello</span></p>';
+      final quillDelta = [
+        {
+          'insert': 'hello',
+          'attributes': {'line-height': 1.5}
+        },
+        {'insert': '\n'}
+      ];
+      expect(Delta.fromJson(quillDelta).toHtml().trim(), html.trim());
+    });
+
+    test('should parse block image embed to html', () {
+      const html =
+          '<p><img style="max-width: 100%;object-fit: contain" src="https://img.freepik.com/foto-gratis/belleza-otonal-abstracta-patron-venas-hoja-multicolor-generado-ia_188544-9871.jpg"/></p>';
+      final quillDelta = [
+        {
+          'insert': {
+            'image':
+                'https://img.freepik.com/foto-gratis/belleza-otonal-abstracta-patron-venas-hoja-multicolor-generado-ia_188544-9871.jpg'
+          },
+        },
+        {'insert': '\n'}
       ];
       expect(Delta.fromJson(quillDelta).toHtml().trim(), html.trim());
     });


### PR DESCRIPTION
## Description

Previously, we used optional `ConverterOptions` that did not convert or provide convenient attributes for converting a Delta to html.

For this, I added some default options, which have a pretty big effect on how inline attributes are produced.

Let's take this delta as an example

```dart
[
 {"insert":"hello","attributes":{"size":"12","line-height": 1.5}},
 {"insert":"\n"}
]
```

In the current version (9.5.12) where we use some `ConverterOptions` which do not contain the slightest configuration, it gives this result (yeah, `line-height` is not applied):

```html
<p><span class="ql-size-12">hello</span></p>
```

Unlike before, with these new settings, this is the result

```html
<p><span style="line-height: 1.5px;font-size: 12px">hello</span></p>
```

This is clearly because by default `vsc_quill_delta_to_html` uses classes to apply attributes instead of inline styles. By changing to these configurations, we also make conversions from Delta to `HTML` and vice versa more compatible and easier (`flutter_quill_delta_to_html` does not currently support attributes in classes)

If we use for example this `Delta` now only currently supported attributes

```dart
[ 
 {"insert":"hello","attributes":{"size":"12","font": "Tinos"}},
 {"insert":"\n"}
]
```

This will be the resulting `HTML` output without the new settings:

```html
<p><span class="ql-font-Tinos ql-size-12">hello</span></p>
```

And this is the result with the new configurations

```html
<p><span style="font-family: Tinos;font-size: 12px">hello</span></p>
```

As I mentioned before, it is more convenient to output the `HTML` now, since the package we use to obtain the Deltas from an `HTML` input does not support classes.

An even more convenient reason is that it adds some attributes to the images that could be useful if the resulting `HTML` will be used to render a page:

This is the result of not using these new default settings:

```html
<p><img class="ql-image" src="https://img.freepik.com/foto-gratis/belleza-otonal-abstracta-patron-venas-jaja-multicolor-generado-ia_188544-9
871.jpg"/></p>
```

And this is when we use these new settings:

```html
<p><img style="max-width: 100%;object-fit: contain" src="https://img.freepik.com/foto-gratis/belleza-otonal-abstracta-patron-venas-hoja- multicolor-generated-ia_188544-9871.jpg"/></p>
```

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.