### PR TITLE
Using dart.library.js_interop instead of dart.library.html

### DIFF
--- a/flutter_quill_extensions/lib/embeds/image/editor/image_web_embed.dart
+++ b/flutter_quill_extensions/lib/embeds/image/editor/image_web_embed.dart
@@ -5,7 +5,8 @@ import 'package:universal_html/html.dart' as html;
 
 import '../../../models/config/image/editor/image_web_configurations.dart';
 import '../../../utils/dart_ui/dart_ui_fake.dart'
-    if (dart.library.html) '../../../utils/dart_ui/dart_ui_real.dart' as ui;
+    if (dart.library.js_interop) '../../../utils/dart_ui/dart_ui_real.dart'
+    as ui;
 import '../../../utils/element_utils/element_web_utils.dart';
 import '../../../utils/utils.dart';
 

--- a/flutter_quill_extensions/lib/embeds/video/editor/video_web_embed.dart
+++ b/flutter_quill_extensions/lib/embeds/video/editor/video_web_embed.dart
@@ -6,7 +6,8 @@ import 'package:youtube_player_flutter/youtube_player_flutter.dart'
 
 import '../../../models/config/video/editor/video_web_configurations.dart';
 import '../../../utils/dart_ui/dart_ui_fake.dart'
-    if (dart.library.html) '../../../utils/dart_ui/dart_ui_real.dart' as ui;
+    if (dart.library.js_interop) '../../../utils/dart_ui/dart_ui_real.dart'
+    as ui;
 import '../../../utils/element_utils/element_web_utils.dart';
 import '../../../utils/utils.dart';
 

--- a/flutter_quill_extensions/lib/utils/dart_ui/dart_ui_real.dart
+++ b/flutter_quill_extensions/lib/utils/dart_ui/dart_ui_real.dart
@@ -1,1 +1,1 @@
-export 'dart:ui' if (dart.library.html) 'dart:ui_web';
+export 'dart:ui' if (dart.library.js_interop) 'dart:ui_web';


### PR DESCRIPTION
<!-- 

Thank you for contributing.

Provide a description of your changes below and a general summary in the title.

Consider reading the Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md.

The changes of `CHANGELOG.md` and package version in `pubspec.yaml` are automated.

-->

## Description

Since dart:html is not supported when compiling to Wasm, the correct alternative now is to use dart.library.js_interop to differentiate between native and web


Source:
https://dart.dev/interop/js-interop/package-web

## Related Issues


## Type of Change

- [x] ✨ **New feature:** Adds new functionality without breaking existing features.

## Suggestions

<!-- Optional -->