### PR TITLE
fix: require 10.0.0 as minimum version for quill packages

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,10 +13,10 @@ dependencies:
   cupertino_icons: ^1.0.6
 
   # Flutter Quill Packages
-  flutter_quill: ^9.3.4
-  dart_quill_delta: ^9.3.4
-  flutter_quill_extensions: ^9.3.4
-  flutter_quill_test: ^9.3.4
+  flutter_quill: ^10.0.0
+  dart_quill_delta: ^10.0.0
+  flutter_quill_extensions: ^10.0.0
+  flutter_quill_test: ^10.0.0
   # Dart Packages
   path: ^1.8.3
   equatable: ^2.0.5

--- a/flutter_quill_extensions/pubspec.yaml
+++ b/flutter_quill_extensions/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   universal_html: ^2.2.4
   cross_file: ^0.3.3+6
 
-  flutter_quill: ^9.5.1
+  flutter_quill: ^10.0.0
   photo_view: ^0.15.0
   youtube_explode_dart: ^2.2.1
 

--- a/flutter_quill_test/pubspec.yaml
+++ b/flutter_quill_test/pubspec.yaml
@@ -28,7 +28,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_quill: ^9.0.0-dev-6
+  flutter_quill: ^10.0.0
   flutter_test:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
 
   # Dart Packages
   intl: ^0.19.0
-  dart_quill_delta: ^9.3.3
+  dart_quill_delta: ^10.0.0
   collection: ^1.17.0
   quiver: ^3.2.1
   equatable: ^2.0.5
@@ -54,7 +54,7 @@ dependencies:
   flutter_colorpicker: ^1.1.0
 
   # For converting HTML to Quill delta
-  flutter_quill_delta_from_html: ^1.3.12
+  flutter_quill_delta_from_html: ^1.3.13
   markdown: ^7.2.1
   charcode: ^1.3.1
 
@@ -67,7 +67,7 @@ dev_dependencies:
   flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter
-  flutter_quill_test: ^9.3.4
+  flutter_quill_test: ^10.0.0
   test: ^1.24.3
 
   # For scripts only


### PR DESCRIPTION
<!-- 

Thank you for contributing.

Provide a description of your changes below and a general summary in the title.

-->

## Description

*Require version `10.0.0` as the minimum version for all repo and related quill packages to fix build failure.*

## Related Issues

- *Fix #2034*

## Type of Change

<!--- 

Put an x in all the boxes that apply:

- [x] **Example:**

-->

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [x] 🗑️ **Chore:** Routine tasks, tests, or maintenance.
- [x] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions

I suggest that we plan the future major releases and their breaking changes and discuss them before releasing them so all maintainers and contributors are aware of them.