### PR TITLE
Fix: RTL issues

### DIFF
--- a/lib/src/common/utils/directionality.dart
+++ b/lib/src/common/utils/directionality.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+bool isRTLLanguage(Locale locale) {
+  final rtlLanguages = [
+    'ar', // Arabic
+    'dv', // Divehi (Maldivian)
+    'fa', // Persian (Farsi)
+    'ha', // Hausa (in Ajami script)
+    'he', // Hebrew
+    'khw', // Khowar (in Arabic script)
+    'ks', // Kashmiri (in Arabic script)
+    'ku', // Kurdish (Sorani)
+    'ps', // Pashto
+    'ur', // Urdu
+    'yi', // Yiddish
+    'sd', // Sindhi
+    'ug', // Uyghur
+  ];
+  return rtlLanguages.contains(locale.languageCode);
+}
+
+bool isRTL(BuildContext context) {
+  return isRTLLanguage(Localizations.localeOf(context));
+}

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -23,6 +23,7 @@ import '../../common/structs/horizontal_spacing.dart';
 import '../../common/structs/offset_value.dart';
 import '../../common/structs/vertical_spacing.dart';
 import '../../common/utils/cast.dart';
+import '../../common/utils/directionality.dart';
 import '../../common/utils/platform.dart';
 import '../../controller/quill_controller.dart';
 import '../../delta/delta_diff.dart';
@@ -975,16 +976,23 @@ class QuillRawEditorState extends EditorState
       }
 
       prevNodeOl = attrs[Attribute.list.key] == Attribute.ol;
