### PR TITLE
refactor: moved shortcuts and onKeyEvents to its own file

### DIFF
--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -9,20 +9,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show RenderAbstractViewport;
 import 'package:flutter/scheduler.dart' show SchedulerBinding;
 import 'package:flutter/services.dart'
-    show
-        Clipboard,
-        HardwareKeyboard,
-        KeyDownEvent,
-        LogicalKeyboardKey,
-        SystemChannels,
-        TextInputControl;
+    show Clipboard, HardwareKeyboard, SystemChannels, TextInputControl;
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart'
     show KeyboardVisibilityController;
 
 import '../../common/structs/horizontal_spacing.dart';
 import '../../common/structs/offset_value.dart';
 import '../../common/structs/vertical_spacing.dart';
-import '../../common/utils/cast.dart';
 import '../../common/utils/platform.dart';
 import '../../controller/quill_controller.dart';
 import '../../delta/delta_diff.dart';
@@ -30,14 +23,13 @@ import '../../document/attribute.dart';
 import '../../document/document.dart';
 import '../../document/nodes/block.dart';
 import '../../document/nodes/embeddable.dart';
-import '../../document/nodes/leaf.dart' as leaf;
 import '../../document/nodes/line.dart';
 import '../../document/nodes/node.dart';
 import '../../editor_toolbar_controller_shared/clipboard/clipboard_service_provider.dart';
 import '../editor.dart';
 import '../widgets/cursor.dart';
 import '../widgets/default_styles.dart';
-import '../widgets/keyboard_listener.dart';
+import '../widgets/keyboard_service_widget.dart';
 import '../widgets/link.dart';
 import '../widgets/proxy.dart';
 import '../widgets/text/text_block.dart';
@@ -526,8 +518,6 @@ class QuillRawEditorState extends EditorState
             maxHeight: widget.configurations.maxHeight ?? double.infinity,
           );
 
