### PR TITLE
enhance stringToColor with a custom defined palette from `DefaultStyles`

### DIFF
--- a/lib/src/common/utils/color.dart
+++ b/lib/src/common/utils/color.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../../flutter_quill.dart';
+import '../../editor/widgets/default_styles.dart';
 
 Color stringToColor(String? s,
     [Color? originalColor, DefaultStyles? defaultStyles]) {

--- a/lib/src/common/utils/color.dart
+++ b/lib/src/common/utils/color.dart
@@ -1,6 +1,17 @@
 import 'package:flutter/material.dart';
 
-Color stringToColor(String? s, [Color? originalColor]) {
+import '../../../flutter_quill.dart';
+
+Color stringToColor(String? s,
+    [Color? originalColor, DefaultStyles? defaultStyles]) {
+  final palette = defaultStyles?.palette;
+  if (s != null && palette != null) {
+    final maybeColor = palette[s];
+    if (maybeColor != null) {
+      return maybeColor;
+    }
+  }
+
   switch (s) {
     case 'transparent':
       return Colors.transparent;

--- a/lib/src/editor/widgets/default_styles.dart
+++ b/lib/src/editor/widgets/default_styles.dart
@@ -200,6 +200,7 @@ class DefaultStyles {
     this.sizeSmall,
     this.sizeLarge,
     this.sizeHuge,
+    this.palette,
   });
 
   final DefaultTextBlockStyle? h1;
@@ -235,6 +236,9 @@ class DefaultStyles {
   final DefaultTextBlockStyle? indent;
   final DefaultTextBlockStyle? align;
   final DefaultTextBlockStyle? leading;
+
+  /// Custom palette of colors
+  final Map<String, Color>? palette;
 
   static DefaultStyles getInstance(BuildContext context) {
     final themeData = Theme.of(context);
@@ -518,6 +522,7 @@ class DefaultStyles {
       sizeSmall: other.sizeSmall ?? sizeSmall,
       sizeLarge: other.sizeLarge ?? sizeLarge,
       sizeHuge: other.sizeHuge ?? sizeHuge,
+      palette: other.palette ?? palette,
     );
   }
 }

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -445,7 +445,7 @@ class _TextLineState extends State<TextLine> {
         if (k == Attribute.underline.key || k == Attribute.strikeThrough.key) {
           var textColor = defaultStyles.color;
           if (color?.value is String) {
-            textColor = stringToColor(color?.value, textColor);
+            textColor = stringToColor(color?.value, textColor, defaultStyles);
           }
           res = _merge(res.copyWith(decorationColor: textColor),
               s!.copyWith(decorationColor: textColor));
@@ -499,7 +499,7 @@ class _TextLineState extends State<TextLine> {
     if (color != null && color.value != null) {
       var textColor = defaultStyles.color;
       if (color.value is String) {
-        textColor = stringToColor(color.value);
+        textColor = stringToColor(color.value, null, defaultStyles);
       }
       if (textColor != null) {
         res = res.merge(TextStyle(color: textColor));
@@ -508,7 +508,8 @@ class _TextLineState extends State<TextLine> {
 
     final background = nodeStyle.attributes[Attribute.background.key];
     if (background != null && background.value != null) {
-      final backgroundColor = stringToColor(background.value);
+      final backgroundColor =
+          stringToColor(background.value, null, defaultStyles);
       res = res.merge(TextStyle(backgroundColor: backgroundColor));
     }
 


### PR DESCRIPTION
## Description

This change allows overriding and extending colors provided by `stringToColor`.  You're now able to define custom colors in `DefautStyles` e.g.:

```dart
palette: {
  "primary": Colors.red,
  "secondary": Colors.blue
}
```

and later use it:

```
BackgroundAttribute("primary")
```

### Why?

This is particularly useful if your app has multiple themes and some limited color set per each theme. Currently there is a big [switch](https://github.com/singerdmx/flutter-quill/blob/master/lib/src/common/utils/color.dart#L4) with hardcoded values in `stringToColor` which cannot be customized. This PR solves this problem without introducing any breaking changes.

## Related Issues

There was no issue for this.

## Type of Change

- [x] ✨ **New feature:** Adds new functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions

This switch could be a default palette https://github.com/singerdmx/flutter-quill/blob/master/lib/src/common/utils/color.dart#L4 🤔 