### PR TITLE
Fix: direction has no opposite effect if the language is rtl

### DIFF
--- a/lib/src/delta/delta_diff.dart
+++ b/lib/src/delta/delta_diff.dart
@@ -88,9 +88,12 @@ int getPositionDelta(Delta user, Delta actual) {
   return diff;
 }
 
-TextDirection getDirectionOfNode(Node node) {
+TextDirection getDirectionOfNode(Node node, [TextDirection? currentDirection]) {
   final direction = node.style.attributes[Attribute.direction.key];
-  if (direction == Attribute.rtl) {
+  // If it is RTL, then create the opposite direction
+  if (currentDirection == TextDirection.rtl && direction == Attribute.rtl) {
+    return TextDirection.ltr;
+  } else if (direction == Attribute.rtl) {
     return TextDirection.rtl;
   }
   return TextDirection.ltr;

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -975,15 +975,7 @@ class QuillRawEditorState extends EditorState
       }
 
       prevNodeOl = attrs[Attribute.list.key] == Attribute.ol;
-      var nodeTextDirection = getDirectionOfNode(node);
-      // verify if the direction from nodeTextDirection is the default direction
-      // and watch if the system language is a RTL language and avoid putting
-      // to the edge of the left side any checkbox or list point/number if is a
-      // RTL language
-      if (nodeTextDirection == TextDirection.ltr &&
-          _textDirection == TextDirection.rtl) {
-        nodeTextDirection = TextDirection.rtl;
-      }
+      final nodeTextDirection = getDirectionOfNode(node, _textDirection);
       if (node is Line) {
         final editableTextLine = _getEditableTextLineFromNode(node, context);
         result.add(Directionality(

--- a/lib/src/editor/widgets/text/text_block.dart
+++ b/lib/src/editor/widgets/text/text_block.dart
@@ -196,15 +196,7 @@ class EditableTextBlock extends StatelessWidget {
         MediaQuery.devicePixelRatioOf(context),
         cursorCont,
       );
-      var nodeTextDirection = getDirectionOfNode(line);
-      // verify if the direction from nodeTextDirection is the default direction
-      // and watch if the system language is a RTL language and avoid putting
-      // to the edge of the left side any checkbox or list point/number if is a
-      // RTL language
-      if (nodeTextDirection == TextDirection.ltr &&
-          textDirection == TextDirection.rtl) {
-        nodeTextDirection = TextDirection.rtl;
-      }
+      final nodeTextDirection = getDirectionOfNode(line, textDirection);
       children.add(
         Directionality(
           textDirection: nodeTextDirection,


### PR DESCRIPTION
## Description

If we assume we have a language like **Hebrew**, when we try to use the `Direction` button to toggle the direction to `LTR` instead of the current `RTL` view, then the view will have no effect because we are not taking into account the opposite case of directions.

## Related Issues

- *Fix #2136*

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions

We should need to add a LRT `DirectionAttribute` to be more clear if the user has a RTL language.