### PR TITLE
Update flutter_quill_delta_from_html on pubspec.yaml to fix current issues

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   flutter_colorpicker: ^1.1.0
 
   # For converting HTML to Quill delta
-  flutter_quill_delta_from_html: ^1.2.1
+  flutter_quill_delta_from_html: ^1.2.5
   markdown: ^7.2.1
   charcode: ^1.3.1
 


### PR DESCRIPTION
## Description

In the current version of flutter_quill_delta_from_html (1.2.1) html is not supported within a `<div>` and there are even errors during the parsing of the `font-size` to a valid value for `flutter_quill`.

With this new version the inclusion of `<div>` is officially in the package for `HTML` like this:

```html
<div><p>Text</p></div>
```

Will converted on: 

```json
{"insert":"Text"},
{"insert":"\n"}
```

And an important point was fixed, which is the parsing of the `font-size` and `line-height`, where if before we used values ​​like: `rem`, `em`, `pc`, `pt`, etc. the editor threw errors because those values ​​were not valid referenced in this [comment](https://github.com/singerdmx/flutter-quill/pull/1990#issuecomment-2218248024):

Previously if we had a:

```html
<p style="font-size: 0.75em">Text</p>
```

The parsing to `Delta` was:

```json
{"insert":"Text","attributes":{"size":"0.75"}},
{"insert":"\n"}
```

Which caused errors in the rendering. Now, with the addition of parsing and calculation based on the unit type, the `Delta` will have an output such that:

```json
{"insert":"Text","attributes":{"size":"small"}},
{"insert":"\n"}
```

_The default values: `0.75em`, `1.5em`, and `2.5em` will be equivalent to: `small`, `large` and `huge`_

## Related Issues

*Fix  #1994*
*Fix https://github.com/singerdmx/flutter-quill/pull/1990#issuecomment-2218248024*

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.