### PR TITLE
Fix: context menu is visible even when selection is collapsed

### DIFF
--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -9,8 +9,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show RenderAbstractViewport;
 import 'package:flutter/scheduler.dart' show SchedulerBinding;
 import 'package:flutter/services.dart'
-    show Clipboard, HardwareKeyboard, KeyDownEvent, LogicalKeyboardKey, SystemChannels, TextInputControl;
-import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart' show KeyboardVisibilityController;
+    show
+        Clipboard,
+        HardwareKeyboard,
+        KeyDownEvent,
+        LogicalKeyboardKey,
+        SystemChannels,
+        TextInputControl;
+import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart'
+    show KeyboardVisibilityController;
 
 import '../../common/structs/horizontal_spacing.dart';
 import '../../common/structs/offset_value.dart';
@@ -100,9 +107,11 @@ class QuillRawEditorState extends EditorState
 
   @override
   void insertContent(KeyboardInsertedContent content) {
-    assert(
-        widget.configurations.contentInsertionConfiguration?.allowedMimeTypes.contains(content.mimeType) ?? false);
-    widget.configurations.contentInsertionConfiguration?.onContentInserted.call(content);
+    assert(widget.configurations.contentInsertionConfiguration?.allowedMimeTypes
+            .contains(content.mimeType) ??
+        false);
+    widget.configurations.contentInsertionConfiguration?.onContentInserted
+        .call(content);
   }
 
   /// Copy current selection to [Clipboard].
@@ -118,7 +127,8 @@ class QuillRawEditorState extends EditorState
       userUpdateTextEditingValue(
         TextEditingValue(
           text: textEditingValue.text,
-          selection: TextSelection.collapsed(offset: textEditingValue.selection.end),
+          selection:
+              TextSelection.collapsed(offset: textEditingValue.selection.end),
         ),
         SelectionChangedCause.toolbar,
       );
@@ -192,7 +202,8 @@ class QuillRawEditorState extends EditorState
   void selectAll(SelectionChangedCause cause) {
     userUpdateTextEditingValue(
       textEditingValue.copyWith(
-        selection: TextSelection(baseOffset: 0, extentOffset: textEditingValue.text.length),
+        selection: TextSelection(
+            baseOffset: 0, extentOffset: textEditingValue.text.length),
       ),
       cause,
     );
@@ -207,14 +218,27 @@ class QuillRawEditorState extends EditorState
   /// Copied from [EditableTextState].
   List<ContextMenuButtonItem> get contextMenuButtonItems {
     return EditableText.getEditableButtonItems(
-      clipboardStatus: (_clipboardStatus != null) ? _clipboardStatus!.value : null,
-      onCopy: copyEnabled ? () => copySelection(SelectionChangedCause.toolbar) : null,
-      onCut: cutEnabled ? () => cutSelection(SelectionChangedCause.toolbar) : null,
-      onPaste: pasteEnabled ? () => pasteText(SelectionChangedCause.toolbar) : null,
-      onSelectAll: selectAllEnabled ? () => selectAll(SelectionChangedCause.toolbar) : null,
-      onLookUp: lookUpEnabled ? () => lookUpSelection(SelectionChangedCause.toolbar) : null,
-      onSearchWeb: searchWebEnabled ? () => searchWebForSelection(SelectionChangedCause.toolbar) : null,
-      onShare: shareEnabled ? () => shareSelection(SelectionChangedCause.toolbar) : null,
+      clipboardStatus:
+          (_clipboardStatus != null) ? _clipboardStatus!.value : null,
+      onCopy: copyEnabled
+          ? () => copySelection(SelectionChangedCause.toolbar)
+          : null,
+      onCut:
+          cutEnabled ? () => cutSelection(SelectionChangedCause.toolbar) : null,
+      onPaste:
+          pasteEnabled ? () => pasteText(SelectionChangedCause.toolbar) : null,
+      onSelectAll: selectAllEnabled
+          ? () => selectAll(SelectionChangedCause.toolbar)
+          : null,
+      onLookUp: lookUpEnabled
+          ? () => lookUpSelection(SelectionChangedCause.toolbar)
+          : null,
+      onSearchWeb: searchWebEnabled
+          ? () => searchWebForSelection(SelectionChangedCause.toolbar)
+          : null,
+      onShare: shareEnabled
+          ? () => shareSelection(SelectionChangedCause.toolbar)
+          : null,
       onLiveTextInput: liveTextInputEnabled ? () {} : null,
     );
   }
@@ -308,8 +332,10 @@ class QuillRawEditorState extends EditorState
       );
     }
 
