### PR TITLE
Update delta_from_html to fix nested lists issues and more

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   flutter_colorpicker: ^1.1.0
 
   # For converting HTML to Quill delta
-  flutter_quill_delta_from_html: ^1.2.5
+  flutter_quill_delta_from_html: ^1.3.0
   markdown: ^7.2.1
   charcode: ^1.3.1
 

--- a/test/utils/delta_x_test.dart
+++ b/test/utils/delta_x_test.dart
@@ -9,9 +9,6 @@ void main() {
   const htmlWithUnderline =
       '<p>This is a normal sentence, and this section has greater <u>underline</u>';
 
-  const htmlWithIframeVideo =
-      '<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="YouTube video player"></iframe>';
-
   const htmlWithVideoTag =
       '<video src="https://www.youtube.com/embed/dQw4w9WgXcQ">Your browser does not support the video tag.</video>';
 
@@ -53,11 +50,6 @@ void main() {
   test('should detect underline and parse correctly', () {
     final delta = DeltaX.fromHtml(htmlWithUnderline);
     expect(delta, expectedDeltaUnderline);
-  });
-
-  test('should detect iframe and parse correctly', () {
-    final delta = DeltaX.fromHtml(htmlWithIframeVideo);
-    expect(delta, expectedDeltaVideo);
   });
 
   test('should detect video and parse correctly', () {


### PR DESCRIPTION
## Description

During the previous version (1.2.5) quite a few errors occurred, whether because the [flutter_quill_delta_from_html](https://github.com/CatHood0/flutter_quill_delta_from_html) package did not support image styles, or because it did not add correct indentation if an element of a list was already nested in another, or even because some attributes were not parsed as expected.

In this version (1.3.0) several issues with inline and block attribute detection were fixed, and support for more attributes was added.

## Added support for lists indentation

For example, `HTML` like this:

```html
<ul>
    <li>
      Item 1
        <ol>
           <li>
             Sub item 1
              <ul>
                  <li>
                   Sub sub item 1
                  </li>
              </ul>
            </li>
         </ol>
    </li>
</ul>
```

Now it must be transformed to a `Delta` like:

```json
{"insert":"Item 1"},
{"insert":"\n","attributes":{"list":"bullet"}},
{"insert":"Sub item 1"},
{"insert":"\n","attributes":{"list":"ordered","indent": 1}},
{"insert":"Sub sub item 1"},
{"insert":"\n","attributes":{"list":"bullet","indent": 2}},
{"insert":"\n"}
```

## Added support for general indentation of other HTML tags

The indentation in any `HTML` tag based on the value of the `padding` (how these values ​​are parsed to a valid indentation for `Quill Delta` is specific to the package and may be subject to change since it is based on constant values ​​and that could be wrong).

_indentation parsing is only available if a label style has a `padding-left` or `padding-right` attribute_

For example, `HTML` like this:

```html
<p style="padding-left: 2em;">Hello</p>
```

It will now be parsed as:

```json
{"insert":"Hello"},
{"insert":"\n","attributes":{"indent": 2}},
{"insert":"\n"}
```

_It was taken into account that the indentation level has a limit of 5 levels, so if a padding value exceeds the maximum of 5, it will be automatically replaced by the maximum available value. The only units supported for padding are: `pt`, `pc`, `px`, `percentage`, `em` and `rem`_

## Added support for image styles

Now if the images (`<img>`) contain any style within the label, the desired ones will be taken and applied. It was taken into account that we can only have: `width`, `height`, `margin`, and `alignment`

You could take as an example an image like:

```html
<p>This is an image:</p><img align="center" style="width: 50px;height: 250px;margin: 5px;" src="https://example.com/image.png" />
```

It will be converted to a `Delta` like:

```json
{"insert":"This is an image:"},
{"insert": 
         {"image": "https://example.com/image.png"},
         "attributes": {"style": "width:50px;height:250px;margin:5px;alignment:center"}
},
{"insert":"\n"}
```

> [!NOTE]
> Fixed some problems with the parsing of `<blockquote>` and `<pre>` which instead of being block attributes, they were parsed to an inline attribute. The following Delta can be taken as an example: 
> 
> ```json
> {"insert":"console.log('hello')","attributes":{"code-block": true}},
> {"insert":"\n"}
> ```
> 
> With this new version it was solved:
>
> ```json
> {"insert":"console.log('hello')"}
> {"insert":"\n","attributes":{"code-block": true}}
> ```

## Related Issues

*Fix https://github.com/singerdmx/flutter-quill/pull/1997#issuecomment-2220198438*

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.