### PR TITLE
restore ability to pass in key to QuillEditor

### DIFF
--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -141,6 +141,7 @@ class QuillEditor extends StatefulWidget {
   factory QuillEditor({
     required FocusNode focusNode,
     required ScrollController scrollController,
+    Key? key,
 
     /// Controller and configurations are required
     ///
@@ -164,13 +165,15 @@ class QuillEditor extends StatefulWidget {
     return QuillEditor._(
         focusNode: focusNode,
         scrollController: scrollController,
-        controller: controller);
+        controller: controller,
+        key: key);
   }
 
   const QuillEditor._(
       {required this.focusNode,
       required this.scrollController,
-      required this.controller});
+      required this.controller,
+      super.key});
 
   factory QuillEditor.basic({
     /// The controller for the quill editor widget of flutter quill


### PR DESCRIPTION
## Description

commit 23fbb43 - Move Controller outside of configurations data class (singerdmx#2078) (replacing default QuillEditor constructor with factory method) removed the ability to pass in a key when QuillEditor is constructed.  

This PR restores that ability by adding an option key parameter to the factory method.

- [x ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
