### PR TITLE
Allow backspace at start of document to remove block style and header style

### DIFF
--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -761,6 +761,11 @@ class QuillRawEditorState extends EditorState
       return _handleSpaceKey(event);
     }
 
+    // Handles removing styles when pressing the backspace key at the beginning of the document.
+    if (event.logicalKey == LogicalKeyboardKey.backspace) {
+      return _handleBackspaceKey(event);
+    }
+
     return KeyEventResult.ignored;
   }
 
@@ -794,6 +799,49 @@ class QuillRawEditorState extends EditorState
       return KeyEventResult.ignored;
     }
 
+    return KeyEventResult.handled;
+  }
+
+  KeyEventResult _handleBackspaceKey(KeyEvent event) {
+    final child =
+        controller.document.queryChild(controller.selection.baseOffset);
+    if (child.node == null) {
+      return KeyEventResult.ignored;
+    }
+
+    if (child.node == null) {
+      return KeyEventResult.ignored;
+    }
+
+    // Only process when the backspace key is pressed at the beginning of the document.
+    if (controller.selection.baseOffset != 0) {
+      return KeyEventResult.ignored;
+    }
+
+    // Blocks and headers are targeted.
+    final node = child.node!;
+    final parent = node.parent;
+    if (parent == null && (parent is Block || parent is Root)) {
+      return KeyEventResult.ignored;
+    }
+
+    // Remove the parent's style.
+    // Block attributes are removed.
+    final style = parent!.style;
+    if (style.isNotEmpty) {
+      for (final attr in style.values) {
+        controller.formatSelection(Attribute.clone(attr, null));
+      }
+    }
+
+    // Remove the first child's style.
+    // Header attributes are removed.
+    final firstChildStyle = parent.first?.style;
+    if (firstChildStyle != null) {
+      for (final attr in firstChildStyle.values) {
+        controller.formatSelection(Attribute.clone(attr, null));
+      }
+    }
     return KeyEventResult.handled;
   }
 


### PR DESCRIPTION
## Description

This is a fix for #2180. It adjusts behavior so that pressing backspace at the beginning of a document when the cursor is on a header/block will remove the header/block style. This allows styles to be removed using only keyboard operations, without needing to use the toolbar, thereby improving convenience.

https://github.com/user-attachments/assets/005ba3c9-352c-4fbd-acf3-a4e99ef6e9ac

**This pull request will slightly modify existing behavior.**

## Related Issues

- *Fix #2180*

## Type of Change

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions


