### PR TITLE
Update quill_screen.dart, i chaged the logic for showing a lock when …

### DIFF
--- a/example/lib/screens/quill/quill_screen.dart
+++ b/example/lib/screens/quill/quill_screen.dart
@@ -138,7 +138,7 @@ class _QuillScreenState extends State<QuillScreen> {
         ],
       ),
       floatingActionButton: FloatingActionButton(
-        child: Icon(_isReadOnly ? Icons.lock : Icons.edit),
+        child: Icon(!_isReadOnly ? Icons.lock : Icons.edit),
         onPressed: () => setState(() => _isReadOnly = !_isReadOnly),
       ),
     );


### PR DESCRIPTION
…in edit mode and showing edit icon when  in lock mode

<!-- 

Thank you for contributing.

Provide a description of your changes below and a general summary in the title.

Consider reading the Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md.

The changes of `CHANGELOG.md` and package version in `pubspec.yaml` are automated.

-->

## Description

This pull request updates the logic in the library's example to enhance the user experience when toggling between edit and read-only modes. The following changes have been made:

Edit Mode: The UI now displays a lock icon when in edit mode, allowing users to switch to read-only mode easily.
Read-Only Mode: Conversely, when in read-only mode, the UI displays an edit icon, enabling users to switch back to edit mode.
These changes improve the clarity and functionality of the mode-switching mechanism, making it more intuitive for users.

## Related Issues

<!--

No related issues.

-->


<!--- 

Put an x in all the boxes that apply:

- [x] **Example:**

-->

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions
None at this time.
<!-- Optional -->