### PR TITLE
Feat: Add configuration option to always indent on TAB key press

### DIFF
--- a/lib/src/editor/config/editor_configurations.dart
+++ b/lib/src/editor/config/editor_configurations.dart
@@ -58,6 +58,7 @@ class QuillEditorConfigurations extends Equatable {
     this.onSingleLongTapMoveUpdate,
     this.onSingleLongTapEnd,
     this.enableMarkdownStyleConversion = true,
+    this.enableAlwaysIndentOnTab = false,
     this.embedBuilders,
     this.unknownEmbedBuilder,
     this.searchConfigurations = const QuillSearchConfigurations(),
@@ -145,6 +146,16 @@ class QuillEditorConfigurations extends Equatable {
   /// entering '1.' followed by a space or '-' followed by a space
   /// will automatically convert the input into a Markdown list format.
   final bool enableMarkdownStyleConversion;
+
+  /// Enables always indenting when the TAB key is pressed.
+  ///
+  /// When set to true, pressing the TAB key will always insert an indentation
+  /// regardless of the context. If set to false, the TAB key will only indent
+  /// when the cursor is at the beginning of a list item. In other cases, it will
+  /// insert a tab character.
+  ///
+  /// Defaults to false. Must not be null.
+  final bool enableAlwaysIndentOnTab;
 
   /// Additional space around the content of this editor.
   /// by default will be [EdgeInsets.zero]
@@ -412,6 +423,7 @@ class QuillEditorConfigurations extends Equatable {
     bool? disableClipboard,
     bool? scrollable,
     bool? enableMarkdownStyleConversion,
+    bool? enableAlwaysIndentOnTab,
     double? scrollBottomInset,
     EdgeInsetsGeometry? padding,
     bool? autoFocus,
@@ -474,6 +486,8 @@ class QuillEditorConfigurations extends Equatable {
       padding: padding ?? this.padding,
       enableMarkdownStyleConversion:
           enableMarkdownStyleConversion ?? this.enableMarkdownStyleConversion,
+      enableAlwaysIndentOnTab:
+          enableAlwaysIndentOnTab ?? this.enableAlwaysIndentOnTab,
       autoFocus: autoFocus ?? this.autoFocus,
       isOnTapOutsideEnabled:
           isOnTapOutsideEnabled ?? this.isOnTapOutsideEnabled,

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -305,6 +305,7 @@ class QuillEditorState extends State<QuillEditor>
               scrollable: configurations.scrollable,
               enableMarkdownStyleConversion:
                   configurations.enableMarkdownStyleConversion,
+              enableAlwaysIndentOnTab: configurations.enableAlwaysIndentOnTab,
               scrollBottomInset: configurations.scrollBottomInset,
               padding: configurations.padding,
               readOnly: controller.readOnly,

--- a/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
@@ -72,6 +72,7 @@ class QuillRawEditorConfigurations extends Equatable {
     this.expands = false,
     this.isOnTapOutsideEnabled = true,
     this.enableMarkdownStyleConversion = true,
+    this.enableAlwaysIndentOnTab = false,
     this.onTapOutside,
     this.keyboardAppearance,
     this.enableInteractiveSelection = true,
@@ -111,6 +112,16 @@ class QuillRawEditorConfigurations extends Equatable {
   final EdgeInsetsGeometry padding;
 
   final bool enableMarkdownStyleConversion;
+
+  /// Enables always indenting when the TAB key is pressed.
+  ///
+  /// When set to true, pressing the TAB key will always insert an indentation
+  /// regardless of the context. If set to false, the TAB key will only indent
+  /// when the cursor is at the beginning of a list item. In other cases, it will
+  /// insert a tab character.
+  ///
+  /// Defaults to false. Must not be null.
+  final bool enableAlwaysIndentOnTab;
 
   /// Whether the text can be changed.
   ///

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -809,8 +809,12 @@ class QuillRawEditorState extends EditorState
       if (widget.configurations.readOnly) {
         return KeyEventResult.ignored;
       }
-      controller.replaceText(controller.selection.baseOffset, 0, '\t', null);
-      _moveCursor(1);
+      if (widget.configurations.enableAlwaysIndentOnTab) {
+        controller.indentSelection(!HardwareKeyboard.instance.isShiftPressed);
+      } else {
+        controller.replaceText(controller.selection.baseOffset, 0, '\t', null);
+        _moveCursor(1);
+      }
       return KeyEventResult.handled;
     }
 


### PR DESCRIPTION
## Description

I have added an option that allows indentation/un-indentation to be applied whenever the Tab key is pressed, regardless of the cursor position.

Previously, the Tab key would only function as an indent when the cursor was at the beginning of a line. If the Tab key was pressed in the middle of a line (for example, within a bullet point), it would just insert a tab character without indenting.

In common editors like Google Docs or Notion, and in input fields such as Slack, pressing Tab is always recognized as an indent and Shift + Tab as an un-indent, regardless of the cursor's position. To make Flutter Quill more accessible and familiar to a wider audience, we have introduced a feature that mimics this behavior.

By default, the Tab key will still only trigger indentation at the beginning of a line, as it has in the past.

Since tabs are visually indistinguishable from spaces in the editor, the need to input a tab character directly seems rare. Therefore, we considered making it so that the Tab key always functions as an indent, without adding an option. While we’ve chosen to introduce this as an optional feature for now to maintain the current behavior, we could also consider changing the default behavior or setting this option to true by default if there's no strong reason to preserve the existing behavior.

Please feel free to share your thoughts on this approach.

## Related Issues

- *Related #1188*
- *Related＃1171*

## Type of Change

- [x] ✨ **New feature:** Adds new functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions
