### PR TITLE
Feat(config): added option to disable automatic list conversion

### DIFF
--- a/lib/src/models/config/editor/editor_configurations.dart
+++ b/lib/src/models/config/editor/editor_configurations.dart
@@ -53,6 +53,7 @@ class QuillEditorConfigurations extends Equatable {
     this.onSingleLongTapStart,
     this.onSingleLongTapMoveUpdate,
     this.onSingleLongTapEnd,
+    this.enableMarkdownStyleConversion = true,
     this.embedBuilders,
     this.unknownEmbedBuilder,
     this.linkActionPickerDelegate = defaultLinkActionPickerDelegate,
@@ -126,6 +127,13 @@ class QuillEditorConfigurations extends Equatable {
   /// by default it will by true
   final bool scrollable;
   final double scrollBottomInset;
+
+  /// Configuration to enable or disable automatic Markdown style conversions.
+  ///
+  /// This setting controls the behavior of input. Specifically, when enabled,
+  /// entering '1.' followed by a space or '-' followed by a space
+  /// will automatically convert the input into a Markdown list format.
+  final bool enableMarkdownStyleConversion;
 
   /// Additional space around the content of this editor.
   /// by default will be [EdgeInsets.zero]
@@ -385,6 +393,7 @@ class QuillEditorConfigurations extends Equatable {
     bool? checkBoxReadOnly,
     bool? disableClipboard,
     bool? scrollable,
+    bool? enableMarkdownStyleConversion,
     double? scrollBottomInset,
     EdgeInsetsGeometry? padding,
     bool? autoFocus,
@@ -439,6 +448,8 @@ class QuillEditorConfigurations extends Equatable {
       scrollable: scrollable ?? this.scrollable,
       scrollBottomInset: scrollBottomInset ?? this.scrollBottomInset,
       padding: padding ?? this.padding,
+      enableMarkdownStyleConversion:
+          enableMarkdownStyleConversion ?? this.enableMarkdownStyleConversion,
       autoFocus: autoFocus ?? this.autoFocus,
       isOnTapOutsideEnabled:
           isOnTapOutsideEnabled ?? this.isOnTapOutsideEnabled,

--- a/lib/src/models/config/raw_editor/raw_editor_configurations.dart
+++ b/lib/src/models/config/raw_editor/raw_editor_configurations.dart
@@ -67,6 +67,7 @@ class QuillRawEditorConfigurations extends Equatable {
     this.customActions,
     this.expands = false,
     this.isOnTapOutsideEnabled = true,
+    this.enableMarkdownStyleConversion = true,
     this.onTapOutside,
     this.keyboardAppearance,
     this.enableInteractiveSelection = true,
@@ -99,6 +100,8 @@ class QuillRawEditorConfigurations extends Equatable {
 
   /// Additional space around the editor contents.
   final EdgeInsetsGeometry padding;
+
+  final bool enableMarkdownStyleConversion;
 
   /// Whether the text can be changed.
   ///

--- a/lib/src/widgets/editor/editor.dart
+++ b/lib/src/widgets/editor/editor.dart
@@ -236,6 +236,8 @@ class QuillEditorState extends State<QuillEditor>
               focusNode: widget.focusNode,
               scrollController: widget.scrollController,
               scrollable: configurations.scrollable,
+              enableMarkdownStyleConversion:
+                  configurations.enableMarkdownStyleConversion,
               scrollBottomInset: configurations.scrollBottomInset,
               padding: configurations.padding,
               readOnly: configurations.readOnly,

--- a/lib/src/widgets/raw_editor/raw_editor_state.dart
+++ b/lib/src/widgets/raw_editor/raw_editor_state.dart
@@ -785,10 +785,12 @@ class QuillRawEditorState extends EditorState
 
     const olKeyPhrase = '1.';
     const ulKeyPhrase = '-';
+    final enableMdConversion =
+        widget.configurations.enableMarkdownStyleConversion;
 
-    if (text.value == olKeyPhrase) {
+    if (text.value == olKeyPhrase && enableMdConversion) {
       _updateSelectionForKeyPhrase(olKeyPhrase, Attribute.ol);
-    } else if (text.value == ulKeyPhrase) {
+    } else if (text.value == ulKeyPhrase && enableMdConversion) {
       _updateSelectionForKeyPhrase(ulKeyPhrase, Attribute.ul);
     } else {
       return KeyEventResult.ignored;


### PR DESCRIPTION
## Description

If you input '1.' and space or input '-' and space. It will auto convert to the markdown style. By this, was added an option that allows developers to remove/ignore this behavior.

_By default it is activated_

### Why might it be necessary?

It turns out that many times, developers do not want or do not want their editors to have features that could make them appear to allow conversion of Markdown syntax to the syntax that the editor understands.

By adding this option, it even makes the user experience more comfortable, since for several users it could be annoying that a "1." or "-" are converted directly to a list, since you probably just wanted to add these respective characters manually.

## Related Issues

*Fix #1966*
*Related  #1949*

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.