-
+      var nodeTextDirection = getDirectionOfNode(node);
+      // verify if the direction from nodeTextDirection is the default direction 
+      // and watch if the system language is a RTL language and avoid putting
+      // to the edge of the left side any checkbox or list point/number if is a
+      // RTL language
+      if(nodeTextDirection == TextDirection.ltr && isRTL(context)){
+        nodeTextDirection = TextDirection.rtl; 
+      }
       if (node is Line) {
         final editableTextLine = _getEditableTextLineFromNode(node, context);
         result.add(Directionality(
-            textDirection: getDirectionOfNode(node), child: editableTextLine));
+            textDirection: nodeTextDirection, child: editableTextLine));
       } else if (node is Block) {
         final editableTextBlock = EditableTextBlock(
           block: node,
           controller: controller,
-          textDirection: getDirectionOfNode(node),
+          textDirection: nodeTextDirection,
           scrollBottomInset: widget.configurations.scrollBottomInset,
           horizontalSpacing: _getHorizontalSpacingForBlock(node, _styles),
           verticalSpacing: _getVerticalSpacingForBlock(node, _styles),
@@ -1011,7 +1019,7 @@ class QuillRawEditorState extends EditorState
         );
         result.add(
           Directionality(
-            textDirection: getDirectionOfNode(node),
+            textDirection: nodeTextDirection,
             child: editableTextBlock,
           ),
         );

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -977,12 +977,12 @@ class QuillRawEditorState extends EditorState
 
       prevNodeOl = attrs[Attribute.list.key] == Attribute.ol;
       var nodeTextDirection = getDirectionOfNode(node);
-      // verify if the direction from nodeTextDirection is the default direction 
+      // verify if the direction from nodeTextDirection is the default direction
       // and watch if the system language is a RTL language and avoid putting
       // to the edge of the left side any checkbox or list point/number if is a
       // RTL language
-      if(nodeTextDirection == TextDirection.ltr && isRTL(context)){
-        nodeTextDirection = TextDirection.rtl; 
+      if (nodeTextDirection == TextDirection.ltr && isRTL(context)) {
+        nodeTextDirection = TextDirection.rtl;
       }
       if (node is Line) {
         final editableTextLine = _getEditableTextLineFromNode(node, context);

--- a/lib/src/editor/widgets/text/text_block.dart
+++ b/lib/src/editor/widgets/text/text_block.dart
@@ -3,6 +3,7 @@ import 'package:flutter/rendering.dart';
 
 import '../../../common/structs/horizontal_spacing.dart';
 import '../../../common/structs/vertical_spacing.dart';
+import '../../../common/utils/directionality.dart';
 import '../../../common/utils/font.dart';
 import '../../../controller/quill_controller.dart';
 import '../../../delta/delta_diff.dart';
@@ -134,6 +135,15 @@ class EditableTextBlock extends StatelessWidget {
       Block node, DefaultStyles? defaultStyles) {
     final attrs = block.style.attributes;
     if (attrs.containsKey(Attribute.blockQuote.key)) {
+      // Verify if the direction is RTL and avoid passing the decoration
+      // to the left when need to be on right side
+      if(textDirection == TextDirection.rtl){
+        return defaultStyles!.quote!.decoration?.copyWith(
+          border: Border(
+            right: BorderSide(width: 4, color: Colors.grey.shade300),
+          ),
+        );
+      }
       return defaultStyles!.quote!.decoration;
     }
     if (attrs.containsKey(Attribute.codeBlock.key)) {
@@ -184,7 +194,14 @@ class EditableTextBlock extends StatelessWidget {
         MediaQuery.devicePixelRatioOf(context),
         cursorCont,
       );
-      final nodeTextDirection = getDirectionOfNode(line);
+      var nodeTextDirection = getDirectionOfNode(line);
+      // verify if the direction from nodeTextDirection is the default direction 
+      // and watch if the system language is a RTL language and avoid putting
+      // to the edge of the left side any checkbox or list point/number if is a
+      // RTL language
+      if(nodeTextDirection == TextDirection.ltr && isRTL(context)){
+        nodeTextDirection = TextDirection.rtl; 
+      }
       children.add(
         Directionality(
           textDirection: nodeTextDirection,

--- a/lib/src/editor/widgets/text/text_block.dart
+++ b/lib/src/editor/widgets/text/text_block.dart
@@ -137,7 +137,7 @@ class EditableTextBlock extends StatelessWidget {
     if (attrs.containsKey(Attribute.blockQuote.key)) {
       // Verify if the direction is RTL and avoid passing the decoration
       // to the left when need to be on right side
-      if(textDirection == TextDirection.rtl){
+      if (textDirection == TextDirection.rtl) {
         return defaultStyles!.quote!.decoration?.copyWith(
           border: Border(
             right: BorderSide(width: 4, color: Colors.grey.shade300),
@@ -195,12 +195,12 @@ class EditableTextBlock extends StatelessWidget {
         cursorCont,
       );
       var nodeTextDirection = getDirectionOfNode(line);
-      // verify if the direction from nodeTextDirection is the default direction 
+      // verify if the direction from nodeTextDirection is the default direction
       // and watch if the system language is a RTL language and avoid putting
       // to the edge of the left side any checkbox or list point/number if is a
       // RTL language
-      if(nodeTextDirection == TextDirection.ltr && isRTL(context)){
-        nodeTextDirection = TextDirection.rtl; 
+      if (nodeTextDirection == TextDirection.ltr && isRTL(context)) {
+        nodeTextDirection = TextDirection.rtl;
       }
       children.add(
         Directionality(

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -11,9 +11,7 @@ import 'package:flutter/services.dart' show ClipboardData, Clipboard;
 import 'package:url_launcher/url_launcher_string.dart' show launchUrlString;
 
 import '../../../../flutter_quill.dart';
-import '../../../../translations.dart';
 import '../../../common/utils/color.dart';
-import '../../../common/utils/directionality.dart';
 import '../../../common/utils/font.dart';
 import '../../../common/utils/platform.dart';
 import '../../../document/nodes/container.dart' as container_node;

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -11,7 +11,9 @@ import 'package:flutter/services.dart' show ClipboardData, Clipboard;
 import 'package:url_launcher/url_launcher_string.dart' show launchUrlString;
 
 import '../../../../flutter_quill.dart';
+import '../../../../translations.dart';
 import '../../../common/utils/color.dart';
+import '../../../common/utils/directionality.dart';
 import '../../../common/utils/font.dart';
 import '../../../common/utils/platform.dart';
 import '../../../document/nodes/container.dart' as container_node;


### PR DESCRIPTION
## Description

As we know, we always have issues related with the RTL directionality. At this moment, the current implementation of List, Checkbox or Blockquote, force the direction to be LTR, even if the system language is a RTL. 

_To test this i use some languages as **hebrew** or **arabic** that are RTL (as far i know)_

### Before these changes

![Before 1](https://github.com/user-attachments/assets/156df6b9-4d25-4512-88a0-8078809e2fb9) ![Before 2(1)](https://github.com/user-attachments/assets/89d9e664-9a97-47aa-805f-84c817a18345)

### After these changes

![After1(1)](https://github.com/user-attachments/assets/f5e3c6a0-1ef4-4c26-a5c1-e5c912400d22) ![After2](https://github.com/user-attachments/assets/5ada700b-b13f-4bc1-a890-95691a0c1aff) ![After3](https://github.com/user-attachments/assets/05bf0d0b-47ae-466d-b71c-b38b57be41f3)


## Related Issues

*Fix #1928*

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.


## Suggestions

We really **need** to avoid harcode the widgets on the editor. 

I'll try to separate the logic to another file and make more extensible soon