### PR TITLE
revert: disable rich text paste feature on web as a workaround

### DIFF
--- a/lib/src/controller/web/quill_controller_web_real.dart
+++ b/lib/src/controller/web/quill_controller_web_real.dart
@@ -5,6 +5,7 @@ import 'dart:async' show StreamSubscription;
 import 'package:web/web.dart';
 
 import '../quill_controller.dart';
+// ignore: unused_import
 import '../quill_controller_rich_paste.dart';
 
 /// Paste event for the web.

--- a/lib/src/controller/web/quill_controller_web_real.dart
+++ b/lib/src/controller/web/quill_controller_web_real.dart
@@ -23,7 +23,9 @@ extension QuillControllerWeb on QuillController {
       if (html == null) {
         return;
       }
-      pasteHTML(html: html);
+      // TODO: Temporarily disable the rich text pasting feature as a workaround
+      //    due to issue https://github.com/singerdmx/flutter-quill/issues/2220
+      // pasteHTML(html: html);
     });
   }
 


### PR DESCRIPTION
## Description

*Disable feature #2009 due to issue #2220.*

Will fix this issue ASAP, for now disabling it to avoid any regressions.

## Related Issues

<!--

Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/singerdmx/flutter-quill/issues). Indicate, which of these issues are resolved or fixed by this PR.

-->

<!-- *e.g.* -->
- *Related #2220*
- *Related #2009*

## Type of Change

<!--- 

Put an x in all the boxes that apply:

- [x] **Example:**

-->

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [x] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.
