### PR TITLE
fix(toolbar): regard showDividers in simple toolbar

### DIFF
--- a/lib/src/toolbar/simple_toolbar.dart
+++ b/lib/src/toolbar/simple_toolbar.dart
@@ -305,7 +305,7 @@ class QuillSimpleToolbar extends StatelessWidget
         final buttons = groups[i];
 
         if (buttons.isNotEmpty) {
-          if (buttonsAll.isNotEmpty) {
+          if (buttonsAll.isNotEmpty && configurations.showDividers) {
             buttonsAll.add(divider);
           }
           buttonsAll.addAll(buttons);


### PR DESCRIPTION
<!-- 

Thank you for contributing.

Provide a description of your changes below and a general summary in the title.

Consider reading the Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md.

The changes of `CHANGELOG.md` and package version in `pubspec.yaml` are automated.

-->

## Description

Dividers in toolbar still presents after set `showDividers` to false.

![image](https://github.com/user-attachments/assets/82cc3a18-70b8-413c-bd13-f074d7896761)


## Related Issues
- *Fix #2171*

## Type of Change

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions

<!-- Optional -->