### PR TITLE
Fix(example): image_cropper outdated version

### DIFF
--- a/example/lib/screens/quill/my_quill_toolbar.dart
+++ b/example/lib/screens/quill/my_quill_toolbar.dart
@@ -31,16 +31,16 @@ class MyQuillToolbar extends StatelessWidget {
   ) async {
     final croppedFile = await ImageCropper().cropImage(
       sourcePath: image,
-      aspectRatioPresets: [
-        CropAspectRatioPreset.square,
-        CropAspectRatioPreset.ratio3x2,
-        CropAspectRatioPreset.original,
-        CropAspectRatioPreset.ratio4x3,
-        CropAspectRatioPreset.ratio16x9
-      ],
       uiSettings: [
         AndroidUiSettings(
           toolbarTitle: 'Cropper',
+          aspectRatioPresets: [
+            CropAspectRatioPreset.square,
+            CropAspectRatioPreset.ratio3x2,
+            CropAspectRatioPreset.original,
+            CropAspectRatioPreset.ratio4x3,
+            CropAspectRatioPreset.ratio16x9
+          ],
           toolbarColor: Colors.deepOrange,
           toolbarWidgetColor: Colors.white,
           initAspectRatio: CropAspectRatioPreset.original,
@@ -48,6 +48,13 @@ class MyQuillToolbar extends StatelessWidget {
         ),
         IOSUiSettings(
           title: 'Cropper',
+          aspectRatioPresets: [
+            CropAspectRatioPreset.square,
+            CropAspectRatioPreset.ratio3x2,
+            CropAspectRatioPreset.original,
+            CropAspectRatioPreset.ratio4x3,
+            CropAspectRatioPreset.ratio16x9
+          ],
         ),
         WebUiSettings(
           context: context,

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   json_annotation: ^4.8.1
 
   # Plugins
-  image_cropper: ^5.0.1
+  image_cropper: ^8.0.1
   path_provider: ^2.1.2
   # For drag and drop feature
   desktop_drop: ^0.4.4


### PR DESCRIPTION
## Description

If we update to the lastest `Flutter` version, when we try to run the example, this one will fail and it shows this stacktrace:

```console
Target dart2js failed: ProcessException: Process exited abnormally with exit code 1:
../../../../.pub-cache/hosted/pub.dev/image_cropper_platform_interface-5.0.0/lib/src/models/cropped_file/html.dart:32:38:
Error: The method 'UnmodifiableUint8ListView' isn't defined for the class 'CroppedFile'.
- 'CroppedFile' is from 'package:image_cropper_platform_interface/src/models/cropped_file/html.dart' ('../../../../.pub-cache/hosted/pub.dev/image_cropper_platform_interface-5.0.0/lib/src/models/cropped_file/html.dart').
return Future.value(UnmodifiableUint8ListView(_initBytes!));
^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Compilation failed.
```

This happens because since Dart 3.4 `UnmodifiableUint8ListView` was deprecated. [see this](https://github.com/dart-lang/sdk/issues/53218).

## Related Issues

- *Related https://github.com/singerdmx/flutter-quill/pull/2095#issuecomment-2278209015*

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.