### PR TITLE
Fix: Resolved issue with broken IME composing rect in Windows desktop

### DIFF
--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -97,9 +97,19 @@ mixin RawEditorStateTextInputClientMixin on EditorState
     _textInputConnection!.show();
   }
 
+  TextRange _getComposingRange() {
+    if (_lastKnownRemoteTextEditingValue != null &&
+        _lastKnownRemoteTextEditingValue?.composing.isValid == true) {
+      return _lastKnownRemoteTextEditingValue!.composing;
+    } else if (textEditingValue.composing.isValid == true) {
+      return textEditingValue.composing;
+    } else {
+      return widget.controller.selection;
+    }
+  }
+
   void _updateComposingRectIfNeeded() {
-    final composingRange = _lastKnownRemoteTextEditingValue?.composing ??
-        textEditingValue.composing;
+    final composingRange = _getComposingRange();
     if (hasConnection) {
       assert(mounted);
       final offset = composingRange.isValid ? composingRange.start : 0;


### PR DESCRIPTION
## Description

When using the Japanese IME in the Windows desktop app, the composing region often appears at the beginning of the document instead of at the selection position, which leads to a poor user experience. The issue was caused by assigning a fixed position of 0 when the position calculated from the conversion information was invalid. This issue can be resolved by using the current selection position as the offset instead of fixing it to 0. Additionally, the function to calculate the ComposingRange has been refactored into a separate function.

Before:
https://github.com/user-attachments/assets/3afd158f-73f1-45ba-b56e-56ff4c9b965a

After:
https://github.com/user-attachments/assets/e9246da5-6ed0-416d-b358-36bc83f74c62

## Related Issues

## Type of Change

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions

