### PR TITLE
 Fix(rule): PreserveInlineStyleRule assume the type of the operation data and throw stacktrace

### DIFF
--- a/lib/src/models/rules/insert.dart
+++ b/lib/src/models/rules/insert.dart
@@ -568,7 +568,8 @@ class PreserveInlineStylesRule extends InsertRule {
       if (prevData.endsWith('\n')) {
         /// If current line is empty get attributes from a prior line
         final currLine = itr.next();
-        final currData = currLine.data is String ? currLine.data as String : null;
+        final currData =
+            currLine.data is String ? currLine.data as String : null;
         if (currData != null && (currData.isEmpty || currData[0] == '\n')) {
           if (prevData.trimRight().isEmpty) {
             final back =

--- a/lib/src/models/rules/insert.dart
+++ b/lib/src/models/rules/insert.dart
@@ -568,17 +568,19 @@ class PreserveInlineStylesRule extends InsertRule {
       if (prevData.endsWith('\n')) {
         /// If current line is empty get attributes from a prior line
         final currLine = itr.next();
-        final currData = currLine.data as String?;
-        if (currData != null && (currData.isEmpty || currData[0] == '\n')) {
-          if (prevData.trimRight().isEmpty) {
-            final back =
-                DeltaIterator(documentDelta).skip(index - prevData.length);
-            if (back != null && back.data is String) {
-              prev = back;
+        if (currLine.data is String) {
+          final currData = currLine.data as String?;
+          if (currData != null && (currData.isEmpty || currData[0] == '\n')) {
+            if (prevData.trimRight().isEmpty) {
+              final back =
+                  DeltaIterator(documentDelta).skip(index - prevData.length);
+              if (back != null && back.data is String) {
+                prev = back;
+              }
             }
+          } else {
+            prev = currLine;
           }
-        } else {
-          prev = currLine;
         }
       }
     }

--- a/lib/src/models/rules/insert.dart
+++ b/lib/src/models/rules/insert.dart
@@ -568,19 +568,17 @@ class PreserveInlineStylesRule extends InsertRule {
       if (prevData.endsWith('\n')) {
         /// If current line is empty get attributes from a prior line
         final currLine = itr.next();
-        if (currLine.data is String) {
-          final currData = currLine.data as String?;
-          if (currData != null && (currData.isEmpty || currData[0] == '\n')) {
-            if (prevData.trimRight().isEmpty) {
-              final back =
-                  DeltaIterator(documentDelta).skip(index - prevData.length);
-              if (back != null && back.data is String) {
-                prev = back;
-              }
+        final currData = currLine.data is String ? currLine.data as String : null;
+        if (currData != null && (currData.isEmpty || currData[0] == '\n')) {
+          if (prevData.trimRight().isEmpty) {
+            final back =
+                DeltaIterator(documentDelta).skip(index - prevData.length);
+            if (back != null && back.data is String) {
+              prev = back;
             }
-          } else {
-            prev = currLine;
           }
+        } else {
+          prev = currLine;
         }
       }
     }


### PR DESCRIPTION
## Description

I understand if you take this as something that normally wouldn't happen, but in the event that some developer creates their own `CustomEmbedBlock`, these types of errors are better to avoid from the beginning.

In this case, I have a video that explains a little better how I reproduced this error (it is not easy to reproduce. I had to record several times until I finally managed it)

_Yeah, the PR was repeated because I accidentally deleted the branch_

https://github.com/user-attachments/assets/8902f1c8-d5d9-445b-88ed-9a066f8bc518


## Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] I have run the commands in `./scripts/before_push.sh` and it all passed successfully

## Breaking Change

Does your PR require developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.