### PR TITLE
fix null reference exception when dragging selection on non scrollable selection

### DIFF
--- a/lib/src/editor/widgets/delegate.dart
+++ b/lib/src/editor/widgets/delegate.dart
@@ -762,8 +762,8 @@ class EditorTextSelectionGestureDetectorBuilder {
     // if (editor?.textEditingValue.selection.isCollapsed == false) return;
     if (!_isShiftPressed) {
       // Adjust the drag start offset for possible viewport offset changes.
-      final editableOffset =
-          Offset(0, renderEditor!.offset!.pixels - _dragStartViewportOffset);
+      final editableOffset = Offset(
+          0, (renderEditor!.offset?.pixels ?? 0) - _dragStartViewportOffset);
       final scrollableOffset =
           Offset(0, _scrollPosition - _dragStartScrollOffset);
       final dragStartGlobalPosition =


### PR DESCRIPTION


## Description

fix null reference exception when dragging selection on non scrollable selection. offset will be null when the editor is not scrollable, which causes a null ref exception.

## Related Issues

<!--

Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/singerdmx/flutter-quill/issues). Indicate, which of these issues are resolved or fixed by this PR.

-->

<!-- *e.g.* -->
- *Fix #123*
- *Related #456*

## Type of Change

<!--- 

Put an x in all the boxes that apply:

- [x] **Example:**

-->

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions

<!-- Optional -->