### PR TITLE
if magnifier removes toolbar, restore it when it is hidden

### DIFF
--- a/lib/src/editor/widgets/text/text_selection.dart
+++ b/lib/src/editor/widgets/text/text_selection.dart
@@ -181,6 +181,7 @@ class EditorTextSelectionOverlay {
 
   /// A copy/paste toolbar.
   OverlayEntry? toolbar;
+  bool _restoreToolbar = false;
 
   TextSelection get _selection => value.selection;
 
@@ -411,8 +412,12 @@ class EditorTextSelectionOverlay {
   void _showMagnifier(MagnifierInfo initialMagnifierInfo) {
     // 隐藏toolbar
     if (toolbar != null) {
+      _restoreToolbar = true;
       hideToolbar();
+    } else {
+      _restoreToolbar = false;
     }
+
     // 更新 magnifierInfo
     _magnifierInfo.value = initialMagnifierInfo;
 
@@ -456,6 +461,10 @@ class EditorTextSelectionOverlay {
       return;
     }
     _magnifierController.hide();
+    if (_restoreToolbar) {
+      _restoreToolbar = false;
+      showToolbar();
+    }
   }
 
   // build magnifier info


### PR DESCRIPTION
<!-- 

Thank you for contributing.

Provide a description of your changes below and a general summary in the title.

Consider reading the Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md.

The changes of `CHANGELOG.md` and package version in `pubspec.yaml` are automated.

-->

## Description

Magnifier is removing selection context menu, but not restoring the menu after it's dismissed. This PR fixes that bug

- *Fix #2046*

## Type of Change

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.