### PR TITLE
chore(example): downgrade Kotlin from 1.9.24 to 1.7.10

### DIFF
--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -19,8 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "7.3.0" apply false
-    // TODO: We should update the project to not require higher version of Kotlin
-    id "org.jetbrains.kotlin.android" version "1.9.24" apply false
+    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
 }
 
 include ":app"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -39,7 +39,13 @@ dependencies:
   image_cropper: ^8.0.1
   path_provider: ^2.1.2
   # For drag and drop feature
-  desktop_drop: ^0.4.4
+  # Switch to the pub.dev version after https://github.com/MixinNetwork/flutter-plugins/pull/351
+  # is published
+  desktop_drop:
+    git:
+      url: https://github.com/MixinNetwork/flutter-plugins.git
+      path: packages/desktop_drop
+      ref: 0d1ce578abddd171b309b15847bd6e4f9163881e
   # For picking quill document files
   file_picker: ^8.0.0+1
   # For sharing text


### PR DESCRIPTION
## Description

*Downgrade Kotlin from `1.9.24` to `1.7.10` in the example as it is the currently supported version by Flutter.*

Using newer Kotlin versions may cause unexpected issues in release mode and other unnoticeable issues.

See the section `Flutter tool enforces version requirements on Gradle, AGP, Java, and Kotlin` in [What's new in Flutter 3.22](https://medium.com/flutter/whats-new-in-flutter-3-22-fbde6c164fe3).

This PR uses a newer unpublished version of `desktop_drop` to fix this issue that also uses the package `web` and adds support for WASM.

## Type of Change

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [x] 🗑️ **Chore:** Routine tasks, or maintenance.
- [x] ✅ **Build configuration change:** Changes to build or deploy processes.
