### PR TITLE
fix: Hide selection toolbar if editor loses focus

### DIFF
--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -174,16 +174,28 @@ class QuillEditorState extends State<QuillEditor>
   @override
   void initState() {
     super.initState();
-    widget.configurations.controller.editorFocusNode ??= widget.focusNode;
-    if (configurations.autoFocus) {
-      widget.configurations.controller.editorFocusNode?.requestFocus();
-    }
+
     _editorKey = configurations.editorKey ?? GlobalKey<EditorState>();
     _selectionGestureDetectorBuilder =
         _QuillEditorSelectionGestureDetectorBuilder(
       this,
       configurations.detectWordBoundary,
     );
+
+    final focusNode =
+        widget.configurations.controller.editorFocusNode ?? widget.focusNode;
+    widget.configurations.controller.editorFocusNode = focusNode;
+
+    if (configurations.autoFocus) {
+      focusNode.requestFocus();
+    }
+
+    // Hide toolbar when the editor loses focus.
+    focusNode.addListener(() {
+      if (!focusNode.hasFocus) {
+        _editorKey.currentState?.hideToolbar();
+      }
+    });
   }
 
   @override


### PR DESCRIPTION
<!-- 

Thank you for contributing.

Provide a description of your changes below and a general summary in the title.

Consider reading the Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md.

The changes of `CHANGELOG.md` and package version in `pubspec.yaml` are automated.

-->

## Description

Currently, selection toolbar doesn't hide itself when editor loses focus. It looks wired on a page including more than one focusable widgets.

## Related Issues

<!--

Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/singerdmx/flutter-quill/issues). Indicate, which of these issues are resolved or fixed by this PR.

-->

<!-- *e.g.* -->
N/A

## Type of Change

<!--- 

Put an x in all the boxes that apply:

- [x] **Example:**

-->

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions

<!-- Optional -->