### PR TITLE
Feat: Spellchecker for Flutter Quill

### DIFF
--- a/example/lib/screens/quill/quill_screen.dart
+++ b/example/lib/screens/quill/quill_screen.dart
@@ -43,6 +43,8 @@ class _QuillScreenState extends State<QuillScreen> {
   void initState() {
     super.initState();
     _controller.document = widget.args.document;
+    SpellcheckerServiceProvider.setInstance(
+        SimpleSpellCheckerImpl(language: 'en'));
   }
 
   @override

--- a/example/lib/screens/quill/quill_screen.dart
+++ b/example/lib/screens/quill/quill_screen.dart
@@ -43,8 +43,6 @@ class _QuillScreenState extends State<QuillScreen> {
   void initState() {
     super.initState();
     _controller.document = widget.args.document;
-    SpellcheckerServiceProvider.setInstance(
-        SimpleSpellCheckerImpl(language: 'en'));
   }
 
   @override

--- a/lib/flutter_quill.dart
+++ b/lib/flutter_quill.dart
@@ -24,6 +24,8 @@ export 'src/editor/raw_editor/config/raw_editor_configurations.dart';
 export 'src/editor/raw_editor/quill_single_child_scroll_view.dart';
 export 'src/editor/raw_editor/raw_editor.dart';
 export 'src/editor/raw_editor/raw_editor_state.dart';
+export 'src/editor/spellchecker/spellchecker_service.dart';
+export 'src/editor/spellchecker/spellchecker_service_provider.dart';
 export 'src/editor/style_widgets/style_widgets.dart';
 export 'src/editor/widgets/cursor.dart';
 export 'src/editor/widgets/default_styles.dart';

--- a/lib/flutter_quill.dart
+++ b/lib/flutter_quill.dart
@@ -24,6 +24,7 @@ export 'src/editor/raw_editor/config/raw_editor_configurations.dart';
 export 'src/editor/raw_editor/quill_single_child_scroll_view.dart';
 export 'src/editor/raw_editor/raw_editor.dart';
 export 'src/editor/raw_editor/raw_editor_state.dart';
+export 'src/editor/spellchecker/simple_spellchecker_impl.dart';
 export 'src/editor/spellchecker/spellchecker_service.dart';
 export 'src/editor/spellchecker/spellchecker_service_provider.dart';
 export 'src/editor/style_widgets/style_widgets.dart';

--- a/lib/src/editor/spellchecker/default_spellchecker_service.dart
+++ b/lib/src/editor/spellchecker/default_spellchecker_service.dart
@@ -2,11 +2,14 @@ import 'package:flutter/gestures.dart' show LongPressGestureRecognizer;
 import 'package:flutter/material.dart' show TextSpan;
 import 'spellchecker_service.dart' show SpellcheckerService;
 
+/// A default implementation of the [SpellcheckerService]
+/// that always will return null since Spell checking
+/// is not a standard feature
 class DefaultSpellcheckerService extends SpellcheckerService {
   DefaultSpellcheckerService() : super(language: 'en');
 
   @override
-  void dispose() {}
+  void dispose({bool onlyPartial = false}) {}
 
   @override
   List<TextSpan>? fetchSpellchecker(String text,

--- a/lib/src/editor/spellchecker/default_spellchecker_service.dart
+++ b/lib/src/editor/spellchecker/default_spellchecker_service.dart
@@ -1,11 +1,17 @@
-import 'package:flutter/material.dart';
-import 'spellchecker_service.dart';
+import 'package:flutter/gestures.dart' show LongPressGestureRecognizer;
+import 'package:flutter/material.dart' show TextSpan;
+import 'spellchecker_service.dart' show SpellcheckerService;
 
-class DefaultSpellcheckerService extends SpellcheckerService{
+class DefaultSpellcheckerService extends SpellcheckerService {
   DefaultSpellcheckerService() : super(language: 'en');
 
   @override
-  List<TextSpan>? fetchSpellchecker(String text) {
+  void dispose() {}
+
+  @override
+  List<TextSpan>? fetchSpellchecker(String text,
+      {LongPressGestureRecognizer Function(String p1)?
+          customLongPressRecognizerOnWrongSpan}) {
     return null;
   }
 }

--- a/lib/src/editor/spellchecker/default_spellchecker_service.dart
+++ b/lib/src/editor/spellchecker/default_spellchecker_service.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/services.dart';
+import 'spellchecker_service.dart';
+
+class DefaultSpellcheckerService extends SpellcheckerService{
+  DefaultSpellcheckerService() : super(language: 'en');
+
+  @override
+  List<SuggestionSpan>? getSuggestions(String text) {
+    return null;
+  }
+}

--- a/lib/src/editor/spellchecker/simple_spellchecker_impl.dart
+++ b/lib/src/editor/spellchecker/simple_spellchecker_impl.dart
@@ -4,7 +4,7 @@ import 'package:simple_spell_checker/simple_spell_checker.dart';
 
 import 'spellchecker_service.dart';
 
-/// SimpleSpellCheckerImpl is a simple spell checker for get 
+/// SimpleSpellCheckerImpl is a simple spell checker for get
 /// all words divide on different objects if them are wrong or not
 class SimpleSpellCheckerImpl extends SpellcheckerService {
   SimpleSpellCheckerImpl({required super.language})
@@ -12,9 +12,10 @@ class SimpleSpellCheckerImpl extends SpellcheckerService {
           language: language,
           safeDictionaryLoad: true,
         );
+
   /// [SimpleSpellChecker] comes from the package [simple_spell_checker]
   /// that give us all necessary methods for get our spans with highlighting
-  /// where needed 
+  /// where needed
   final SimpleSpellChecker checker;
 
   @override
@@ -32,7 +33,7 @@ class SimpleSpellCheckerImpl extends SpellcheckerService {
 
   @override
   void dispose({bool onlyPartial = false}) {
-    if(onlyPartial) {
+    if (onlyPartial) {
       checker.disposeControllers();
       return;
     }

--- a/lib/src/editor/spellchecker/simple_spellchecker_impl.dart
+++ b/lib/src/editor/spellchecker/simple_spellchecker_impl.dart
@@ -1,13 +1,32 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:simple_spell_checker/simple_spell_checker.dart';
 
 import 'spellchecker_service.dart';
 
 class SimpleSpellCheckerImpl extends SpellcheckerService {
-  SimpleSpellCheckerImpl({required super.language});
+  SimpleSpellCheckerImpl({required super.language})
+      : checker = SimpleSpellChecker(
+          language: language,
+          safeDictionaryLoad: true,
+        );
+  final SimpleSpellChecker checker;
 
   @override
-  List<TextSpan>? fetchSpellchecker(String text) {
-    return null;
+  List<TextSpan>? fetchSpellchecker(
+    String text, {
+    LongPressGestureRecognizer Function(String word)?
+        customLongPressRecognizerOnWrongSpan,
+  }) {
+    return checker.check(
+      text,
+      customLongPressRecognizerOnWrongSpan:
+          customLongPressRecognizerOnWrongSpan,
+    );
   }
 
+  @override
+  void dispose() {
+    checker.dispose(closeDirectionary: true);
+  }
 }

--- a/lib/src/editor/spellchecker/simple_spellchecker_impl.dart
+++ b/lib/src/editor/spellchecker/simple_spellchecker_impl.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
+
 import 'spellchecker_service.dart';
 
-class DefaultSpellcheckerService extends SpellcheckerService{
-  DefaultSpellcheckerService() : super(language: 'en');
+class SimpleSpellCheckerImpl extends SpellcheckerService {
+  SimpleSpellCheckerImpl({required super.language});
 
   @override
   List<TextSpan>? fetchSpellchecker(String text) {
     return null;
   }
+
 }

--- a/lib/src/editor/spellchecker/simple_spellchecker_impl.dart
+++ b/lib/src/editor/spellchecker/simple_spellchecker_impl.dart
@@ -4,12 +4,17 @@ import 'package:simple_spell_checker/simple_spell_checker.dart';
 
 import 'spellchecker_service.dart';
 
+/// SimpleSpellCheckerImpl is a simple spell checker for get 
+/// all words divide on different objects if them are wrong or not
 class SimpleSpellCheckerImpl extends SpellcheckerService {
   SimpleSpellCheckerImpl({required super.language})
       : checker = SimpleSpellChecker(
           language: language,
           safeDictionaryLoad: true,
         );
+  /// [SimpleSpellChecker] comes from the package [simple_spell_checker]
+  /// that give us all necessary methods for get our spans with highlighting
+  /// where needed 
   final SimpleSpellChecker checker;
 
   @override
@@ -26,7 +31,11 @@ class SimpleSpellCheckerImpl extends SpellcheckerService {
   }
 
   @override
-  void dispose() {
+  void dispose({bool onlyPartial = false}) {
+    if(onlyPartial) {
+      checker.disposeControllers();
+      return;
+    }
     checker.dispose(closeDirectionary: true);
   }
 }

--- a/lib/src/editor/spellchecker/spellchecker_service.dart
+++ b/lib/src/editor/spellchecker/spellchecker_service.dart
@@ -1,12 +1,22 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
+/// A representation a custom SpellCheckService.
 abstract class SpellcheckerService {
   SpellcheckerService({required this.language});
 
   final String language;
+  /// dispose all the resources used for SpellcheckerService
+  /// 
+  /// if [onlyPartial] is true just dispose a part of the SpellcheckerService 
+  /// (this comes from the implementation)
+  ///
+  /// if [onlyPartial] is false dispose all resources
+  void dispose({bool onlyPartial = false});
 
-  void dispose();
+  /// Facilitates a spell check request.
+  ///
+  /// Returns a [List<TextSpan>] with all misspelled words divide from the right words.
   List<TextSpan>? fetchSpellchecker(String text,
       {LongPressGestureRecognizer Function(String)?
           customLongPressRecognizerOnWrongSpan});

--- a/lib/src/editor/spellchecker/spellchecker_service.dart
+++ b/lib/src/editor/spellchecker/spellchecker_service.dart
@@ -1,12 +1,8 @@
-import 'package:flutter/services.dart';
+import 'package:flutter/material.dart';
 
 abstract class SpellcheckerService {
-  SpellcheckerService({
-    required this.language,
-  });
+  SpellcheckerService({required this.language});
 
   final String language;
-  List<SuggestionSpan>? getSuggestions(String text);
+  List<TextSpan>? fetchSpellchecker(String text);
 }
-
-

--- a/lib/src/editor/spellchecker/spellchecker_service.dart
+++ b/lib/src/editor/spellchecker/spellchecker_service.dart
@@ -1,8 +1,13 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 abstract class SpellcheckerService {
   SpellcheckerService({required this.language});
 
   final String language;
-  List<TextSpan>? fetchSpellchecker(String text);
+
+  void dispose();
+  List<TextSpan>? fetchSpellchecker(String text,
+      {LongPressGestureRecognizer Function(String)?
+          customLongPressRecognizerOnWrongSpan});
 }

--- a/lib/src/editor/spellchecker/spellchecker_service.dart
+++ b/lib/src/editor/spellchecker/spellchecker_service.dart
@@ -6,9 +6,10 @@ abstract class SpellcheckerService {
   SpellcheckerService({required this.language});
 
   final String language;
+
   /// dispose all the resources used for SpellcheckerService
-  /// 
-  /// if [onlyPartial] is true just dispose a part of the SpellcheckerService 
+  ///
+  /// if [onlyPartial] is true just dispose a part of the SpellcheckerService
   /// (this comes from the implementation)
   ///
   /// if [onlyPartial] is false dispose all resources

--- a/lib/src/editor/spellchecker/spellchecker_service.dart
+++ b/lib/src/editor/spellchecker/spellchecker_service.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/services.dart';
+
+abstract class SpellcheckerService {
+  SpellcheckerService({
+    required this.language,
+  });
+
+  final String language;
+  List<SuggestionSpan>? getSuggestions(String text);
+}
+
+

--- a/lib/src/editor/spellchecker/spellchecker_service_provider.dart
+++ b/lib/src/editor/spellchecker/spellchecker_service_provider.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/foundation.dart' show immutable;
+import 'default_spellchecker_service.dart';
+import 'spellchecker_service.dart';
+
+@immutable
+class SpellcheckerServiceProvider {
+  const SpellcheckerServiceProvider._();
+  static SpellcheckerService _instance = DefaultSpellcheckerService();
+
+  static SpellcheckerService get instance => _instance;
+
+  static void setInstance(SpellcheckerService service) {
+    _instance = service;
+  }
+
+  static void setInstanceToDefault() {
+    _instance = DefaultSpellcheckerService();
+  }
+}

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -405,7 +405,8 @@ class _TextLineState extends State<TextLine> {
     }
 
     // verify is node is not link because we never need check a link word
-    if (!isLink) {
+    // and avoid to show highlighting when is only reading
+    if (!isLink && !widget.readOnly && !widget.line.style.attributes.containsKey('code-block')) {
       final service = SpellcheckerServiceProvider.instance;
       final spellcheckedSpans = service.fetchSpellchecker(textNode.value);
       if (spellcheckedSpans != null && spellcheckedSpans.isNotEmpty) {

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -391,10 +391,8 @@ class _TextLineState extends State<TextLine> {
     final nodeStyle = textNode.style;
     final isLink = nodeStyle.containsKey(Attribute.link.key) &&
         nodeStyle.attributes[Attribute.link.key]!.value != null;
-
     final style =
         _getInlineTextStyle(nodeStyle, defaultStyles, lineStyle, isLink);
-
     if (widget.controller.configurations.requireScriptFontFeatures == false &&
         textNode.value.isNotEmpty) {
       if (nodeStyle.containsKey(Attribute.script.key)) {
@@ -403,6 +401,19 @@ class _TextLineState extends State<TextLine> {
           return _scriptSpan(textNode.value, attr == Attribute.superscript,
               style, defaultStyles);
         }
+      }
+    }
+
+    // verify is node is not link because we never need check a link word
+    if (!isLink) {
+      final service = SpellcheckerServiceProvider.instance;
+      final spellcheckedSpans = service.fetchSpellchecker(textNode.value);
+      if (spellcheckedSpans != null && spellcheckedSpans.isNotEmpty) {
+        return TextSpan(
+          children: spellcheckedSpans,
+          style: style,
+          mouseCursor: null,
+        );
       }
     }
 

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -404,7 +404,10 @@ class _TextLineState extends State<TextLine> {
       }
     }
 
-    if (!isLink && !widget.readOnly && !widget.line.style.attributes.containsKey('code-block') && !kIsWeb) {
+    if (!isLink &&
+        !widget.readOnly &&
+        !widget.line.style.attributes.containsKey('code-block') &&
+        !kIsWeb) {
       final service = SpellcheckerServiceProvider.instance;
       final spellcheckedSpans = service.fetchSpellchecker(textNode.value);
       if (spellcheckedSpans != null && spellcheckedSpans.isNotEmpty) {

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -404,9 +404,7 @@ class _TextLineState extends State<TextLine> {
       }
     }
 
-    // verify is node is not link because we never need check a link word
-    // and avoid to show highlighting when is only reading
-    if (!isLink && !widget.readOnly && !widget.line.style.attributes.containsKey('code-block')) {
+    if (!isLink && !widget.readOnly && !widget.line.style.attributes.containsKey('code-block') && !kIsWeb) {
       final service = SpellcheckerServiceProvider.instance;
       final spellcheckedSpans = service.fetchSpellchecker(textNode.value);
       if (spellcheckedSpans != null && spellcheckedSpans.isNotEmpty) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   # Dart Packages
   intl: ^0.19.0
   dart_quill_delta: ^10.0.0
-  simple_spell_checker: ^1.0.4
+  simple_spell_checker: ^1.0.6
   collection: ^1.17.0
   quiver: ^3.2.1
   equatable: ^2.0.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   # Dart Packages
   intl: ^0.19.0
   dart_quill_delta: ^10.0.0
-  simple_spell_checker: ^1.0.3
+  simple_spell_checker: ^1.0.4
   collection: ^1.17.0
   quiver: ^3.2.1
   equatable: ^2.0.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   # Dart Packages
   intl: ^0.19.0
   dart_quill_delta: ^10.0.0
-  simple_spell_checker: ^1.0.1
+  simple_spell_checker: ^1.0.3
   collection: ^1.17.0
   quiver: ^3.2.1
   equatable: ^2.0.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   # Dart Packages
   intl: ^0.19.0
   dart_quill_delta: ^10.0.0
+  simple_spell_checker: ^1.0.1
   collection: ^1.17.0
   quiver: ^3.2.1
   equatable: ^2.0.5


### PR DESCRIPTION
## Description

For many versions I have been wondering how we could add spell-checking to the project or when it would even be implemented. However, now here is a feature that surely more than one of the thousands who use the package have wanted for their project, but that, unfortunately, had not been easy to implement.

Thanks to the [simple_spell_checker](https://pub.dev/packages/simple_spell_checker) package, getting which words are not spelled correctly from those that are was never so easy and fast.

Now, in order to activate this Feature we would have to take into account the existence of the `SpellcheckerService` class which allows us to create any custom implementation for our editor to directly use without any cover-ups.

```dart
abstract class SpellcheckerService {
  SpellcheckerService({required this.language});

  final String language;

  /// dispose all the resources used for SpellcheckerService
  ///
  /// if [onlyPartial] is true just dispose a part of the SpellcheckerService
  /// (this comes from the implementation)
  ///
  /// if [onlyPartial] is false dispose all resources
  void dispose({bool onlyPartial = false});

  /// Facilitates a spell check request.
  ///
  /// Returns a [List<TextSpan>] with all misspelled words divide from the right words.
  List<TextSpan>? fetchSpellchecker(String text,
      {LongPressGestureRecognizer Function(String)?
          customLongPressRecognizerOnWrongSpan});
}
```

By default `DefaultSpellcheckerService` is the one that the editor uses, which as we can see, has no function because it directly returns a null value.

```dart
class DefaultSpellcheckerService extends SpellcheckerService {
  DefaultSpellcheckerService() : super(language: 'en');

  @override
  void dispose({bool onlyPartial = false}) {}

  @override
  List<TextSpan>? fetchSpellchecker(String text,
      {LongPressGestureRecognizer Function(String p1)?
          customLongPressRecognizerOnWrongSpan}) {
    return null;
  }
}
```

And now, if we want to activate this new functionality that we added, we would have to use `SimpleSpellCheckerServiceImpl` which contains the implementation that we need to be able to activate spell-checking as if we were in Word or LibreOffice (obviously I'm exaggerating)

```dart
class SimpleSpellCheckerImpl extends SpellcheckerService {
  SimpleSpellCheckerImpl({required super.language})
      : checker = SimpleSpellChecker(
          language: language,
          safeDictionaryLoad: true,
        );

  /// [SimpleSpellChecker] comes from the package [simple_spell_checker]
  /// that give us all necessary methods for get our spans with highlighting
  /// where needed
  final SimpleSpellChecker checker;

  @override
  List<TextSpan>? fetchSpellchecker(
    String text, {
    LongPressGestureRecognizer Function(String word)?
        customLongPressRecognizerOnWrongSpan,
  }) {
    return checker.check(
      text,
      customLongPressRecognizerOnWrongSpan:
          customLongPressRecognizerOnWrongSpan,
    );
  }

  @override
  void dispose({bool onlyPartial = false}) {
    if (onlyPartial) {
      checker.disposeControllers();
      return;
    }
    checker.dispose();
  }
}
```

In order to make our instance valid, we have to use `SpellcheckerServiceProvider` with the setInstance() method
```dart
SpellcheckerServiceProvider.setInstance(SimpleSpellCheckerServiceImpl(language: '<your_language>'));
```
And voilá, we will have at our disposal a powerful tool that will be useful for those who write novels, notes, or any type of document that requires correct spelling and grammar.

> [!NOTE]
> It should be noted that the `dispose()` method of `SpellcheckerService` is not just for show. This method, at least for `SimpleSpellCheckerServiceImpl`, is responsible for closing the spell-checker itself once we no longer use it. This is important to note because `SimpleSpellChecker` is used within our custom service, and it contains several `StreamControllers` that need to be closed to avoid memory issues.
>
> ```dart
> SpellcheckerServiceProvider.instance.dispose(); // call when spell-checker will no longer used
> ```

## A little preview of this Feat:

_there's some issue with some words, but this is an error from [simple_spell_checker](https://pub.dev/packages/simple_spell_checker) since i delete case sensitive (i'll fix it later)_

https://github.com/user-attachments/assets/e164d208-c3db-4871-8413-01d24b90c3e8

- [x] ✨ **New feature:** Adds new functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.