### PR TITLE
Fix outdated contributor guide link on PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@
 
 ## Checklist
 
-- [ ] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
+- [ ] I read the [Contributor Guide](https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
 - [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
 - [ ] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
 - [ ] All existing and new tests are passing.


### PR DESCRIPTION
## Description

Changed the previous redirect since it did not lead to the contribution guide page used by the package

## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.