### PR TITLE
Refine IME composing range styling by applying underline as text style

### DIFF
--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -707,6 +707,7 @@ class QuillRawEditorState extends EditorState
       linkActionPicker: _linkActionPicker,
       onLaunchUrl: widget.configurations.onLaunchUrl,
       customLinkPrefixes: widget.configurations.customLinkPrefixes,
+      composingRange: composingRange.value,
     );
     final editableTextLine = EditableTextLine(
         node,
@@ -721,9 +722,7 @@ class QuillRawEditorState extends EditorState
         _hasFocus,
         MediaQuery.devicePixelRatioOf(context),
         _cursorCont,
-        _styles!.inlineCode!,
-        composingRange.value,
-        _styles!.paragraph!.style.color!);
+        _styles!.inlineCode!);
     return editableTextLine;
   }
 

--- a/lib/src/editor/widgets/text/text_block.dart
+++ b/lib/src/editor/widgets/text/text_block.dart
@@ -195,6 +195,7 @@ class EditableTextBlock extends StatelessWidget {
           onLaunchUrl: onLaunchUrl,
           customLinkPrefixes: customLinkPrefixes,
           customRecognizerBuilder: customRecognizerBuilder,
+          composingRange: composingRange,
         ),
         indentWidthBuilder(block, context, count, numberPointWidthBuilder),
         _getSpacingForLine(line, index, count, defaultStyles),
