### PR TITLE
fix: the composing text did not show an underline during IME conversion

### DIFF
--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -674,6 +674,7 @@ class QuillRawEditorState extends EditorState
               widget.configurations.customRecognizerBuilder,
           customStyleBuilder: widget.configurations.customStyleBuilder,
           customLinkPrefixes: widget.configurations.customLinkPrefixes,
+          composingRange: composingRange.value,
         );
         result.add(
           Directionality(
@@ -720,7 +721,9 @@ class QuillRawEditorState extends EditorState
         _hasFocus,
         MediaQuery.devicePixelRatioOf(context),
         _cursorCont,
-        _styles!.inlineCode!);
+        _styles!.inlineCode!,
+        composingRange.value,
+        _styles!.paragraph!.style.color!);
     return editableTextLine;
   }
 
@@ -849,6 +852,9 @@ class QuillRawEditorState extends EditorState
     // Floating cursor
     _floatingCursorResetController = AnimationController(vsync: this);
     _floatingCursorResetController.addListener(onFloatingCursorResetTick);
+
+    // listen to composing range changes
+    composingRange.addListener(_onComposingRangeChanged);
 
     if (isKeyboardOS) {
       _keyboardVisible = true;
@@ -987,6 +993,7 @@ class QuillRawEditorState extends EditorState
     controller.removeListener(_didChangeTextEditingValueListener);
     widget.configurations.focusNode.removeListener(_handleFocusChanged);
     _cursorCont.dispose();
+    composingRange.removeListener(_onComposingRangeChanged);
     if (_clipboardStatus != null) {
       _clipboardStatus!
         ..removeListener(_onChangedClipboardStatus)
@@ -997,6 +1004,13 @@ class QuillRawEditorState extends EditorState
 
   void _updateSelectionOverlayForScroll() {
     _selectionOverlay?.updateForScroll();
+  }
+
+  void _onComposingRangeChanged() {
+    if (!mounted) {
+      return;
+    }
+    _markNeedsBuild();
   }
 
   /// Marks the editor as dirty and trigger a rebuild.

--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -2,7 +2,7 @@ import 'dart:ui' show lerpDouble;
 
 import 'package:flutter/animation.dart' show Curves;
 import 'package:flutter/cupertino.dart' show CupertinoTheme;
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show ValueNotifier, kIsWeb;
 import 'package:flutter/material.dart' show Theme;
 import 'package:flutter/scheduler.dart' show SchedulerBinding;
 import 'package:flutter/services.dart';
@@ -15,7 +15,22 @@ import 'raw_editor.dart';
 mixin RawEditorStateTextInputClientMixin on EditorState
     implements TextInputClient {
   TextInputConnection? _textInputConnection;
-  TextEditingValue? _lastKnownRemoteTextEditingValue;
+  TextEditingValue? __lastKnownRemoteTextEditingValue;
+
+  set _lastKnownRemoteTextEditingValue(TextEditingValue? value) {
+    __lastKnownRemoteTextEditingValue = value;
+    if (composingRange.value != value?.composing) {
+      composingRange.value = value?.composing ?? TextRange.empty;
+    }
+  }
+
+  TextEditingValue? get _lastKnownRemoteTextEditingValue =>
+      __lastKnownRemoteTextEditingValue;
+
+  /// The range of text that is currently being composed.
+  final ValueNotifier<TextRange> composingRange = ValueNotifier<TextRange>(
+    TextRange.empty,
+  );
 
   /// Whether to create an input connection with the platform for text editing
   /// or not.

--- a/lib/src/editor/widgets/text/text_block.dart
+++ b/lib/src/editor/widgets/text/text_block.dart
@@ -78,6 +78,7 @@ class EditableTextBlock extends StatelessWidget {
     required this.onCheckboxTap,
     required this.readOnly,
     required this.customRecognizerBuilder,
+    required this.composingRange,
     this.checkBoxReadOnly,
     this.onLaunchUrl,
     this.customStyleBuilder,
@@ -111,6 +112,7 @@ class EditableTextBlock extends StatelessWidget {
   final bool readOnly;
   final bool? checkBoxReadOnly;
   final List<String> customLinkPrefixes;
+  final TextRange composingRange;
 
   @override
   Widget build(BuildContext context) {
@@ -204,6 +206,8 @@ class EditableTextBlock extends StatelessWidget {
         MediaQuery.devicePixelRatioOf(context),
         cursorCont,
         styles!.inlineCode!,
+        composingRange,
+        styles!.paragraph!.style.color!,
       );
       final nodeTextDirection = getDirectionOfNode(line, textDirection);
       children.add(


### PR DESCRIPTION
## Description

Flutter Quill did not previously reflect the composing range during IME conversion in the UI. I have now added an underline beneath the text being composed based on changes to the composing range from the IME. This aligns the behavior with Flutter's TextFormField.

Users who rely on IME will now have visual feedback for the currently composing text, improving the user experience. (For IME users, the lack of this support previously resulted in a significantly poor user experience, as it’s crucial for them.)

I have tested this with the Japanese IME on iOS, macOS, and Windows. I haven’t tested it with other languages, but I believe it should work fine. If anyone is using an IME for other languages, I would appreciate your feedback.

Before:

https://github.com/user-attachments/assets/deb0daec-5d04-4f19-b9bb-0b99890905cb

After: 

https://github.com/user-attachments/assets/d01f9f5c-03bb-4841-a055-fd65ba71ac6e

## Related Issues

- *Fix #2179*

## Type of Change

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions
