### PR TITLE
fix drag selection extension (does not start at tap location if you are dragging quickly

### DIFF
--- a/lib/src/editor/widgets/delegate.dart
+++ b/lib/src/editor/widgets/delegate.dart
@@ -206,7 +206,11 @@ class EditorTextSelectionGestureDetectorBuilder {
     assert(renderEditor?.selection.baseOffset != null);
 
     final tappedPosition = renderEditor!.getPositionForOffset(offset);
-    final selection = renderEditor!.selection;
+    final selection = switch (cause) {
+      SelectionChangedCause.drag => _dragStartSelection!,
+      _ => renderEditor!.selection
+    };
+
     final nextSelection = selection.copyWith(
       extentOffset: tappedPosition.offset,
     );
@@ -691,7 +695,7 @@ class EditorTextSelectionGestureDetectorBuilder {
           switch (details.kind) {
             case PointerDeviceKind.mouse:
             case PointerDeviceKind.trackpad:
-              renderEditor?.selectPositionAt(
+              _dragStartSelection = renderEditor?.selectPositionAt(
                 from: details.globalPosition,
                 cause: SelectionChangedCause.drag,
               );
@@ -704,7 +708,7 @@ class EditorTextSelectionGestureDetectorBuilder {
               assert(_dragBeganOnPreviousSelection != null);
               if (renderEditor?.hasFocus == true &&
                   _dragBeganOnPreviousSelection!) {
-                renderEditor?.selectPositionAt(
+                _dragStartSelection = renderEditor?.selectPositionAt(
                   from: details.globalPosition,
                   cause: SelectionChangedCause.drag,
                 );
@@ -717,7 +721,7 @@ class EditorTextSelectionGestureDetectorBuilder {
           switch (details.kind) {
             case PointerDeviceKind.mouse:
             case PointerDeviceKind.trackpad:
-              renderEditor?.selectPositionAt(
+              _dragStartSelection = renderEditor?.selectPositionAt(
                 from: details.globalPosition,
                 cause: SelectionChangedCause.drag,
               );
@@ -728,7 +732,7 @@ class EditorTextSelectionGestureDetectorBuilder {
               // For Android, Fucshia, and iOS platforms, a touch drag
               // does not initiate unless the editable has focus.
               if (renderEditor?.hasFocus == true) {
-                renderEditor?.selectPositionAt(
+                _dragStartSelection = renderEditor?.selectPositionAt(
                   from: details.globalPosition,
                   cause: SelectionChangedCause.drag,
                 );
@@ -739,7 +743,7 @@ class EditorTextSelectionGestureDetectorBuilder {
         case TargetPlatform.linux:
         case TargetPlatform.macOS:
         case TargetPlatform.windows:
-          renderEditor?.selectPositionAt(
+          _dragStartSelection = renderEditor?.selectPositionAt(
             from: details.globalPosition,
             cause: SelectionChangedCause.drag,
           );


### PR DESCRIPTION
<!-- 

Thank you for contributing.

Provide a description of your changes below and a general summary in the title.

Consider reading the Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md.

The changes of `CHANGELOG.md` and package version in `pubspec.yaml` are automated.

-->

## Description

This fixes an issue with selection dragging when dragging quickly. If dragging quickly, the selection was extending from the location it was in before the tap down, rather than starting at the location where the tap down occurred. 

## Related Issues

<!--

Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/singerdmx/flutter-quill/issues). Indicate, which of these issues are resolved or fixed by this PR.

-->

<!-- *e.g.* -->
- *Fix #123*
- *Related #456*

## Type of Change

<!--- 

Put an x in all the boxes that apply:

- [x] **Example:**

-->

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [X] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions

<!-- Optional -->