### PR TITLE
Enhancement: Backspace handling at the start of blocks in delete rules

### DIFF
--- a/lib/src/rules/delete.dart
+++ b/lib/src/rules/delete.dart
@@ -89,6 +89,34 @@ class PreserveLineStyleOnMergeRule extends DeleteRule {
       ..retain(index)
       ..delete(len);
 
+    // Check if the previous line is empty
+    final prevItr = DeltaIterator(document.toDelta())..skip(index - 1);
+    final prevOp = prevItr.next(1);
+    if (prevOp.data == '\n') {
+      // Check if the current block is at the start and not empty
+      final currentBlockItr = DeltaIterator(document.toDelta())..skip(index);
+      var currentBlockOp = currentBlockItr.next(1);
+      final isBlockStart = currentBlockOp.data == '\n';
+      var isBlockNotEmpty = false;
+
+      while (currentBlockItr.hasNext) {
+        currentBlockOp = currentBlockItr.next();
+        if (currentBlockOp.data is String &&
+            (currentBlockOp.data as String).contains('\n')) {
+          break;
+        }
+        if (currentBlockOp.data is String &&
+            (currentBlockOp.data as String).trim().isNotEmpty) {
+          isBlockNotEmpty = true;
+        }
+      }
+
+      if (isBlockStart && isBlockNotEmpty) {
+        // Previous line is empty, skip the merge
+        return delta;
+      }
+    }
+
     while (itr.hasNext) {
       op = itr.next();
       final text = op.data is String ? (op.data as String?)! : '';


### PR DESCRIPTION
## Description

Adjusts the handling of the backspace key at the start of blocks. It introduces a condition to delete the empty previous line and skip the merging action if the backspace key is pressed, preserving the current block's style and integrity. This change ensures a more intuitive editing experience.

https://github.com/user-attachments/assets/63e93d4d-5bb0-4080-80d6-2aa28515febf

This resolves the issue where, when wanting to move content to the top of a document by pressing backspace to delete empty lines, such as within code blocks, the block style is unintentionally removed. The behavior is similar to that of the message input field in Slack.

**This pull request will slightly modify existing behavior.** 

## Related Issues

## Type of Change

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions

