### PR TITLE
Fix: Block Attributes are not displayed if the editor is empty

### DIFF
--- a/lib/src/delta/delta_diff.dart
+++ b/lib/src/delta/delta_diff.dart
@@ -39,11 +39,17 @@ Diff getDiff(String oldText, String newText, int cursorPosition) {
       end > limit && oldText[end - 1] == newText[end + delta - 1];
       end--) {}
   var start = 0;
+  //TODO: we need to improve this part because this loop has a lot of unsafe index operations
   for (final startLimit = cursorPosition - math.max(0, delta);
-      start < startLimit && oldText[start] == newText[start];
+      start < startLimit &&
+          (start > oldText.length - 1 ? '' : oldText[start]) ==
+              (start > newText.length - 1 ? '' : newText[start]);
       start++) {}
   final deleted = (start >= end) ? '' : oldText.substring(start, end);
-  final inserted = newText.substring(start, end + delta);
+  // we need to make the check if the start is major than the end because if we directly get the
+  // new inserted text without checking first, this will always throw an error since this is an unsafe op
+  final inserted =
+      (start >= end + delta) ? '' : newText.substring(start, end + delta);
   return Diff(
     start: start,
     deleted: deleted,

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -404,15 +404,15 @@ class QuillRawEditorState extends EditorState
     var doc = controller.document;
     if (doc.isEmpty() && widget.configurations.placeholder != null) {
       final raw = widget.configurations.placeholder?.replaceAll(r'"', '\\"');
-      // get current block attributes applied to the first line even if it 
-      // is empty 
+      // get current block attributes applied to the first line even if it
+      // is empty
       final blockAttributesWithoutContent =
           doc.root.children.firstOrNull?.toDelta().first.attributes;
       // check if it has code block attribute to add '//' to give to the users
       // the feeling of this is really a block of code
       final isCodeBlock =
           blockAttributesWithoutContent?.containsKey('code-block') ?? false;
-      // we add the block attributes at the same time as the placeholder to allow the editor to display them without removing 
+      // we add the block attributes at the same time as the placeholder to allow the editor to display them without removing
       // the placeholder (this is really awkward when everything is empty)
       final blockAttrInsertion = blockAttributesWithoutContent == null
           ? ''

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -404,16 +404,16 @@ class QuillRawEditorState extends EditorState
     var doc = controller.document;
     if (doc.isEmpty() && widget.configurations.placeholder != null) {
       final raw = widget.configurations.placeholder?.replaceAll(r'"', '\\"');
-      // we use this to show the current block attribute applied to the first line even if this line
-      // is empty (is most for show cases)
+      // get current block attributes applied to the first line even if it 
+      // is empty 
       final blockAttributesWithoutContent =
           doc.root.children.firstOrNull?.toDelta().first.attributes;
-      // we use this to check if it has code block attribute to add '//' to give to the users
+      // check if it has code block attribute to add '//' to give to the users
       // the feeling of this is really a block of code
       final isCodeBlock =
           blockAttributesWithoutContent?.containsKey('code-block') ?? false;
-      //  We add the block attributes at the same time of the placeholder to let the editor show them without remove
-      // the placeholder (that is really unconfortable when all is empty)
+      // we add the block attributes at the same time as the placeholder to allow the editor to display them without removing 
+      // the placeholder (this is really awkward when everything is empty)
       final blockAttrInsertion = blockAttributesWithoutContent == null
           ? ''
           : ',{"insert":"\\n","attributes":${jsonEncode(blockAttributesWithoutContent)}}';

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -130,6 +130,11 @@ class _TextLineState extends State<TextLine> {
     super.dispose();
   }
 
+  /// Check if this line contains the placeholder attribute
+  bool get isPlaceholderLine =>
+      widget.line.toDelta().first.attributes?.containsKey('placeholder') ??
+      false;
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
@@ -325,6 +330,16 @@ class _TextLineState extends State<TextLine> {
         textStyle.merge(textStyle.copyWith(height: x[lineHeight]?.height));
 
     textStyle = _applyCustomAttributes(textStyle, widget.line.style.attributes);
+
+    if (isPlaceholderLine) {
+      final oldStyle = textStyle;
+      textStyle = defaultStyles.placeHolder!.style;
+      textStyle = textStyle.merge(oldStyle.copyWith(
+        color: textStyle.color,
+        backgroundColor: textStyle.backgroundColor,
+        background: textStyle.background,
+      ));
+    }
 
     return textStyle;
   }

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -423,7 +423,7 @@ class _TextLineState extends State<TextLine> {
         !widget.readOnly &&
         !widget.line.style.attributes.containsKey('code-block') &&
         !widget.line.style.attributes.containsKey('placeholder') &&
-        !kIsWeb && 
+        !kIsWeb &&
         !isPlaceholderLine) {
       final service = SpellCheckerServiceProvider.instance;
       final spellcheckedSpans = service.checkSpelling(textNode.value);

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -423,7 +423,8 @@ class _TextLineState extends State<TextLine> {
         !widget.readOnly &&
         !widget.line.style.attributes.containsKey('code-block') &&
         !widget.line.style.attributes.containsKey('placeholder') &&
-        !kIsWeb) {
+        !kIsWeb && 
+        !isPlaceholderLine) {
       final service = SpellCheckerServiceProvider.instance;
       final spellcheckedSpans = service.checkSpelling(textNode.value);
       if (spellcheckedSpans != null && spellcheckedSpans.isNotEmpty) {


### PR DESCRIPTION
## Description

### Block Attributes issue

Also fixed an issue with block attributes not being visible when the `Document` was empty. In addition to this, added the ability for the editor to display block attributes next to the placeholder (the attribute) so that the user can see how their text will look even if the entire `Document` is empty.

### Before:

https://github.com/user-attachments/assets/3109fdf6-1445-4731-91bf-56715783e98e

### After: 

https://github.com/user-attachments/assets/47555b95-1c2c-4f1e-9acc-c6e45e38a1eb

### Delta diff issue

Fixed some issues with trying to constantly select or move to a position that doesn't exist. This was because `delta_diff` previously didn't reliably check the difference between 2 Deltas. Now added some checks (not perfect) which avoid these issues.

### How it works now:

https://github.com/user-attachments/assets/85ba9da7-bd2b-4cf2-9173-cf166d96819d

However, I'll keep an eye out for different scenarios that could cause `delta_diff` to fail (I'm not doing it in this PR as I'm already doing 2 PRs in one due to time constraints).

## Related Issues

- *Fix #2209*
- *Fix #2159*

- [x] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.