-    final startCharacterRect = renderEditor.getLocalRectForCaret(selection.base);
-    final endCharacterRect = renderEditor.getLocalRectForCaret(selection.extent);
+    final startCharacterRect =
+        renderEditor.getLocalRectForCaret(selection.base);
+    final endCharacterRect =
+        renderEditor.getLocalRectForCaret(selection.extent);
     return QuillEditorGlyphHeights(
       startCharacterRect.height,
       endCharacterRect.height,
@@ -356,9 +382,12 @@ class QuillRawEditorState extends EditorState
   Widget _scribbleFocusable(Widget child) {
     return ScribbleFocusable(
       editorKey: _editorKey,
-      enabled: widget.configurations.enableScribble && !widget.configurations.readOnly,
-      renderBoxForBounds: () =>
-          context.findAncestorStateOfType<QuillEditorState>()?.context.findRenderObject() as RenderBox?,
+      enabled: widget.configurations.enableScribble &&
+          !widget.configurations.readOnly,
+      renderBoxForBounds: () => context
+          .findAncestorStateOfType<QuillEditorState>()
+          ?.context
+          .findRenderObject() as RenderBox?,
       onScribbleFocus: (offset) {
         widget.configurations.focusNode.requestFocus();
         widget.configurations.onScribbleActivated?.call();
@@ -404,7 +433,8 @@ class QuillRawEditorState extends EditorState
       /// the scroll view with [BaselineProxy] which mimics the editor's
       /// baseline.
       // This implies that the first line has no styles applied to it.
-      final baselinePadding = EdgeInsets.only(top: _styles!.paragraph!.verticalSpacing.top);
+      final baselinePadding =
+          EdgeInsets.only(top: _styles!.paragraph!.verticalSpacing.top);
       child = BaselineProxy(
         textStyle: _styles!.paragraph!.style,
         padding: baselinePadding,
@@ -434,7 +464,8 @@ class QuillRawEditorState extends EditorState
                   padding: widget.configurations.padding,
                   maxContentWidth: widget.configurations.maxContentWidth,
                   cursorController: _cursorCont,
-                  floatingCursorDisabled: widget.configurations.floatingCursorDisabled,
+                  floatingCursorDisabled:
+                      widget.configurations.floatingCursorDisabled,
                   children: _buildChildren(doc, context),
                 ),
               ),
@@ -466,7 +497,8 @@ class QuillRawEditorState extends EditorState
                 scrollBottomInset: widget.configurations.scrollBottomInset,
                 padding: widget.configurations.padding,
                 maxContentWidth: widget.configurations.maxContentWidth,
-                floatingCursorDisabled: widget.configurations.floatingCursorDisabled,
+                floatingCursorDisabled:
+                    widget.configurations.floatingCursorDisabled,
                 children: _buildChildren(doc, context),
               ),
             ),
@@ -676,12 +708,15 @@ class QuillRawEditorState extends EditorState
                 LogicalKeyboardKey.pageUp,
                 control: !isDesktopMacOS,
                 meta: isDesktopMacOS,
-              ): const ScrollIntent(direction: AxisDirection.up, type: ScrollIncrementType.page),
+              ): const ScrollIntent(
+                  direction: AxisDirection.up, type: ScrollIncrementType.page),
               SingleActivator(
                 LogicalKeyboardKey.pageDown,
                 control: !isDesktopMacOS,
                 meta: isDesktopMacOS,
-              ): const ScrollIntent(direction: AxisDirection.down, type: ScrollIncrementType.page),
+              ): const ScrollIntent(
+                  direction: AxisDirection.down,
+                  type: ScrollIncrementType.page),
             },
           ),
           child: Actions(
@@ -735,7 +770,8 @@ class QuillRawEditorState extends EditorState
   }
 
   KeyEventResult _handleSpaceKey(KeyEvent event) {
-    final child = controller.document.queryChild(controller.selection.baseOffset);
+    final child =
+        controller.document.queryChild(controller.selection.baseOffset);
     if (child.node == null) {
       return KeyEventResult.ignored;
     }
@@ -752,7 +788,8 @@ class QuillRawEditorState extends EditorState
 
     const olKeyPhrase = '1.';
     const ulKeyPhrase = '-';
-    final enableMdConversion = widget.configurations.enableMarkdownStyleConversion;
+    final enableMdConversion =
+        widget.configurations.enableMarkdownStyleConversion;
 
     if (text.value == olKeyPhrase && enableMdConversion) {
       _updateSelectionForKeyPhrase(olKeyPhrase, Attribute.ol);
@@ -766,7 +803,8 @@ class QuillRawEditorState extends EditorState
   }
 
   KeyEventResult _handleTabKey(KeyEvent event) {
-    final child = controller.document.queryChild(controller.selection.baseOffset);
+    final child =
+        controller.document.queryChild(controller.selection.baseOffset);
 
     KeyEventResult insertTabCharacter() {
       if (widget.configurations.readOnly) {
@@ -828,20 +866,23 @@ class QuillRawEditorState extends EditorState
   void _moveCursor(int chars) {
     final selection = controller.selection;
     controller.updateSelection(
-        controller.selection
-            .copyWith(baseOffset: selection.baseOffset + chars, extentOffset: selection.baseOffset + chars),
+        controller.selection.copyWith(
+            baseOffset: selection.baseOffset + chars,
+            extentOffset: selection.baseOffset + chars),
         ChangeSource.local);
   }
 
   void _updateSelectionForKeyPhrase(String phrase, Attribute attribute) {
-    controller.replaceText(controller.selection.baseOffset - phrase.length, phrase.length, '\n', null);
+    controller.replaceText(controller.selection.baseOffset - phrase.length,
+        phrase.length, '\n', null);
     _moveCursor(-phrase.length);
     controller
       ..formatSelection(attribute)
       // Remove the added newline.
       ..replaceText(controller.selection.baseOffset + 1, 1, '', null);
     //
-    final style = controller.document.collectStyle(controller.selection.baseOffset, 0);
+    final style =
+        controller.document.collectStyle(controller.selection.baseOffset, 0);
     if (style.isNotEmpty) {
       for (final attr in style.values) {
         controller.formatSelection(attr);
@@ -889,8 +930,10 @@ class QuillRawEditorState extends EditorState
   /// Updates the checkbox positioned at [offset] in document
   /// by changing its attribute according to [value].
   void _handleCheckboxTap(int offset, bool value) {
-    final requestKeyboardFocusOnCheckListChanged = widget.configurations.requestKeyboardFocusOnCheckListChanged;
-    if (!(widget.configurations.checkBoxReadOnly ?? widget.configurations.readOnly)) {
+    final requestKeyboardFocusOnCheckListChanged =
+        widget.configurations.requestKeyboardFocusOnCheckListChanged;
+    if (!(widget.configurations.checkBoxReadOnly ??
+        widget.configurations.readOnly)) {
       _disableScrollControllerAnimateOnce = true;
       final currentSelection = controller.selection.copyWith();
       final attribute = value ? Attribute.checked : Attribute.unchecked;
@@ -903,7 +946,10 @@ class QuillRawEditorState extends EditorState
 
         // Checkbox tapping causes controller.selection to go to offset 0
         // Stop toggling those two toolbar buttons
-        ..toolbarButtonToggler = {Attribute.list.key: attribute, Attribute.header.key: Attribute.header};
+        ..toolbarButtonToggler = {
+          Attribute.list.key: attribute,
+          Attribute.header.key: Attribute.header
+        };
 
       // Go back from offset 0 to current selection
       SchedulerBinding.instance.addPostFrameCallback((_) {
@@ -939,12 +985,14 @@ class QuillRawEditorState extends EditorState
       // and watch if the system language is a RTL language and avoid putting
       // to the edge of the left side any checkbox or list point/number if is a
       // RTL language
-      if (nodeTextDirection == TextDirection.ltr && _textDirection == TextDirection.rtl) {
+      if (nodeTextDirection == TextDirection.ltr &&
+          _textDirection == TextDirection.rtl) {
         nodeTextDirection = TextDirection.rtl;
       }
       if (node is Line) {
         final editableTextLine = _getEditableTextLineFromNode(node, context);
-        result.add(Directionality(textDirection: nodeTextDirection, child: editableTextLine));
+        result.add(Directionality(
+            textDirection: nodeTextDirection, child: editableTextLine));
       } else if (node is Block) {
         final editableTextBlock = EditableTextBlock(
           block: node,
@@ -956,9 +1004,12 @@ class QuillRawEditorState extends EditorState
           textSelection: controller.selection,
           color: widget.configurations.selectionColor,
           styles: _styles,
-          enableInteractiveSelection: widget.configurations.enableInteractiveSelection,
+          enableInteractiveSelection:
+              widget.configurations.enableInteractiveSelection,
           hasFocus: _hasFocus,
-          contentPadding: attrs.containsKey(Attribute.codeBlock.key) ? const EdgeInsets.all(16) : null,
+          contentPadding: attrs.containsKey(Attribute.codeBlock.key)
+              ? const EdgeInsets.all(16)
+              : null,
           embedBuilder: widget.configurations.embedBuilder,
           linkActionPicker: _linkActionPicker,
           onLaunchUrl: widget.configurations.onLaunchUrl,
@@ -988,7 +1039,8 @@ class QuillRawEditorState extends EditorState
     return result;
   }
 
-  EditableTextLine _getEditableTextLineFromNode(Line node, BuildContext context) {
+  EditableTextLine _getEditableTextLineFromNode(
+      Line node, BuildContext context) {
     final textLine = TextLine(
       line: node,
       textDirection: _textDirection,
@@ -1084,7 +1136,8 @@ class QuillRawEditorState extends EditorState
     return defaultStyles!.paragraph!.verticalSpacing;
   }
 
-  HorizontalSpacing _getHorizontalSpacingForBlock(Block node, DefaultStyles? defaultStyles) {
+  HorizontalSpacing _getHorizontalSpacingForBlock(
+      Block node, DefaultStyles? defaultStyles) {
     final attrs = node.style.attributes;
     if (attrs.containsKey(Attribute.blockQuote.key)) {
       return defaultStyles!.quote!.horizontalSpacing;
@@ -1100,7 +1153,8 @@ class QuillRawEditorState extends EditorState
     return HorizontalSpacing.zero;
   }
 
-  VerticalSpacing _getVerticalSpacingForBlock(Block node, DefaultStyles? defaultStyles) {
+  VerticalSpacing _getVerticalSpacingForBlock(
+      Block node, DefaultStyles? defaultStyles) {
     final attrs = node.style.attributes;
     if (attrs.containsKey(Attribute.blockQuote.key)) {
       return defaultStyles!.quote!.verticalSpacing;
@@ -1155,7 +1209,8 @@ class QuillRawEditorState extends EditorState
         } else {
           _keyboardVisibilityController = KeyboardVisibilityController();
           _keyboardVisible = _keyboardVisibilityController!.isVisible;
-          _keyboardVisibilitySubscription = _keyboardVisibilityController?.onChange.listen((visible) {
+          _keyboardVisibilitySubscription =
+              _keyboardVisibilityController?.onChange.listen((visible) {
             _keyboardVisible = visible;
             if (visible) {
               _onChangeTextEditingValue(!_hasFocus);
@@ -1197,7 +1252,9 @@ class QuillRawEditorState extends EditorState
     super.didChangeDependencies();
     final parentStyles = QuillStyles.getStyles(context, true);
     final defaultStyles = DefaultStyles.getInstance(context);
-    _styles = (parentStyles != null) ? defaultStyles.merge(parentStyles) : defaultStyles;
+    _styles = (parentStyles != null)
+        ? defaultStyles.merge(parentStyles)
+        : defaultStyles;
 
     if (widget.configurations.customStyles != null) {
       _styles = _styles!.merge(widget.configurations.customStyles!);
@@ -1260,7 +1317,8 @@ class QuillRawEditorState extends EditorState
   }
 
   bool _shouldShowSelectionHandles() {
-    return widget.configurations.showSelectionHandles && !controller.selection.isCollapsed;
+    return widget.configurations.showSelectionHandles &&
+        !controller.selection.isCollapsed;
   }
 
   @override
@@ -1388,16 +1446,18 @@ class QuillRawEditorState extends EditorState
       clipboardStatus: _clipboardStatus,
       contextMenuBuilder: widget.configurations.contextMenuBuilder == null
           ? null
-          : (context) => widget.configurations.contextMenuBuilder!(context, this),
-      magnifierConfiguration:
-          widget.configurations.magnifierConfiguration ?? TextMagnifier.adaptiveMagnifierConfiguration,
+          : (context) =>
+              widget.configurations.contextMenuBuilder!(context, this),
+      magnifierConfiguration: widget.configurations.magnifierConfiguration ??
+          TextMagnifier.adaptiveMagnifierConfiguration,
     );
   }
 
   void _handleFocusChanged() {
     if (dirty) {
       requestKeyboard();
-      SchedulerBinding.instance.addPostFrameCallback((_) => _handleFocusChanged());
+      SchedulerBinding.instance
+          .addPostFrameCallback((_) => _handleFocusChanged());
       return;
     }
     openOrCloseConnection();
@@ -1421,7 +1481,8 @@ class QuillRawEditorState extends EditorState
 
   Future<LinkMenuAction> _linkActionPicker(Node linkNode) async {
     final link = linkNode.style.attributes[Attribute.link.key]!.value!;
-    return widget.configurations.linkActionPickerDelegate(context, link, linkNode);
+    return widget.configurations
+        .linkActionPickerDelegate(context, link, linkNode);
   }
 
   bool _showCaretOnScreenScheduled = false;
@@ -1448,7 +1509,8 @@ class QuillRawEditorState extends EditorState
         }
 
         final viewport = RenderAbstractViewport.of(renderEditor);
-        final editorOffset = renderEditor.localToGlobal(const Offset(0, 0), ancestor: viewport);
+        final editorOffset =
+            renderEditor.localToGlobal(const Offset(0, 0), ancestor: viewport);
         final offsetInViewport = _scrollController.offset + editorOffset.dy;
 
         final offset = renderEditor.getOffsetToRevealCursor(
@@ -1476,7 +1538,8 @@ class QuillRawEditorState extends EditorState
   ///
   /// This property is typically used to notify the renderer of input gestures.
   @override
-  RenderEditor get renderEditor => _editorKey.currentContext!.findRenderObject() as RenderEditor;
+  RenderEditor get renderEditor =>
+      _editorKey.currentContext!.findRenderObject() as RenderEditor;
 
   /// Express interest in interacting with the keyboard.
   ///
@@ -1541,7 +1604,8 @@ class QuillRawEditorState extends EditorState
 
   void _replaceText(ReplaceTextIntent intent) {
     userUpdateTextEditingValue(
-      intent.currentTextEditingValue.replaced(intent.replacementRange, intent.replacementText),
+      intent.currentTextEditingValue
+          .replaced(intent.replacementRange, intent.replacementText),
       intent.cause,
     );
   }
@@ -1550,18 +1614,22 @@ class QuillRawEditorState extends EditorState
   bool get wantKeepAlive => widget.configurations.focusNode.hasFocus;
 
   @override
-  AnimationController get floatingCursorResetController => _floatingCursorResetController;
+  AnimationController get floatingCursorResetController =>
+      _floatingCursorResetController;
 
   late AnimationController _floatingCursorResetController;
 
   // --------------------------- Text Editing Actions --------------------------
 
-  QuillEditorTextBoundary _characterBoundary(DirectionalTextEditingIntent intent) {
+  QuillEditorTextBoundary _characterBoundary(
+      DirectionalTextEditingIntent intent) {
     final atomicTextBoundary = QuillEditorCharacterBoundary(textEditingValue);
-    return QuillEditorCollapsedSelectionBoundary(atomicTextBoundary, intent.forward);
+    return QuillEditorCollapsedSelectionBoundary(
+        atomicTextBoundary, intent.forward);
   }
 
-  QuillEditorTextBoundary _nextWordBoundary(DirectionalTextEditingIntent intent) {
+  QuillEditorTextBoundary _nextWordBoundary(
+      DirectionalTextEditingIntent intent) {
     final QuillEditorTextBoundary atomicTextBoundary;
     final QuillEditorTextBoundary boundary;
 
@@ -1570,7 +1638,8 @@ class QuillRawEditorState extends EditorState
     atomicTextBoundary = QuillEditorCharacterBoundary(textEditingValue);
     // This isn't enough. Newline characters.
     boundary = QuillEditorExpandedTextBoundary(
-        QuillEditorWhitespaceBoundary(textEditingValue), QuillEditorWordBoundary(renderEditor, textEditingValue));
+        QuillEditorWhitespaceBoundary(textEditingValue),
+        QuillEditorWordBoundary(renderEditor, textEditingValue));
 
     final mixedBoundary = intent.forward
         ? QuillEditorMixedBoundary(atomicTextBoundary, boundary)
@@ -1595,18 +1664,22 @@ class QuillRawEditorState extends EditorState
     // since the document boundary is unique and the linebreak boundary is
     // already caret-location based.
     return intent.forward
-        ? QuillEditorMixedBoundary(QuillEditorCollapsedSelectionBoundary(atomicTextBoundary, true), boundary)
+        ? QuillEditorMixedBoundary(
+            QuillEditorCollapsedSelectionBoundary(atomicTextBoundary, true),
+            boundary)
         : QuillEditorMixedBoundary(
             boundary,
             QuillEditorCollapsedSelectionBoundary(atomicTextBoundary, false),
           );
   }
 
-  QuillEditorTextBoundary _documentBoundary(DirectionalTextEditingIntent intent) =>
+  QuillEditorTextBoundary _documentBoundary(
+          DirectionalTextEditingIntent intent) =>
       QuillEditorDocumentBoundary(textEditingValue);
 
   Action<T> _makeOverridable<T extends Intent>(Action<T> defaultAction) {
-    return Action<T>.overridable(context: context, defaultAction: defaultAction);
+    return Action<T>.overridable(
+        context: context, defaultAction: defaultAction);
   }
 
   late final Action<ReplaceTextIntent> _replaceTextAction =
@@ -1622,20 +1695,27 @@ class QuillRawEditorState extends EditorState
   late final Action<UpdateSelectionIntent> _updateSelectionAction =
       CallbackAction<UpdateSelectionIntent>(onInvoke: _updateSelection);
 
-  late final QuillEditorUpdateTextSelectionToAdjacentLineAction<ExtendSelectionVerticallyToAdjacentLineIntent>
-      _adjacentLineAction =
-      QuillEditorUpdateTextSelectionToAdjacentLineAction<ExtendSelectionVerticallyToAdjacentLineIntent>(this);
+  late final QuillEditorUpdateTextSelectionToAdjacentLineAction<
+          ExtendSelectionVerticallyToAdjacentLineIntent> _adjacentLineAction =
+      QuillEditorUpdateTextSelectionToAdjacentLineAction<
+          ExtendSelectionVerticallyToAdjacentLineIntent>(this);
 
   late final _adjacentPageAction =
-      QuillEditorUpdateTextSelectionToAdjacentPageAction<ExtendSelectionVerticallyToAdjacentPageIntent>(this);
+      QuillEditorUpdateTextSelectionToAdjacentPageAction<
+          ExtendSelectionVerticallyToAdjacentPageIntent>(this);
 
-  late final QuillEditorToggleTextStyleAction _formatSelectionAction = QuillEditorToggleTextStyleAction(this);
+  late final QuillEditorToggleTextStyleAction _formatSelectionAction =
+      QuillEditorToggleTextStyleAction(this);
 
-  late final QuillEditorIndentSelectionAction _indentSelectionAction = QuillEditorIndentSelectionAction(this);
+  late final QuillEditorIndentSelectionAction _indentSelectionAction =
+      QuillEditorIndentSelectionAction(this);
 
-  late final QuillEditorOpenSearchAction _openSearchAction = QuillEditorOpenSearchAction(this);
-  late final QuillEditorApplyHeaderAction _applyHeaderAction = QuillEditorApplyHeaderAction(this);
-  late final QuillEditorApplyCheckListAction _applyCheckListAction = QuillEditorApplyCheckListAction(this);
+  late final QuillEditorOpenSearchAction _openSearchAction =
+      QuillEditorOpenSearchAction(this);
+  late final QuillEditorApplyHeaderAction _applyHeaderAction =
+      QuillEditorApplyHeaderAction(this);
+  late final QuillEditorApplyCheckListAction _applyCheckListAction =
+      QuillEditorApplyCheckListAction(this);
 
   late final Map<Type, Action<Intent>> _actions = <Type, Action<Intent>>{
     DoNothingAndStopPropagationTextIntent: DoNothingAction(consumesKey: false),
@@ -1644,39 +1724,48 @@ class QuillRawEditorState extends EditorState
     DirectionalFocusIntent: DirectionalFocusAction.forTextField(),
 
     // Delete
-    DeleteCharacterIntent:
-        _makeOverridable(QuillEditorDeleteTextAction<DeleteCharacterIntent>(this, _characterBoundary)),
-    DeleteToNextWordBoundaryIntent:
-        _makeOverridable(QuillEditorDeleteTextAction<DeleteToNextWordBoundaryIntent>(this, _nextWordBoundary)),
-    DeleteToLineBreakIntent:
-        _makeOverridable(QuillEditorDeleteTextAction<DeleteToLineBreakIntent>(this, _linebreak)),
+    DeleteCharacterIntent: _makeOverridable(
+        QuillEditorDeleteTextAction<DeleteCharacterIntent>(
+            this, _characterBoundary)),
+    DeleteToNextWordBoundaryIntent: _makeOverridable(
+        QuillEditorDeleteTextAction<DeleteToNextWordBoundaryIntent>(
+            this, _nextWordBoundary)),
+    DeleteToLineBreakIntent: _makeOverridable(
+        QuillEditorDeleteTextAction<DeleteToLineBreakIntent>(this, _linebreak)),
 
     // Extend/Move Selection
-    ExtendSelectionByCharacterIntent:
-        _makeOverridable(QuillEditorUpdateTextSelectionAction<ExtendSelectionByCharacterIntent>(
+    ExtendSelectionByCharacterIntent: _makeOverridable(
+        QuillEditorUpdateTextSelectionAction<ExtendSelectionByCharacterIntent>(
       this,
       false,
       _characterBoundary,
     )),
     ExtendSelectionToNextWordBoundaryIntent: _makeOverridable(
-        QuillEditorUpdateTextSelectionAction<ExtendSelectionToNextWordBoundaryIntent>(
+        QuillEditorUpdateTextSelectionAction<
+                ExtendSelectionToNextWordBoundaryIntent>(
             this, true, _nextWordBoundary)),
     ExtendSelectionToLineBreakIntent: _makeOverridable(
-        QuillEditorUpdateTextSelectionAction<ExtendSelectionToLineBreakIntent>(this, true, _linebreak)),
-    ExtendSelectionVerticallyToAdjacentLineIntent: _makeOverridable(_adjacentLineAction),
+        QuillEditorUpdateTextSelectionAction<ExtendSelectionToLineBreakIntent>(
+            this, true, _linebreak)),
+    ExtendSelectionVerticallyToAdjacentLineIntent:
+        _makeOverridable(_adjacentLineAction),
     ExtendSelectionToDocumentBoundaryIntent: _makeOverridable(
-        QuillEditorUpdateTextSelectionAction<ExtendSelectionToDocumentBoundaryIntent>(
+        QuillEditorUpdateTextSelectionAction<
+                ExtendSelectionToDocumentBoundaryIntent>(
             this, true, _documentBoundary)),
-    ExtendSelectionToNextWordBoundaryOrCaretLocationIntent:
-        _makeOverridable(QuillEditorExtendSelectionOrCaretPositionAction(this, _nextWordBoundary)),
+    ExtendSelectionToNextWordBoundaryOrCaretLocationIntent: _makeOverridable(
+        QuillEditorExtendSelectionOrCaretPositionAction(
+            this, _nextWordBoundary)),
 
     // Copy Paste
     SelectAllTextIntent: _makeOverridable(QuillEditorSelectAllAction(this)),
-    CopySelectionTextIntent: _makeOverridable(QuillEditorCopySelectionAction(this)),
-    PasteTextIntent:
-        _makeOverridable(CallbackAction<PasteTextIntent>(onInvoke: (intent) => pasteText(intent.cause))),
+    CopySelectionTextIntent:
+        _makeOverridable(QuillEditorCopySelectionAction(this)),
+    PasteTextIntent: _makeOverridable(CallbackAction<PasteTextIntent>(
+        onInvoke: (intent) => pasteText(intent.cause))),
 
-    HideSelectionToolbarIntent: _makeOverridable(QuillEditorHideSelectionToolbarAction(this)),
+    HideSelectionToolbarIntent:
+        _makeOverridable(QuillEditorHideSelectionToolbarAction(this)),
     UndoTextIntent: _makeOverridable(QuillEditorUndoKeyboardAction(this)),
     RedoTextIntent: _makeOverridable(QuillEditorRedoKeyboardAction(this)),
 

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -1422,8 +1422,7 @@ class QuillRawEditorState extends EditorState
       if (!_hasFocus || textEditingValue.selection.isCollapsed) {
         _selectionOverlay?.dispose();
         _selectionOverlay = null;
-      }
-      if (_hasFocus) {
+      } else if (_hasFocus) {
         _selectionOverlay!.update(textEditingValue);
       }
     } else if (_hasFocus) {

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -9,15 +9,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show RenderAbstractViewport;
 import 'package:flutter/scheduler.dart' show SchedulerBinding;
 import 'package:flutter/services.dart'
-    show
-        Clipboard,
-        HardwareKeyboard,
-        KeyDownEvent,
-        LogicalKeyboardKey,
-        SystemChannels,
-        TextInputControl;
-import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart'
-    show KeyboardVisibilityController;
+    show Clipboard, HardwareKeyboard, KeyDownEvent, LogicalKeyboardKey, SystemChannels, TextInputControl;
+import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart' show KeyboardVisibilityController;
 
 import '../../common/structs/horizontal_spacing.dart';
 import '../../common/structs/offset_value.dart';
@@ -107,11 +100,9 @@ class QuillRawEditorState extends EditorState
 
   @override
   void insertContent(KeyboardInsertedContent content) {
-    assert(widget.configurations.contentInsertionConfiguration?.allowedMimeTypes
-            .contains(content.mimeType) ??
-        false);
-    widget.configurations.contentInsertionConfiguration?.onContentInserted
-        .call(content);
+    assert(
+        widget.configurations.contentInsertionConfiguration?.allowedMimeTypes.contains(content.mimeType) ?? false);
+    widget.configurations.contentInsertionConfiguration?.onContentInserted.call(content);
   }
 
   /// Copy current selection to [Clipboard].
@@ -127,8 +118,7 @@ class QuillRawEditorState extends EditorState
       userUpdateTextEditingValue(
         TextEditingValue(
           text: textEditingValue.text,
-          selection:
-              TextSelection.collapsed(offset: textEditingValue.selection.end),
+          selection: TextSelection.collapsed(offset: textEditingValue.selection.end),
         ),
         SelectionChangedCause.toolbar,
       );
@@ -202,8 +192,7 @@ class QuillRawEditorState extends EditorState
   void selectAll(SelectionChangedCause cause) {
     userUpdateTextEditingValue(
       textEditingValue.copyWith(
-        selection: TextSelection(
-            baseOffset: 0, extentOffset: textEditingValue.text.length),
+        selection: TextSelection(baseOffset: 0, extentOffset: textEditingValue.text.length),
       ),
       cause,
     );
@@ -218,27 +207,14 @@ class QuillRawEditorState extends EditorState
   /// Copied from [EditableTextState].
   List<ContextMenuButtonItem> get contextMenuButtonItems {
     return EditableText.getEditableButtonItems(
-      clipboardStatus:
-          (_clipboardStatus != null) ? _clipboardStatus!.value : null,
-      onCopy: copyEnabled
-          ? () => copySelection(SelectionChangedCause.toolbar)
-          : null,
-      onCut:
-          cutEnabled ? () => cutSelection(SelectionChangedCause.toolbar) : null,
-      onPaste:
-          pasteEnabled ? () => pasteText(SelectionChangedCause.toolbar) : null,
-      onSelectAll: selectAllEnabled
-          ? () => selectAll(SelectionChangedCause.toolbar)
-          : null,
-      onLookUp: lookUpEnabled
-          ? () => lookUpSelection(SelectionChangedCause.toolbar)
-          : null,
-      onSearchWeb: searchWebEnabled
-          ? () => searchWebForSelection(SelectionChangedCause.toolbar)
-          : null,
-      onShare: shareEnabled
-          ? () => shareSelection(SelectionChangedCause.toolbar)
-          : null,
+      clipboardStatus: (_clipboardStatus != null) ? _clipboardStatus!.value : null,
+      onCopy: copyEnabled ? () => copySelection(SelectionChangedCause.toolbar) : null,
+      onCut: cutEnabled ? () => cutSelection(SelectionChangedCause.toolbar) : null,
+      onPaste: pasteEnabled ? () => pasteText(SelectionChangedCause.toolbar) : null,
+      onSelectAll: selectAllEnabled ? () => selectAll(SelectionChangedCause.toolbar) : null,
+      onLookUp: lookUpEnabled ? () => lookUpSelection(SelectionChangedCause.toolbar) : null,
+      onSearchWeb: searchWebEnabled ? () => searchWebForSelection(SelectionChangedCause.toolbar) : null,
+      onShare: shareEnabled ? () => shareSelection(SelectionChangedCause.toolbar) : null,
       onLiveTextInput: liveTextInputEnabled ? () {} : null,
     );
   }
@@ -332,10 +308,8 @@ class QuillRawEditorState extends EditorState
       );
     }
 
-    final startCharacterRect =
-        renderEditor.getLocalRectForCaret(selection.base);
-    final endCharacterRect =
-        renderEditor.getLocalRectForCaret(selection.extent);
+    final startCharacterRect = renderEditor.getLocalRectForCaret(selection.base);
+    final endCharacterRect = renderEditor.getLocalRectForCaret(selection.extent);
     return QuillEditorGlyphHeights(
       startCharacterRect.height,
       endCharacterRect.height,
@@ -382,12 +356,9 @@ class QuillRawEditorState extends EditorState
   Widget _scribbleFocusable(Widget child) {
     return ScribbleFocusable(
       editorKey: _editorKey,
-      enabled: widget.configurations.enableScribble &&
-          !widget.configurations.readOnly,
-      renderBoxForBounds: () => context
-          .findAncestorStateOfType<QuillEditorState>()
-          ?.context
-          .findRenderObject() as RenderBox?,
+      enabled: widget.configurations.enableScribble && !widget.configurations.readOnly,
+      renderBoxForBounds: () =>
+          context.findAncestorStateOfType<QuillEditorState>()?.context.findRenderObject() as RenderBox?,
       onScribbleFocus: (offset) {
         widget.configurations.focusNode.requestFocus();
         widget.configurations.onScribbleActivated?.call();
@@ -433,8 +404,7 @@ class QuillRawEditorState extends EditorState
       /// the scroll view with [BaselineProxy] which mimics the editor's
       /// baseline.
       // This implies that the first line has no styles applied to it.
-      final baselinePadding =
-          EdgeInsets.only(top: _styles!.paragraph!.verticalSpacing.top);
+      final baselinePadding = EdgeInsets.only(top: _styles!.paragraph!.verticalSpacing.top);
       child = BaselineProxy(
         textStyle: _styles!.paragraph!.style,
         padding: baselinePadding,
@@ -464,8 +434,7 @@ class QuillRawEditorState extends EditorState
                   padding: widget.configurations.padding,
                   maxContentWidth: widget.configurations.maxContentWidth,
                   cursorController: _cursorCont,
-                  floatingCursorDisabled:
-                      widget.configurations.floatingCursorDisabled,
+                  floatingCursorDisabled: widget.configurations.floatingCursorDisabled,
                   children: _buildChildren(doc, context),
                 ),
               ),
@@ -497,8 +466,7 @@ class QuillRawEditorState extends EditorState
                 scrollBottomInset: widget.configurations.scrollBottomInset,
                 padding: widget.configurations.padding,
                 maxContentWidth: widget.configurations.maxContentWidth,
-                floatingCursorDisabled:
-                    widget.configurations.floatingCursorDisabled,
+                floatingCursorDisabled: widget.configurations.floatingCursorDisabled,
                 children: _buildChildren(doc, context),
               ),
             ),
@@ -708,15 +676,12 @@ class QuillRawEditorState extends EditorState
                 LogicalKeyboardKey.pageUp,
                 control: !isDesktopMacOS,
                 meta: isDesktopMacOS,
-              ): const ScrollIntent(
-                  direction: AxisDirection.up, type: ScrollIncrementType.page),
+              ): const ScrollIntent(direction: AxisDirection.up, type: ScrollIncrementType.page),
               SingleActivator(
                 LogicalKeyboardKey.pageDown,
                 control: !isDesktopMacOS,
                 meta: isDesktopMacOS,
-              ): const ScrollIntent(
-                  direction: AxisDirection.down,
-                  type: ScrollIncrementType.page),
+              ): const ScrollIntent(direction: AxisDirection.down, type: ScrollIncrementType.page),
             },
           ),
           child: Actions(
@@ -770,8 +735,7 @@ class QuillRawEditorState extends EditorState
   }
 
   KeyEventResult _handleSpaceKey(KeyEvent event) {
-    final child =
-        controller.document.queryChild(controller.selection.baseOffset);
+    final child = controller.document.queryChild(controller.selection.baseOffset);
     if (child.node == null) {
       return KeyEventResult.ignored;
     }
@@ -788,8 +752,7 @@ class QuillRawEditorState extends EditorState
 
     const olKeyPhrase = '1.';
     const ulKeyPhrase = '-';
-    final enableMdConversion =
-        widget.configurations.enableMarkdownStyleConversion;
+    final enableMdConversion = widget.configurations.enableMarkdownStyleConversion;
 
     if (text.value == olKeyPhrase && enableMdConversion) {
       _updateSelectionForKeyPhrase(olKeyPhrase, Attribute.ol);
@@ -803,8 +766,7 @@ class QuillRawEditorState extends EditorState
   }
 
   KeyEventResult _handleTabKey(KeyEvent event) {
-    final child =
-        controller.document.queryChild(controller.selection.baseOffset);
+    final child = controller.document.queryChild(controller.selection.baseOffset);
 
     KeyEventResult insertTabCharacter() {
       if (widget.configurations.readOnly) {
@@ -866,23 +828,20 @@ class QuillRawEditorState extends EditorState
   void _moveCursor(int chars) {
     final selection = controller.selection;
     controller.updateSelection(
-        controller.selection.copyWith(
-            baseOffset: selection.baseOffset + chars,
-            extentOffset: selection.baseOffset + chars),
+        controller.selection
+            .copyWith(baseOffset: selection.baseOffset + chars, extentOffset: selection.baseOffset + chars),
         ChangeSource.local);
   }
 
   void _updateSelectionForKeyPhrase(String phrase, Attribute attribute) {
-    controller.replaceText(controller.selection.baseOffset - phrase.length,
-        phrase.length, '\n', null);
+    controller.replaceText(controller.selection.baseOffset - phrase.length, phrase.length, '\n', null);
     _moveCursor(-phrase.length);
     controller
       ..formatSelection(attribute)
       // Remove the added newline.
       ..replaceText(controller.selection.baseOffset + 1, 1, '', null);
     //
-    final style =
-        controller.document.collectStyle(controller.selection.baseOffset, 0);
+    final style = controller.document.collectStyle(controller.selection.baseOffset, 0);
     if (style.isNotEmpty) {
       for (final attr in style.values) {
         controller.formatSelection(attr);
@@ -930,10 +889,8 @@ class QuillRawEditorState extends EditorState
   /// Updates the checkbox positioned at [offset] in document
   /// by changing its attribute according to [value].
   void _handleCheckboxTap(int offset, bool value) {
-    final requestKeyboardFocusOnCheckListChanged =
-        widget.configurations.requestKeyboardFocusOnCheckListChanged;
-    if (!(widget.configurations.checkBoxReadOnly ??
-        widget.configurations.readOnly)) {
+    final requestKeyboardFocusOnCheckListChanged = widget.configurations.requestKeyboardFocusOnCheckListChanged;
+    if (!(widget.configurations.checkBoxReadOnly ?? widget.configurations.readOnly)) {
       _disableScrollControllerAnimateOnce = true;
       final currentSelection = controller.selection.copyWith();
       final attribute = value ? Attribute.checked : Attribute.unchecked;
@@ -946,10 +903,7 @@ class QuillRawEditorState extends EditorState
 
         // Checkbox tapping causes controller.selection to go to offset 0
         // Stop toggling those two toolbar buttons
-        ..toolbarButtonToggler = {
-          Attribute.list.key: attribute,
-          Attribute.header.key: Attribute.header
-        };
+        ..toolbarButtonToggler = {Attribute.list.key: attribute, Attribute.header.key: Attribute.header};
 
       // Go back from offset 0 to current selection
       SchedulerBinding.instance.addPostFrameCallback((_) {
@@ -985,14 +939,12 @@ class QuillRawEditorState extends EditorState
       // and watch if the system language is a RTL language and avoid putting
       // to the edge of the left side any checkbox or list point/number if is a
       // RTL language
-      if (nodeTextDirection == TextDirection.ltr &&
-          _textDirection == TextDirection.rtl) {
+      if (nodeTextDirection == TextDirection.ltr && _textDirection == TextDirection.rtl) {
         nodeTextDirection = TextDirection.rtl;
       }
       if (node is Line) {
         final editableTextLine = _getEditableTextLineFromNode(node, context);
-        result.add(Directionality(
-            textDirection: nodeTextDirection, child: editableTextLine));
+        result.add(Directionality(textDirection: nodeTextDirection, child: editableTextLine));
       } else if (node is Block) {
         final editableTextBlock = EditableTextBlock(
           block: node,
@@ -1004,12 +956,9 @@ class QuillRawEditorState extends EditorState
           textSelection: controller.selection,
           color: widget.configurations.selectionColor,
           styles: _styles,
-          enableInteractiveSelection:
-              widget.configurations.enableInteractiveSelection,
+          enableInteractiveSelection: widget.configurations.enableInteractiveSelection,
           hasFocus: _hasFocus,
-          contentPadding: attrs.containsKey(Attribute.codeBlock.key)
-              ? const EdgeInsets.all(16)
-              : null,
+          contentPadding: attrs.containsKey(Attribute.codeBlock.key) ? const EdgeInsets.all(16) : null,
           embedBuilder: widget.configurations.embedBuilder,
           linkActionPicker: _linkActionPicker,
           onLaunchUrl: widget.configurations.onLaunchUrl,
@@ -1039,8 +988,7 @@ class QuillRawEditorState extends EditorState
     return result;
   }
 
-  EditableTextLine _getEditableTextLineFromNode(
-      Line node, BuildContext context) {
+  EditableTextLine _getEditableTextLineFromNode(Line node, BuildContext context) {
     final textLine = TextLine(
       line: node,
       textDirection: _textDirection,
@@ -1136,8 +1084,7 @@ class QuillRawEditorState extends EditorState
     return defaultStyles!.paragraph!.verticalSpacing;
   }
 
-  HorizontalSpacing _getHorizontalSpacingForBlock(
-      Block node, DefaultStyles? defaultStyles) {
+  HorizontalSpacing _getHorizontalSpacingForBlock(Block node, DefaultStyles? defaultStyles) {
     final attrs = node.style.attributes;
     if (attrs.containsKey(Attribute.blockQuote.key)) {
       return defaultStyles!.quote!.horizontalSpacing;
@@ -1153,8 +1100,7 @@ class QuillRawEditorState extends EditorState
     return HorizontalSpacing.zero;
   }
 
-  VerticalSpacing _getVerticalSpacingForBlock(
-      Block node, DefaultStyles? defaultStyles) {
+  VerticalSpacing _getVerticalSpacingForBlock(Block node, DefaultStyles? defaultStyles) {
     final attrs = node.style.attributes;
     if (attrs.containsKey(Attribute.blockQuote.key)) {
       return defaultStyles!.quote!.verticalSpacing;
@@ -1209,8 +1155,7 @@ class QuillRawEditorState extends EditorState
         } else {
           _keyboardVisibilityController = KeyboardVisibilityController();
           _keyboardVisible = _keyboardVisibilityController!.isVisible;
-          _keyboardVisibilitySubscription =
-              _keyboardVisibilityController?.onChange.listen((visible) {
+          _keyboardVisibilitySubscription = _keyboardVisibilityController?.onChange.listen((visible) {
             _keyboardVisible = visible;
             if (visible) {
               _onChangeTextEditingValue(!_hasFocus);
@@ -1252,9 +1197,7 @@ class QuillRawEditorState extends EditorState
     super.didChangeDependencies();
     final parentStyles = QuillStyles.getStyles(context, true);
     final defaultStyles = DefaultStyles.getInstance(context);
-    _styles = (parentStyles != null)
-        ? defaultStyles.merge(parentStyles)
-        : defaultStyles;
+    _styles = (parentStyles != null) ? defaultStyles.merge(parentStyles) : defaultStyles;
 
     if (widget.configurations.customStyles != null) {
       _styles = _styles!.merge(widget.configurations.customStyles!);
@@ -1317,8 +1260,7 @@ class QuillRawEditorState extends EditorState
   }
 
   bool _shouldShowSelectionHandles() {
-    return widget.configurations.showSelectionHandles &&
-        !controller.selection.isCollapsed;
+    return widget.configurations.showSelectionHandles && !controller.selection.isCollapsed;
   }
 
   @override
@@ -1419,6 +1361,10 @@ class QuillRawEditorState extends EditorState
 
   void _updateOrDisposeSelectionOverlayIfNeeded() {
     if (_selectionOverlay != null) {
+      if (!_hasFocus || textEditingValue.selection.isCollapsed) {
+        _selectionOverlay?.dispose();
+        _selectionOverlay = null;
+      }
       if (_hasFocus) {
         _selectionOverlay!.update(textEditingValue);
       }
@@ -1442,18 +1388,16 @@ class QuillRawEditorState extends EditorState
       clipboardStatus: _clipboardStatus,
       contextMenuBuilder: widget.configurations.contextMenuBuilder == null
           ? null
-          : (context) =>
-              widget.configurations.contextMenuBuilder!(context, this),
-      magnifierConfiguration: widget.configurations.magnifierConfiguration ??
-          TextMagnifier.adaptiveMagnifierConfiguration,
+          : (context) => widget.configurations.contextMenuBuilder!(context, this),
+      magnifierConfiguration:
+          widget.configurations.magnifierConfiguration ?? TextMagnifier.adaptiveMagnifierConfiguration,
     );
   }
 
   void _handleFocusChanged() {
     if (dirty) {
       requestKeyboard();
-      SchedulerBinding.instance
-          .addPostFrameCallback((_) => _handleFocusChanged());
+      SchedulerBinding.instance.addPostFrameCallback((_) => _handleFocusChanged());
       return;
     }
     openOrCloseConnection();
@@ -1477,8 +1421,7 @@ class QuillRawEditorState extends EditorState
 
   Future<LinkMenuAction> _linkActionPicker(Node linkNode) async {
     final link = linkNode.style.attributes[Attribute.link.key]!.value!;
-    return widget.configurations
-        .linkActionPickerDelegate(context, link, linkNode);
+    return widget.configurations.linkActionPickerDelegate(context, link, linkNode);
   }
 
   bool _showCaretOnScreenScheduled = false;
@@ -1505,8 +1448,7 @@ class QuillRawEditorState extends EditorState
         }
 
         final viewport = RenderAbstractViewport.of(renderEditor);
-        final editorOffset =
-            renderEditor.localToGlobal(const Offset(0, 0), ancestor: viewport);
+        final editorOffset = renderEditor.localToGlobal(const Offset(0, 0), ancestor: viewport);
         final offsetInViewport = _scrollController.offset + editorOffset.dy;
 
         final offset = renderEditor.getOffsetToRevealCursor(
@@ -1534,8 +1476,7 @@ class QuillRawEditorState extends EditorState
   ///
   /// This property is typically used to notify the renderer of input gestures.
   @override
-  RenderEditor get renderEditor =>
-      _editorKey.currentContext!.findRenderObject() as RenderEditor;
+  RenderEditor get renderEditor => _editorKey.currentContext!.findRenderObject() as RenderEditor;
 
   /// Express interest in interacting with the keyboard.
   ///
@@ -1600,8 +1541,7 @@ class QuillRawEditorState extends EditorState
 
   void _replaceText(ReplaceTextIntent intent) {
     userUpdateTextEditingValue(
-      intent.currentTextEditingValue
-          .replaced(intent.replacementRange, intent.replacementText),
+      intent.currentTextEditingValue.replaced(intent.replacementRange, intent.replacementText),
       intent.cause,
     );
   }
@@ -1610,22 +1550,18 @@ class QuillRawEditorState extends EditorState
   bool get wantKeepAlive => widget.configurations.focusNode.hasFocus;
 
   @override
-  AnimationController get floatingCursorResetController =>
-      _floatingCursorResetController;
+  AnimationController get floatingCursorResetController => _floatingCursorResetController;
 
   late AnimationController _floatingCursorResetController;
 
   // --------------------------- Text Editing Actions --------------------------
 
-  QuillEditorTextBoundary _characterBoundary(
-      DirectionalTextEditingIntent intent) {
+  QuillEditorTextBoundary _characterBoundary(DirectionalTextEditingIntent intent) {
     final atomicTextBoundary = QuillEditorCharacterBoundary(textEditingValue);
-    return QuillEditorCollapsedSelectionBoundary(
-        atomicTextBoundary, intent.forward);
+    return QuillEditorCollapsedSelectionBoundary(atomicTextBoundary, intent.forward);
   }
 
-  QuillEditorTextBoundary _nextWordBoundary(
-      DirectionalTextEditingIntent intent) {
+  QuillEditorTextBoundary _nextWordBoundary(DirectionalTextEditingIntent intent) {
     final QuillEditorTextBoundary atomicTextBoundary;
     final QuillEditorTextBoundary boundary;
 
@@ -1634,8 +1570,7 @@ class QuillRawEditorState extends EditorState
     atomicTextBoundary = QuillEditorCharacterBoundary(textEditingValue);
     // This isn't enough. Newline characters.
     boundary = QuillEditorExpandedTextBoundary(
-        QuillEditorWhitespaceBoundary(textEditingValue),
-        QuillEditorWordBoundary(renderEditor, textEditingValue));
+        QuillEditorWhitespaceBoundary(textEditingValue), QuillEditorWordBoundary(renderEditor, textEditingValue));
 
     final mixedBoundary = intent.forward
         ? QuillEditorMixedBoundary(atomicTextBoundary, boundary)
@@ -1660,22 +1595,18 @@ class QuillRawEditorState extends EditorState
     // since the document boundary is unique and the linebreak boundary is
     // already caret-location based.
     return intent.forward
-        ? QuillEditorMixedBoundary(
-            QuillEditorCollapsedSelectionBoundary(atomicTextBoundary, true),
-            boundary)
+        ? QuillEditorMixedBoundary(QuillEditorCollapsedSelectionBoundary(atomicTextBoundary, true), boundary)
         : QuillEditorMixedBoundary(
             boundary,
             QuillEditorCollapsedSelectionBoundary(atomicTextBoundary, false),
           );
   }
 
-  QuillEditorTextBoundary _documentBoundary(
-          DirectionalTextEditingIntent intent) =>
+  QuillEditorTextBoundary _documentBoundary(DirectionalTextEditingIntent intent) =>
       QuillEditorDocumentBoundary(textEditingValue);
 
   Action<T> _makeOverridable<T extends Intent>(Action<T> defaultAction) {
-    return Action<T>.overridable(
-        context: context, defaultAction: defaultAction);
+    return Action<T>.overridable(context: context, defaultAction: defaultAction);
   }
 
   late final Action<ReplaceTextIntent> _replaceTextAction =
@@ -1691,27 +1622,20 @@ class QuillRawEditorState extends EditorState
   late final Action<UpdateSelectionIntent> _updateSelectionAction =
       CallbackAction<UpdateSelectionIntent>(onInvoke: _updateSelection);
 
-  late final QuillEditorUpdateTextSelectionToAdjacentLineAction<
-          ExtendSelectionVerticallyToAdjacentLineIntent> _adjacentLineAction =
-      QuillEditorUpdateTextSelectionToAdjacentLineAction<
-          ExtendSelectionVerticallyToAdjacentLineIntent>(this);
+  late final QuillEditorUpdateTextSelectionToAdjacentLineAction<ExtendSelectionVerticallyToAdjacentLineIntent>
+      _adjacentLineAction =
+      QuillEditorUpdateTextSelectionToAdjacentLineAction<ExtendSelectionVerticallyToAdjacentLineIntent>(this);
 
   late final _adjacentPageAction =
-      QuillEditorUpdateTextSelectionToAdjacentPageAction<
-          ExtendSelectionVerticallyToAdjacentPageIntent>(this);
+      QuillEditorUpdateTextSelectionToAdjacentPageAction<ExtendSelectionVerticallyToAdjacentPageIntent>(this);
 
-  late final QuillEditorToggleTextStyleAction _formatSelectionAction =
-      QuillEditorToggleTextStyleAction(this);
+  late final QuillEditorToggleTextStyleAction _formatSelectionAction = QuillEditorToggleTextStyleAction(this);
 
-  late final QuillEditorIndentSelectionAction _indentSelectionAction =
-      QuillEditorIndentSelectionAction(this);
+  late final QuillEditorIndentSelectionAction _indentSelectionAction = QuillEditorIndentSelectionAction(this);
 
-  late final QuillEditorOpenSearchAction _openSearchAction =
-      QuillEditorOpenSearchAction(this);
-  late final QuillEditorApplyHeaderAction _applyHeaderAction =
-      QuillEditorApplyHeaderAction(this);
-  late final QuillEditorApplyCheckListAction _applyCheckListAction =
-      QuillEditorApplyCheckListAction(this);
+  late final QuillEditorOpenSearchAction _openSearchAction = QuillEditorOpenSearchAction(this);
+  late final QuillEditorApplyHeaderAction _applyHeaderAction = QuillEditorApplyHeaderAction(this);
+  late final QuillEditorApplyCheckListAction _applyCheckListAction = QuillEditorApplyCheckListAction(this);
 
   late final Map<Type, Action<Intent>> _actions = <Type, Action<Intent>>{
     DoNothingAndStopPropagationTextIntent: DoNothingAction(consumesKey: false),
@@ -1720,48 +1644,39 @@ class QuillRawEditorState extends EditorState
     DirectionalFocusIntent: DirectionalFocusAction.forTextField(),
 
     // Delete
-    DeleteCharacterIntent: _makeOverridable(
-        QuillEditorDeleteTextAction<DeleteCharacterIntent>(
-            this, _characterBoundary)),
-    DeleteToNextWordBoundaryIntent: _makeOverridable(
-        QuillEditorDeleteTextAction<DeleteToNextWordBoundaryIntent>(
-            this, _nextWordBoundary)),
-    DeleteToLineBreakIntent: _makeOverridable(
-        QuillEditorDeleteTextAction<DeleteToLineBreakIntent>(this, _linebreak)),
+    DeleteCharacterIntent:
+        _makeOverridable(QuillEditorDeleteTextAction<DeleteCharacterIntent>(this, _characterBoundary)),
+    DeleteToNextWordBoundaryIntent:
+        _makeOverridable(QuillEditorDeleteTextAction<DeleteToNextWordBoundaryIntent>(this, _nextWordBoundary)),
+    DeleteToLineBreakIntent:
+        _makeOverridable(QuillEditorDeleteTextAction<DeleteToLineBreakIntent>(this, _linebreak)),
 
     // Extend/Move Selection
-    ExtendSelectionByCharacterIntent: _makeOverridable(
-        QuillEditorUpdateTextSelectionAction<ExtendSelectionByCharacterIntent>(
+    ExtendSelectionByCharacterIntent:
+        _makeOverridable(QuillEditorUpdateTextSelectionAction<ExtendSelectionByCharacterIntent>(
       this,
       false,
       _characterBoundary,
     )),
     ExtendSelectionToNextWordBoundaryIntent: _makeOverridable(
-        QuillEditorUpdateTextSelectionAction<
-                ExtendSelectionToNextWordBoundaryIntent>(
+        QuillEditorUpdateTextSelectionAction<ExtendSelectionToNextWordBoundaryIntent>(
             this, true, _nextWordBoundary)),
     ExtendSelectionToLineBreakIntent: _makeOverridable(
-        QuillEditorUpdateTextSelectionAction<ExtendSelectionToLineBreakIntent>(
-            this, true, _linebreak)),
-    ExtendSelectionVerticallyToAdjacentLineIntent:
-        _makeOverridable(_adjacentLineAction),
+        QuillEditorUpdateTextSelectionAction<ExtendSelectionToLineBreakIntent>(this, true, _linebreak)),
+    ExtendSelectionVerticallyToAdjacentLineIntent: _makeOverridable(_adjacentLineAction),
     ExtendSelectionToDocumentBoundaryIntent: _makeOverridable(
-        QuillEditorUpdateTextSelectionAction<
-                ExtendSelectionToDocumentBoundaryIntent>(
+        QuillEditorUpdateTextSelectionAction<ExtendSelectionToDocumentBoundaryIntent>(
             this, true, _documentBoundary)),
-    ExtendSelectionToNextWordBoundaryOrCaretLocationIntent: _makeOverridable(
-        QuillEditorExtendSelectionOrCaretPositionAction(
-            this, _nextWordBoundary)),
+    ExtendSelectionToNextWordBoundaryOrCaretLocationIntent:
+        _makeOverridable(QuillEditorExtendSelectionOrCaretPositionAction(this, _nextWordBoundary)),
 
     // Copy Paste
     SelectAllTextIntent: _makeOverridable(QuillEditorSelectAllAction(this)),
-    CopySelectionTextIntent:
-        _makeOverridable(QuillEditorCopySelectionAction(this)),
-    PasteTextIntent: _makeOverridable(CallbackAction<PasteTextIntent>(
-        onInvoke: (intent) => pasteText(intent.cause))),
+    CopySelectionTextIntent: _makeOverridable(QuillEditorCopySelectionAction(this)),
+    PasteTextIntent:
+        _makeOverridable(CallbackAction<PasteTextIntent>(onInvoke: (intent) => pasteText(intent.cause))),
 
-    HideSelectionToolbarIntent:
-        _makeOverridable(QuillEditorHideSelectionToolbarAction(this)),
+    HideSelectionToolbarIntent: _makeOverridable(QuillEditorHideSelectionToolbarAction(this)),
     UndoTextIntent: _makeOverridable(QuillEditorUndoKeyboardAction(this)),
     RedoTextIntent: _makeOverridable(QuillEditorRedoKeyboardAction(this)),
 


### PR DESCRIPTION
## Description

As the title says, the context menu (on mobile) is visible even if we write some extra text to try to hide it manually. 

#### Steps to reproduce:

* Select a text
* Write something (yeah, replace the selection)

And voilá, you will see the context menu is visible when it should be hide already.

## Related Issues

- *Fix #2111*

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.