### PR TITLE
fix floating cursor not disappearing after scroll end

### DIFF
--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -1465,6 +1465,7 @@ class RenderEditor extends RenderEditableContainerBox
       _floatingCursorRect = null;
       _cursorController.setFloatingCursorTextPosition(null);
     }
+    markNeedsPaint();
   }
 
   void _paintFloatingCursor(PaintingContext context, Offset offset) {


### PR DESCRIPTION
closes #2162

<!-- 

Thank you for contributing.

Provide a description of your changes below and a general summary in the title.

Consider reading the Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md.

The changes of `CHANGELOG.md` and package version in `pubspec.yaml` are automated.

-->

## Description

- Call `markNeedsPaint` in the right place 🤞 
- Animation now occurs properly - cursor position* is animated and on the drag end the cursor will disappear as expected

__(\*)__ Animation is most of the time not correctly snapped to the right place. The floating cursor seems to be off and even not visible if you scroll the text content down first and then initiate floating cursor 🤷

__(\*\*)__ On second try misaligned snapping doesn't happen so maybe it's all fixed 🤷 

## Type of Change

<!--- 

Put an x in all the boxes that apply:

- [x] **Example:**

-->

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions

<!-- Optional -->