### PR TITLE
feat: add callback to handle performAction

### DIFF
--- a/lib/src/editor/config/editor_configurations.dart
+++ b/lib/src/editor/config/editor_configurations.dart
@@ -81,6 +81,7 @@ class QuillEditorConfigurations extends Equatable {
     this.onScribbleActivated,
     this.scribbleAreaInsets,
     this.readOnlyMouseCursor = SystemMouseCursors.text,
+    this.onPerformAction,
   });
 
   final QuillSharedConfigurations sharedConfigurations;
@@ -374,6 +375,9 @@ class QuillEditorConfigurations extends Equatable {
   /// Optional insets for the scribble area.
   final EdgeInsets? scribbleAreaInsets;
 
+  /// Called when a text input action is performed.
+  final void Function(TextInputAction action)? onPerformAction;
+
   @override
   List<Object?> get props => [
         placeholder,
@@ -437,6 +441,7 @@ class QuillEditorConfigurations extends Equatable {
     bool? enableScribble,
     void Function()? onScribbleActivated,
     EdgeInsets? scribbleAreaInsets,
+    void Function(TextInputAction action)? onPerformAction,
   }) {
     return QuillEditorConfigurations(
       sharedConfigurations: sharedConfigurations ?? this.sharedConfigurations,
@@ -503,6 +508,7 @@ class QuillEditorConfigurations extends Equatable {
       enableScribble: enableScribble ?? this.enableScribble,
       onScribbleActivated: onScribbleActivated ?? this.onScribbleActivated,
       scribbleAreaInsets: scribbleAreaInsets ?? this.scribbleAreaInsets,
+      onPerformAction: onPerformAction ?? this.onPerformAction,
     );
   }
 }

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -300,6 +300,7 @@ class QuillEditorState extends State<QuillEditor>
               readOnlyMouseCursor: configurations.readOnlyMouseCursor,
               magnifierConfiguration: configurations.magnifierConfiguration,
               textInputAction: configurations.textInputAction,
+              onPerformAction: configurations.onPerformAction,
             ),
           ),
         ),

--- a/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
@@ -89,6 +89,7 @@ class QuillRawEditorConfigurations extends Equatable {
     this.scribbleAreaInsets,
     this.readOnlyMouseCursor = SystemMouseCursors.text,
     this.magnifierConfiguration,
+    this.onPerformAction,
   });
 
   /// Controls the document being edited.
@@ -340,6 +341,9 @@ class QuillRawEditorConfigurations extends Equatable {
   final EdgeInsets? scribbleAreaInsets;
 
   final TextMagnifierConfiguration? magnifierConfiguration;
+
+  /// Called when a text input action is performed.
+  final void Function(TextInputAction action)? onPerformAction;
 
   @override
   List<Object?> get props => [

--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -212,7 +212,7 @@ mixin RawEditorStateTextInputClientMixin on EditorState
 
   @override
   void performAction(TextInputAction action) {
-    // no-op
+    widget.configurations.onPerformAction?.call(action);
   }
 
   @override


### PR DESCRIPTION
<!-- 

Thank you for contributing.

Provide a description of your changes below and a general summary in the title.

Consider reading the Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md.

The changes of `CHANGELOG.md` and package version in `pubspec.yaml` are automated.

-->

## Description

Add `onPerformAction` callback in `QuillEditorConfigurations` to enable developers to handle text input action from soft keyboard.

After I fixed TextInputAction issue in #2057, I find that there is no way to handle the action right now. That's why I create this PR.

## Related Issues

<!--

Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/singerdmx/flutter-quill/issues). Indicate, which of these issues are resolved or fixed by this PR.

-->

<!-- *e.g.* -->
N/A

## Type of Change

<!--- 

Put an x in all the boxes that apply:

- [x] **Example:**

-->

- [x] ✨ **New feature:** Adds new functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions

<!-- Optional -->