### PR TITLE
fix: textInputAction is not set when creating QuillRawEditorConfiguration

### DIFF
--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -299,6 +299,7 @@ class QuillEditorState extends State<QuillEditor>
               scribbleAreaInsets: configurations.scribbleAreaInsets,
               readOnlyMouseCursor: configurations.readOnlyMouseCursor,
               magnifierConfiguration: configurations.magnifierConfiguration,
+              textInputAction: configurations.textInputAction,
             ),
           ),
         ),


### PR DESCRIPTION
## Description

The `textInputAction` is not correctly set in `QuillEditorState.build()` when creating `QuillRawEditorConfiguration` instance.

## Related Issues

- Fix #1328 

## Type of Change

<!--- 

Put an x in all the boxes that apply:

- [x] **Example:**

-->

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions

<!-- Optional -->