-    final isDesktopMacOS = isMacOS;
-
     return TextFieldTapRegion(
       enabled: widget.configurations.isOnTapOutsideEnabled,
       onTapOutside: (event) {
@@ -540,367 +530,22 @@ class QuillRawEditorState extends EditorState
       },
       child: QuillStyles(
         data: _styles!,
-        child: Shortcuts(
-          /// Merge with widget.configurations.customShortcuts
-          /// first to allow user's defined shortcuts to take
-          /// priority when activation triggers are the same
-          shortcuts: mergeMaps<ShortcutActivator, Intent>(
-            {...?widget.configurations.customShortcuts},
-            {
-              // shortcuts added for Desktop platforms.
-              const SingleActivator(
-                LogicalKeyboardKey.escape,
-              ): const HideSelectionToolbarIntent(),
-              SingleActivator(
-                LogicalKeyboardKey.keyZ,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const UndoTextIntent(SelectionChangedCause.keyboard),
-              SingleActivator(
-                LogicalKeyboardKey.keyY,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const RedoTextIntent(SelectionChangedCause.keyboard),
-
-              // Selection formatting.
-              SingleActivator(
-                LogicalKeyboardKey.keyB,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const ToggleTextStyleIntent(Attribute.bold),
-              SingleActivator(
-                LogicalKeyboardKey.keyU,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const ToggleTextStyleIntent(Attribute.underline),
-              SingleActivator(
-                LogicalKeyboardKey.keyI,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const ToggleTextStyleIntent(Attribute.italic),
-              SingleActivator(
-                LogicalKeyboardKey.keyS,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-                shift: true,
-              ): const ToggleTextStyleIntent(Attribute.strikeThrough),
-              SingleActivator(
-                LogicalKeyboardKey.backquote,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const ToggleTextStyleIntent(Attribute.inlineCode),
-              SingleActivator(
-                LogicalKeyboardKey.tilde,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-                shift: true,
-              ): const ToggleTextStyleIntent(Attribute.codeBlock),
-              SingleActivator(
-                LogicalKeyboardKey.keyB,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-                shift: true,
-              ): const ToggleTextStyleIntent(Attribute.blockQuote),
-              SingleActivator(
-                LogicalKeyboardKey.keyK,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const QuillEditorApplyLinkIntent(),
-
-              // Lists
-              SingleActivator(
-                LogicalKeyboardKey.keyL,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-                shift: true,
-              ): const ToggleTextStyleIntent(Attribute.ul),
-              SingleActivator(
-                LogicalKeyboardKey.keyO,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-                shift: true,
-              ): const ToggleTextStyleIntent(Attribute.ol),
-              SingleActivator(
-                LogicalKeyboardKey.keyC,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-                shift: true,
-              ): const QuillEditorApplyCheckListIntent(),
-
-              // Indents
-              SingleActivator(
-                LogicalKeyboardKey.keyM,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const IndentSelectionIntent(true),
-              SingleActivator(
-                LogicalKeyboardKey.keyM,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-                shift: true,
-              ): const IndentSelectionIntent(false),
-
-              // Headers
-              SingleActivator(
-                LogicalKeyboardKey.digit1,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const QuillEditorApplyHeaderIntent(Attribute.h1),
-              SingleActivator(
-                LogicalKeyboardKey.digit2,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const QuillEditorApplyHeaderIntent(Attribute.h2),
-              SingleActivator(
-                LogicalKeyboardKey.digit3,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const QuillEditorApplyHeaderIntent(Attribute.h3),
-              SingleActivator(
-                LogicalKeyboardKey.digit4,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const QuillEditorApplyHeaderIntent(Attribute.h4),
-              SingleActivator(
-                LogicalKeyboardKey.digit5,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const QuillEditorApplyHeaderIntent(Attribute.h5),
-              SingleActivator(
-                LogicalKeyboardKey.digit6,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const QuillEditorApplyHeaderIntent(Attribute.h6),
-              SingleActivator(
-                LogicalKeyboardKey.digit0,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const QuillEditorApplyHeaderIntent(Attribute.header),
-
-              SingleActivator(
-                LogicalKeyboardKey.keyG,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const QuillEditorInsertEmbedIntent(Attribute.image),
-
-              SingleActivator(
-                LogicalKeyboardKey.keyF,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const OpenSearchIntent(),
-
-              // Navigate to the start or end of the document
-              SingleActivator(
-                LogicalKeyboardKey.home,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const ScrollToDocumentBoundaryIntent(forward: false),
-              SingleActivator(
-                LogicalKeyboardKey.end,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const ScrollToDocumentBoundaryIntent(forward: true),
-
-              //  Arrow key scrolling
-              SingleActivator(
-                LogicalKeyboardKey.arrowUp,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const ScrollIntent(direction: AxisDirection.up),
-              SingleActivator(
-                LogicalKeyboardKey.arrowDown,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const ScrollIntent(direction: AxisDirection.down),
-              SingleActivator(
-                LogicalKeyboardKey.pageUp,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const ScrollIntent(
-                  direction: AxisDirection.up, type: ScrollIncrementType.page),
-              SingleActivator(
-                LogicalKeyboardKey.pageDown,
-                control: !isDesktopMacOS,
-                meta: isDesktopMacOS,
-              ): const ScrollIntent(
-                  direction: AxisDirection.down,
-                  type: ScrollIncrementType.page),
-            },
-          ),
-          child: Actions(
-            actions: mergeMaps<Type, Action<Intent>>(_actions, {
-              ...?widget.configurations.customActions,
-            }),
-            child: Focus(
-              focusNode: widget.configurations.focusNode,
-              onKeyEvent: _onKeyEvent,
-              child: QuillKeyboardListener(
-                child: Container(
-                  constraints: constraints,
-                  child: child,
-                ),
-              ),
-            ),
-          ),
+        child: QuillKeyboardServiceWidget(
+          actions: _actions,
+          constraints: constraints,
+          focusNode: widget.configurations.focusNode,
+          controller: controller,
+          readOnly: widget.configurations.readOnly,
+          enableAlwaysIndentOnTab:
+              widget.configurations.enableAlwaysIndentOnTab,
+          enableMdConversion:
+              widget.configurations.enableMarkdownStyleConversion,
+          customShortcuts: widget.configurations.customShortcuts,
+          customActions: widget.configurations.customActions,
+          child: child,
         ),
       ),
     );
-  }
-
-  KeyEventResult _onKeyEvent(node, KeyEvent event) {
-    // Don't handle key if there is a meta key pressed.
-    if (HardwareKeyboard.instance.isAltPressed ||
-        HardwareKeyboard.instance.isControlPressed ||
-        HardwareKeyboard.instance.isMetaPressed) {
-      return KeyEventResult.ignored;
-    }
-
-    if (event is! KeyDownEvent) {
-      return KeyEventResult.ignored;
-    }
-    // Handle indenting blocks when pressing the tab key.
-    if (event.logicalKey == LogicalKeyboardKey.tab) {
-      return _handleTabKey(event);
-    }
-
-    // Don't handle key if there is an active selection.
-    if (controller.selection.baseOffset != controller.selection.extentOffset) {
-      return KeyEventResult.ignored;
-    }
-
-    // Handle inserting lists when space is pressed following
-    // a list initiating phrase.
-    if (event.logicalKey == LogicalKeyboardKey.space) {
-      return _handleSpaceKey(event);
-    }
-
-    return KeyEventResult.ignored;
-  }
-
-  KeyEventResult _handleSpaceKey(KeyEvent event) {
-    final child =
-        controller.document.queryChild(controller.selection.baseOffset);
-    if (child.node == null) {
-      return KeyEventResult.ignored;
-    }
-
-    final line = child.node as Line?;
-    if (line == null) {
-      return KeyEventResult.ignored;
-    }
-
-    final text = castOrNull<leaf.QuillText>(line.first);
-    if (text == null) {
-      return KeyEventResult.ignored;
-    }
-
-    const olKeyPhrase = '1.';
-    const ulKeyPhrase = '-';
-    final enableMdConversion =
-        widget.configurations.enableMarkdownStyleConversion;
-
-    if (text.value == olKeyPhrase && enableMdConversion) {
-      _updateSelectionForKeyPhrase(olKeyPhrase, Attribute.ol);
-    } else if (text.value == ulKeyPhrase && enableMdConversion) {
-      _updateSelectionForKeyPhrase(ulKeyPhrase, Attribute.ul);
-    } else {
-      return KeyEventResult.ignored;
-    }
-
-    return KeyEventResult.handled;
-  }
-
-  KeyEventResult _handleTabKey(KeyEvent event) {
-    final child =
-        controller.document.queryChild(controller.selection.baseOffset);
-
-    KeyEventResult insertTabCharacter() {
-      if (widget.configurations.readOnly) {
-        return KeyEventResult.ignored;
-      }
-      if (widget.configurations.enableAlwaysIndentOnTab) {
-        controller.indentSelection(!HardwareKeyboard.instance.isShiftPressed);
-      } else {
-        controller.replaceText(controller.selection.baseOffset, 0, '\t', null);
-        _moveCursor(1);
-      }
-      return KeyEventResult.handled;
-    }
-
-    if (controller.selection.baseOffset != controller.selection.extentOffset) {
-      if (child.node == null || child.node!.parent == null) {
-        return KeyEventResult.handled;
-      }
-      final parentBlock = child.node!.parent!;
-      if (parentBlock.style.containsKey(Attribute.ol.key) ||
-          parentBlock.style.containsKey(Attribute.ul.key) ||
-          parentBlock.style.containsKey(Attribute.checked.key)) {
-        controller.indentSelection(!HardwareKeyboard.instance.isShiftPressed);
-      }
-      return KeyEventResult.handled;
-    }
-
-    if (child.node == null) {
-      return insertTabCharacter();
-    }
-
-    final node = child.node!;
-
-    final parent = node.parent;
-    if (parent == null || parent is! Block) {
-      return insertTabCharacter();
-    }
-
-    if (node is! Line || (node.isNotEmpty && node.first is! leaf.QuillText)) {
-      return insertTabCharacter();
-    }
-
-    final parentBlock = parent;
-    if (parentBlock.style.containsKey(Attribute.ol.key) ||
-        parentBlock.style.containsKey(Attribute.ul.key) ||
-        parentBlock.style.containsKey(Attribute.checked.key)) {
-      if (node.isNotEmpty &&
-          (node.first as leaf.QuillText).value.isNotEmpty &&
-          controller.selection.base.offset > node.documentOffset) {
-        return insertTabCharacter();
-      }
-      controller.indentSelection(!HardwareKeyboard.instance.isShiftPressed);
-      return KeyEventResult.handled;
-    }
-
-    if (node.isNotEmpty && (node.first as leaf.QuillText).value.isNotEmpty) {
-      return insertTabCharacter();
-    }
-
-    return insertTabCharacter();
-  }
-
-  void _moveCursor(int chars) {
-    final selection = controller.selection;
-    controller.updateSelection(
-        controller.selection.copyWith(
-            baseOffset: selection.baseOffset + chars,
-            extentOffset: selection.baseOffset + chars),
-        ChangeSource.local);
-  }
-
-  void _updateSelectionForKeyPhrase(String phrase, Attribute attribute) {
-    controller.replaceText(controller.selection.baseOffset - phrase.length,
-        phrase.length, '\n', null);
-    _moveCursor(-phrase.length);
-    controller
-      ..formatSelection(attribute)
-      // Remove the added newline.
-      ..replaceText(controller.selection.baseOffset + 1, 1, '', null);
-    //
-    final style =
-        controller.document.collectStyle(controller.selection.baseOffset, 0);
-    if (style.isNotEmpty) {
-      for (final attr in style.values) {
-        controller.formatSelection(attr);
-      }
-      controller.formatSelection(attribute);
-    }
   }
 
   void _handleSelectionChanged(

--- a/lib/src/editor/widgets/default_single_activator_actions.dart
+++ b/lib/src/editor/widgets/default_single_activator_actions.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/material.dart'
+    show
+        AxisDirection,
+        Intent,
+        RedoTextIntent,
+        ScrollIncrementType,
+        ScrollIntent,
+        ScrollToDocumentBoundaryIntent,
+        SelectionChangedCause,
+        SingleActivator,
+        UndoTextIntent;
+import 'package:flutter/services.dart'
+    show LogicalKeyboardKey, SelectionChangedCause;
+
+import '../../document/attribute.dart';
+import '../raw_editor/raw_editor_actions.dart'
+    show
+        HideSelectionToolbarIntent,
+        IndentSelectionIntent,
+        OpenSearchIntent,
+        QuillEditorApplyCheckListIntent,
+        QuillEditorApplyHeaderIntent,
+        QuillEditorApplyLinkIntent,
+        QuillEditorInsertEmbedIntent,
+        ToggleTextStyleIntent;
+
+Map<SingleActivator, Intent> defaultSinlgeActivatorActions(
+        bool isDesktopMacOS) =>
+    {
+      const SingleActivator(
+        LogicalKeyboardKey.escape,
+      ): const HideSelectionToolbarIntent(),
+      SingleActivator(
+        LogicalKeyboardKey.keyZ,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const UndoTextIntent(SelectionChangedCause.keyboard),
+      SingleActivator(
+        LogicalKeyboardKey.keyY,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const RedoTextIntent(SelectionChangedCause.keyboard),
+
+      // Selection formatting.
+      SingleActivator(
+        LogicalKeyboardKey.keyB,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const ToggleTextStyleIntent(Attribute.bold),
+      SingleActivator(
+        LogicalKeyboardKey.keyU,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const ToggleTextStyleIntent(Attribute.underline),
+      SingleActivator(
+        LogicalKeyboardKey.keyI,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const ToggleTextStyleIntent(Attribute.italic),
+      SingleActivator(
+        LogicalKeyboardKey.keyS,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+        shift: true,
+      ): const ToggleTextStyleIntent(Attribute.strikeThrough),
+      SingleActivator(
+        LogicalKeyboardKey.backquote,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const ToggleTextStyleIntent(Attribute.inlineCode),
+      SingleActivator(
+        LogicalKeyboardKey.tilde,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+        shift: true,
+      ): const ToggleTextStyleIntent(Attribute.codeBlock),
+      SingleActivator(
+        LogicalKeyboardKey.keyB,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+        shift: true,
+      ): const ToggleTextStyleIntent(Attribute.blockQuote),
+      SingleActivator(
+        LogicalKeyboardKey.keyK,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const QuillEditorApplyLinkIntent(),
+
+      // Lists
+      SingleActivator(
+        LogicalKeyboardKey.keyL,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+        shift: true,
+      ): const ToggleTextStyleIntent(Attribute.ul),
+      SingleActivator(
+        LogicalKeyboardKey.keyO,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+        shift: true,
+      ): const ToggleTextStyleIntent(Attribute.ol),
+      SingleActivator(
+        LogicalKeyboardKey.keyC,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+        shift: true,
+      ): const QuillEditorApplyCheckListIntent(),
+
+      // Indents
+      SingleActivator(
+        LogicalKeyboardKey.keyM,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const IndentSelectionIntent(true),
+      SingleActivator(
+        LogicalKeyboardKey.keyM,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+        shift: true,
+      ): const IndentSelectionIntent(false),
+
+      // Headers
+      SingleActivator(
+        LogicalKeyboardKey.digit1,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const QuillEditorApplyHeaderIntent(Attribute.h1),
+      SingleActivator(
+        LogicalKeyboardKey.digit2,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const QuillEditorApplyHeaderIntent(Attribute.h2),
+      SingleActivator(
+        LogicalKeyboardKey.digit3,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const QuillEditorApplyHeaderIntent(Attribute.h3),
+      SingleActivator(
+        LogicalKeyboardKey.digit4,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const QuillEditorApplyHeaderIntent(Attribute.h4),
+      SingleActivator(
+        LogicalKeyboardKey.digit5,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const QuillEditorApplyHeaderIntent(Attribute.h5),
+      SingleActivator(
+        LogicalKeyboardKey.digit6,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const QuillEditorApplyHeaderIntent(Attribute.h6),
+      SingleActivator(
+        LogicalKeyboardKey.digit0,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const QuillEditorApplyHeaderIntent(Attribute.header),
+
+      SingleActivator(
+        LogicalKeyboardKey.keyG,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const QuillEditorInsertEmbedIntent(Attribute.image),
+
+      SingleActivator(
+        LogicalKeyboardKey.keyF,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const OpenSearchIntent(),
+
+      // Navigate to the start or end of the document
+      SingleActivator(
+        LogicalKeyboardKey.home,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const ScrollToDocumentBoundaryIntent(forward: false),
+      SingleActivator(
+        LogicalKeyboardKey.end,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const ScrollToDocumentBoundaryIntent(forward: true),
+
+      //  Arrow key scrolling
+      SingleActivator(
+        LogicalKeyboardKey.arrowUp,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const ScrollIntent(direction: AxisDirection.up),
+      SingleActivator(
+        LogicalKeyboardKey.arrowDown,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const ScrollIntent(direction: AxisDirection.down),
+      SingleActivator(
+        LogicalKeyboardKey.pageUp,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const ScrollIntent(
+          direction: AxisDirection.up, type: ScrollIncrementType.page),
+      SingleActivator(
+        LogicalKeyboardKey.pageDown,
+        control: !isDesktopMacOS,
+        meta: isDesktopMacOS,
+      ): const ScrollIntent(
+          direction: AxisDirection.down, type: ScrollIncrementType.page),
+    };

--- a/lib/src/editor/widgets/keyboard_service_widget.dart
+++ b/lib/src/editor/widgets/keyboard_service_widget.dart
@@ -1,0 +1,222 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../common/utils/cast.dart';
+import '../../common/utils/platform.dart';
+import '../../controller/quill_controller.dart';
+import '../../document/attribute.dart';
+import '../../document/document.dart';
+import '../../document/nodes/block.dart';
+import '../../document/nodes/leaf.dart' as leaf;
+import '../../document/nodes/line.dart';
+import 'default_single_activator_actions.dart';
+import 'keyboard_listener.dart';
+
+class QuillKeyboardServiceWidget extends StatelessWidget {
+  const QuillKeyboardServiceWidget({
+    required this.actions,
+    required this.constraints,
+    required this.focusNode,
+    required this.child,
+    required this.controller,
+    required this.readOnly,
+    required this.enableAlwaysIndentOnTab,
+    required this.enableMdConversion,
+    this.customShortcuts,
+    this.customActions,
+    super.key,
+  });
+
+  final bool readOnly;
+  final bool enableAlwaysIndentOnTab;
+  final bool enableMdConversion;
+  final QuillController controller;
+  final Map<ShortcutActivator, Intent>? customShortcuts;
+  final Map<Type, Action<Intent>>? customActions;
+  final Map<Type, Action<Intent>> actions;
+  final BoxConstraints constraints;
+  final FocusNode focusNode;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDesktopMacOS = isMacOS;
+    return Shortcuts(
+      /// Merge with widget.configurations.customShortcuts
+      /// first to allow user's defined shortcuts to take
+      /// priority when activation triggers are the same
+      shortcuts: mergeMaps<ShortcutActivator, Intent>({...?customShortcuts},
+          {...defaultSinlgeActivatorActions(isDesktopMacOS)}),
+      child: Actions(
+        actions: mergeMaps<Type, Action<Intent>>(actions, {
+          ...?customActions,
+        }),
+        child: Focus(
+          focusNode: focusNode,
+          onKeyEvent: _onKeyEvent,
+          child: QuillKeyboardListener(
+            child: Container(
+              constraints: constraints,
+              child: child,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  KeyEventResult _onKeyEvent(node, KeyEvent event) {
+    // Don't handle key if there is a meta key pressed.
+    if (HardwareKeyboard.instance.isAltPressed ||
+        HardwareKeyboard.instance.isControlPressed ||
+        HardwareKeyboard.instance.isMetaPressed) {
+      return KeyEventResult.ignored;
+    }
+
+    if (event is! KeyDownEvent) {
+      return KeyEventResult.ignored;
+    }
+    // Handle indenting blocks when pressing the tab key.
+    if (event.logicalKey == LogicalKeyboardKey.tab) {
+      return _handleTabKey(event);
+    }
+
+    // Don't handle key if there is an active selection.
+    if (controller.selection.baseOffset != controller.selection.extentOffset) {
+      return KeyEventResult.ignored;
+    }
+
+    // Handle inserting lists when space is pressed following
+    // a list initiating phrase.
+    if (event.logicalKey == LogicalKeyboardKey.space) {
+      return _handleSpaceKey(event);
+    }
+
+    return KeyEventResult.ignored;
+  }
+
+  KeyEventResult _handleSpaceKey(KeyEvent event) {
+    final child =
+        controller.document.queryChild(controller.selection.baseOffset);
+    if (child.node == null) {
+      return KeyEventResult.ignored;
+    }
+
+    final line = child.node as Line?;
+    if (line == null) {
+      return KeyEventResult.ignored;
+    }
+
+    final text = castOrNull<leaf.QuillText>(line.first);
+    if (text == null) {
+      return KeyEventResult.ignored;
+    }
+
+    const olKeyPhrase = '1.';
+    const ulKeyPhrase = '-';
+
+    if (text.value == olKeyPhrase && enableMdConversion) {
+      _updateSelectionForKeyPhrase(olKeyPhrase, Attribute.ol);
+    } else if (text.value == ulKeyPhrase && enableMdConversion) {
+      _updateSelectionForKeyPhrase(ulKeyPhrase, Attribute.ul);
+    } else {
+      return KeyEventResult.ignored;
+    }
+
+    return KeyEventResult.handled;
+  }
+
+  KeyEventResult _handleTabKey(KeyEvent event) {
+    final child =
+        controller.document.queryChild(controller.selection.baseOffset);
+
+    KeyEventResult insertTabCharacter() {
+      if (readOnly) {
+        return KeyEventResult.ignored;
+      }
+      if (enableAlwaysIndentOnTab) {
+        controller.indentSelection(!HardwareKeyboard.instance.isShiftPressed);
+      } else {
+        controller.replaceText(controller.selection.baseOffset, 0, '\t', null);
+        _moveCursor(1);
+      }
+      return KeyEventResult.handled;
+    }
+
+    if (controller.selection.baseOffset != controller.selection.extentOffset) {
+      if (child.node == null || child.node!.parent == null) {
+        return KeyEventResult.handled;
+      }
+      final parentBlock = child.node!.parent!;
+      if (parentBlock.style.containsKey(Attribute.ol.key) ||
+          parentBlock.style.containsKey(Attribute.ul.key) ||
+          parentBlock.style.containsKey(Attribute.checked.key)) {
+        controller.indentSelection(!HardwareKeyboard.instance.isShiftPressed);
+      }
+      return KeyEventResult.handled;
+    }
+
+    if (child.node == null) {
+      return insertTabCharacter();
+    }
+
+    final node = child.node!;
+
+    final parent = node.parent;
+    if (parent == null || parent is! Block) {
+      return insertTabCharacter();
+    }
+
+    if (node is! Line || (node.isNotEmpty && node.first is! leaf.QuillText)) {
+      return insertTabCharacter();
+    }
+
+    final parentBlock = parent;
+    if (parentBlock.style.containsKey(Attribute.ol.key) ||
+        parentBlock.style.containsKey(Attribute.ul.key) ||
+        parentBlock.style.containsKey(Attribute.checked.key)) {
+      if (node.isNotEmpty &&
+          (node.first as leaf.QuillText).value.isNotEmpty &&
+          controller.selection.base.offset > node.documentOffset) {
+        return insertTabCharacter();
+      }
+      controller.indentSelection(!HardwareKeyboard.instance.isShiftPressed);
+      return KeyEventResult.handled;
+    }
+
+    if (node.isNotEmpty && (node.first as leaf.QuillText).value.isNotEmpty) {
+      return insertTabCharacter();
+    }
+
+    return insertTabCharacter();
+  }
+
+  void _moveCursor(int chars) {
+    final selection = controller.selection;
+    controller.updateSelection(
+        controller.selection.copyWith(
+            baseOffset: selection.baseOffset + chars,
+            extentOffset: selection.baseOffset + chars),
+        ChangeSource.local);
+  }
+
+  void _updateSelectionForKeyPhrase(String phrase, Attribute attribute) {
+    controller.replaceText(controller.selection.baseOffset - phrase.length,
+        phrase.length, '\n', null);
+    _moveCursor(-phrase.length);
+    controller
+      ..formatSelection(attribute)
+      // Remove the added newline.
+      ..replaceText(controller.selection.baseOffset + 1, 1, '', null);
+    //
+    final style =
+        controller.document.collectStyle(controller.selection.baseOffset, 0);
+    if (style.isNotEmpty) {
+      for (final attr in style.values) {
+        controller.formatSelection(attr);
+      }
+      controller.formatSelection(attribute);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Moved `Shortcut` widget and `Focus` widget that listened for keyboard events to their own file in order to reduce the size of `raw_editor_state` and to separate the logic and make it easier to read.

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [x] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [x] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.