@@ -206,8 +207,6 @@ class EditableTextBlock extends StatelessWidget {
         MediaQuery.devicePixelRatioOf(context),
         cursorCont,
         styles!.inlineCode!,
-        composingRange,
-        styles!.paragraph!.style.color!,
       );
       final nodeTextDirection = getDirectionOfNode(line, textDirection);
       children.add(

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -31,6 +31,7 @@ class TextLine extends StatefulWidget {
     required this.controller,
     required this.onLaunchUrl,
     required this.linkActionPicker,
+    required this.composingRange,
     this.textDirection,
     this.customStyleBuilder,
     this.customRecognizerBuilder,
@@ -49,6 +50,7 @@ class TextLine extends StatefulWidget {
   final ValueChanged<String>? onLaunchUrl;
   final LinkActionPicker linkActionPicker;
   final List<String> customLinkPrefixes;
+  final TextRange composingRange;
 
   @override
   State<TextLine> createState() => _TextLineState();
@@ -267,12 +269,68 @@ class _TextLineState extends State<TextLine> {
     if (nodes.isEmpty && kIsWeb) {
       nodes = LinkedList<Node>()..add(leaf.QuillText('\u{200B}'));
     }
-    final children = nodes
-        .map((node) =>
-            _getTextSpanFromNode(defaultStyles, node, widget.line.style))
-        .toList(growable: false);
+
+    final isComposingRangeOutOfLine = !widget.composingRange.isValid ||
+        widget.composingRange.isCollapsed ||
+        (widget.composingRange.start < widget.line.documentOffset ||
+            widget.composingRange.end >
+                widget.line.documentOffset + widget.line.length);
+
+    if (isComposingRangeOutOfLine) {
+      final children = nodes
+          .map((node) =>
+              _getTextSpanFromNode(defaultStyles, node, widget.line.style))
+          .toList(growable: false);
+      return TextSpan(children: children, style: lineStyle);
+    }
+
+    final children = nodes.expand((node) {
+      final child =
+          _getTextSpanFromNode(defaultStyles, node, widget.line.style);
+      final isNodeInComposingRange =
+          node.documentOffset <= widget.composingRange.start &&
+              widget.composingRange.end <= node.documentOffset + node.length;
+      if (isNodeInComposingRange) {
+        return _splitAndApplyComposingStyle(node, child);
+      } else {
+        return [child];
+      }
+    }).toList(growable: false);
 
     return TextSpan(children: children, style: lineStyle);
+  }
+
+  // split the text nodes into composing and non-composing nodes
+  // and apply the composing style to the composing nodes
+  List<InlineSpan> _splitAndApplyComposingStyle(Node node, InlineSpan child) {
+    assert(widget.composingRange.isValid && !widget.composingRange.isCollapsed);
+
+    final composingStart = widget.composingRange.start - node.documentOffset;
+    final composingEnd = widget.composingRange.end - node.documentOffset;
+    final text = child.toPlainText();
+
+    final textBefore = text.substring(0, composingStart);
+    final textComposing = text.substring(composingStart, composingEnd);
+    final textAfter = text.substring(composingEnd);
+
+    final composingStyle = child.style
+            ?.merge(const TextStyle(decoration: TextDecoration.underline)) ??
+        const TextStyle(decoration: TextDecoration.underline);
+
+    return [
+      TextSpan(
+        text: textBefore,
+        style: child.style,
+      ),
+      TextSpan(
+        text: textComposing,
+        style: composingStyle,
+      ),
+      TextSpan(
+        text: textAfter,
+        style: child.style,
+      ),
+    ];
   }
 
   TextStyle _getLineStyle(DefaultStyles defaultStyles) {
@@ -643,8 +701,6 @@ class EditableTextLine extends RenderObjectWidget {
       this.devicePixelRatio,
       this.cursorCont,
       this.inlineCodeStyle,
-      this.composingRange,
-      this.composingColor,
       {super.key});
 
   final Line line;
@@ -660,8 +716,6 @@ class EditableTextLine extends RenderObjectWidget {
   final double devicePixelRatio;
   final CursorCont cursorCont;
   final InlineCodeStyle inlineCodeStyle;
-  final TextRange composingRange;
-  final Color composingColor;
 
   @override
   RenderObjectElement createElement() {
@@ -680,9 +734,7 @@ class EditableTextLine extends RenderObjectWidget {
         _getPadding(),
         color,
         cursorCont,
-        inlineCodeStyle,
-        composingRange,
-        composingColor);
+        inlineCodeStyle);
   }
 
   @override
@@ -698,8 +750,7 @@ class EditableTextLine extends RenderObjectWidget {
       ..hasFocus = hasFocus
       ..setDevicePixelRatio(devicePixelRatio)
       ..setCursorCont(cursorCont)
-      ..setInlineCodeStyle(inlineCodeStyle)
-      ..setComposingRange(composingRange);
+      ..setInlineCodeStyle(inlineCodeStyle);
   }
 
   EdgeInsetsGeometry _getPadding() {
@@ -726,8 +777,6 @@ class RenderEditableTextLine extends RenderEditableBox {
     this.color,
     this.cursorCont,
     this.inlineCodeStyle,
-    this.composingRange,
-    this.composingColor,
   );
 
   RenderBox? _leading;
@@ -746,8 +795,6 @@ class RenderEditableTextLine extends RenderEditableBox {
   List<TextBox>? _selectedRects;
   late Rect _caretPrototype;
   InlineCodeStyle inlineCodeStyle;
-  TextRange composingRange;
-  Color composingColor;
   final Map<TextLineSlot, RenderBox> children = <TextLineSlot, RenderBox>{};
 
   Iterable<RenderBox> get _children sync* {
@@ -860,12 +907,6 @@ class RenderEditableTextLine extends RenderEditableBox {
   void setInlineCodeStyle(InlineCodeStyle newStyle) {
     if (inlineCodeStyle == newStyle) return;
     inlineCodeStyle = newStyle;
-    markNeedsLayout();
-  }
-
-  void setComposingRange(TextRange newComposingRange) {
-    if (composingRange == newComposingRange) return;
-    composingRange = newComposingRange;
     markNeedsLayout();
   }
 
@@ -1351,11 +1392,6 @@ class RenderEditableTextLine extends RenderEditableBox {
 
         _paintSelection(context, effectiveOffset);
       }
-
-      // Paints an underline to indicate the text being composed by the IME.
-      if (composingRange.isValid) {
-        _paintComposing(context);
-      }
     }
   }
 
@@ -1385,34 +1421,6 @@ class RenderEditableTextLine extends RenderEditableBox {
       position,
       lineHasEmbed,
     );
-  }
-
-  // Paints a line below the composing text.
-  void _paintComposing(PaintingContext context) {
-    assert(composingRange.isValid);
-    final composingStart = composingRange.start - line.documentOffset;
-    final composingEnd = composingRange.end - line.documentOffset;
-    if (composingStart < 0 || composingEnd < 0) {
-      return;
-    }
-    final composingRects = _body!.getBoxesForSelection(
-      TextSelection(
-        baseOffset: composingStart,
-        extentOffset: composingEnd,
-      ),
-    );
-    final paint = Paint()
-      ..color = composingColor
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 1;
-    for (final box in composingRects) {
-      final rect = box.toRect();
-      context.canvas.drawLine(
-        rect.bottomLeft.translate(0, -5),
-        rect.bottomRight.translate(0, -5),
-        paint,
-      );
-    }
   }
 
   @override


### PR DESCRIPTION
## Description

Changed the implementation of the underline styling during IME conversion. Instead of manually drawing a line beneath the composing text, the underline is now applied directly as a text style to the conversion range. This simplifies the implementation and brings it in line with Flutter's standard `TextEditingController` behavior.

`TextEditingController#buildTextSpan` 
https://github.com/flutter/flutter/blob/2277e055508ee6e11ea1313a06ec5b353e76eecc/packages/flutter/lib/src/widgets/editable_text.dart#L285-L309

In the previous implementation, there was an issue where the composing style appeared like a strikethrough, positioned around the middle of the text, especially when the text height was higher than usual, such as with headers. This issue has been completely resolved with the current fix.

before:
![before](https://github.com/user-attachments/assets/0f95373b-14e8-41c5-8b32-a7bd1ea35a08)


after:
![after](https://github.com/user-attachments/assets/a99d73f2-baa3-44db-b6ed-8178084fac2f)



## Related Issues

- *Improve #2179*

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions
