### PR TITLE
fix: properties other than 'style' for custom inline code styles (such as 'backgroundColor') were not being applied correctly

### DIFF
--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -719,7 +719,8 @@ class QuillRawEditorState extends EditorState
         widget.configurations.enableInteractiveSelection,
         _hasFocus,
         MediaQuery.devicePixelRatioOf(context),
-        _cursorCont);
+        _cursorCont,
+        _styles!.inlineCode!);
     return editableTextLine;
   }
 

--- a/lib/src/editor/widgets/text/text_block.dart
+++ b/lib/src/editor/widgets/text/text_block.dart
@@ -203,6 +203,7 @@ class EditableTextBlock extends StatelessWidget {
         hasFocus,
         MediaQuery.devicePixelRatioOf(context),
         cursorCont,
+        styles!.inlineCode!,
       );
       final nodeTextDirection = getDirectionOfNode(line, textDirection);
       children.add(

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -642,6 +642,7 @@ class EditableTextLine extends RenderObjectWidget {
       this.hasFocus,
       this.devicePixelRatio,
       this.cursorCont,
+      this.inlineCodeStyle,
       {super.key});
 
   final Line line;
@@ -656,6 +657,7 @@ class EditableTextLine extends RenderObjectWidget {
   final bool hasFocus;
   final double devicePixelRatio;
   final CursorCont cursorCont;
+  final InlineCodeStyle inlineCodeStyle;
 
   @override
   RenderObjectElement createElement() {
@@ -664,7 +666,6 @@ class EditableTextLine extends RenderObjectWidget {
 
   @override
   RenderObject createRenderObject(BuildContext context) {
-    final defaultStyles = DefaultStyles.getInstance(context);
     return RenderEditableTextLine(
         line,
         textDirection,
@@ -675,13 +676,12 @@ class EditableTextLine extends RenderObjectWidget {
         _getPadding(),
         color,
         cursorCont,
-        defaultStyles.inlineCode!);
+        inlineCodeStyle);
   }
 
   @override
   void updateRenderObject(
       BuildContext context, covariant RenderEditableTextLine renderObject) {
-    final defaultStyles = DefaultStyles.getInstance(context);
     renderObject
       ..setLine(line)
       ..setPadding(_getPadding())
@@ -692,7 +692,7 @@ class EditableTextLine extends RenderObjectWidget {
       ..hasFocus = hasFocus
       ..setDevicePixelRatio(devicePixelRatio)
       ..setCursorCont(cursorCont)
-      ..setInlineCodeStyle(defaultStyles.inlineCode!);
+      ..setInlineCodeStyle(inlineCodeStyle);
   }
 
   EdgeInsetsGeometry _getPadding() {


### PR DESCRIPTION
## Description

I encountered a known issue, so I fixed the bug. The problem occurred because the InlineCodeStyle set in the custom style was not passed through to the final rendering stage and was being replaced by the InlineCodeStyle from DefaultStyles along the way.

I have updated the code to ensure that the InlineCodeStyle set in the custom style is used in the final rendering.

## Related Issues

- *Fix #1409*
- *Fix #1014*

## Type of Change

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions
