### PR TITLE
Fix(test): delta_x tests fail by wrong expected Delta for video embed

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   flutter_colorpicker: ^1.1.0
 
   # For converting HTML to Quill delta
-  flutter_quill_delta_from_html: ^1.3.0
+  flutter_quill_delta_from_html: ^1.3.1
   markdown: ^7.2.1
   charcode: ^1.3.1
 

--- a/test/utils/delta_x_test.dart
+++ b/test/utils/delta_x_test.dart
@@ -32,14 +32,13 @@ void main() {
   ]);
 
   final expectedDeltaVideo = Delta.fromOperations([
-    Operation.insert('\n'),
     Operation.insert({'video': 'https://www.youtube.com/embed/dQw4w9WgXcQ'}),
     Operation.insert('\n'),
   ]);
 
   final expectedDeltaLinkAndVideoLink = Delta.fromOperations([
     Operation.insert('fdsfsd', {'link': 'https://www.macrumors.com/'}),
-    Operation.insert('\n\n'),
+    Operation.insert('\n'),
     Operation.insert({'video': 'https://www.youtube.com/embed/dQw4w9WgXcQ'}),
     Operation.insert('\n'),
   ]);


### PR DESCRIPTION
## Description

Fixed a problem that occurred when testing the `delta_x_test` file because it was not modified taking into account that the format of the `video embed` insertion changed. Previously, a new line was intentionally inserted before inserting the embedded video, however, this behavior was removed since it is not necessary to separate the text from the video block if they are together

## Related Issues

*Related https://github.com/singerdmx/flutter-quill/pull/2008#issuecomment-2226939049*

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.