### PR TITLE
chore: move members of magnifier feature into a separate files when possible (not final yet)

### DIFF
--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -34,6 +34,8 @@ import 'widgets/delegate.dart';
 import 'widgets/float_cursor.dart';
 import 'widgets/text/text_selection.dart';
 
+part './magnifier/quill_editor_magnifier_ext.dart';
+
 /// Base interface for editable render objects.
 abstract class RenderAbstractEditor implements TextLayoutMetrics {
   TextSelection selectWordAtPosition(TextPosition position);

--- a/lib/src/editor/magnifier/quill_editor_magnifier_ext.dart
+++ b/lib/src/editor/magnifier/quill_editor_magnifier_ext.dart
@@ -1,0 +1,22 @@
+part of '../editor.dart';
+
+extension QuillEditorSelectionGestureDetectorBuilderMagnifierExt
+    on _QuillEditorSelectionGestureDetectorBuilder {
+  void _showMagnifierIfSupportedByPlatform(Offset positionToShow) {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+      case TargetPlatform.iOS:
+        editor?.showMagnifier(positionToShow);
+      default:
+    }
+  }
+
+  void _hideMagnifierIfSupportedByPlatform() {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+      case TargetPlatform.iOS:
+        editor?.hideMagnifier();
+      default:
+    }
+  }
+}

--- a/lib/src/editor/magnifier/quill_magnifier_controller.dart
+++ b/lib/src/editor/magnifier/quill_magnifier_controller.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
+
+// TODO: See the difference between Flutter MagnifierController and QuillMagnifierController
+//    and document it.
+@internal
+@experimental
+abstract class QuillMagnifierController {
+  void showMagnifier(Offset positionToShow);
+
+  void updateMagnifier(Offset positionToShow);
+
+  void hideMagnifier();
+}

--- a/lib/src/editor/magnifier/quill_raw_editor_state_magnifier_ext.dart
+++ b/lib/src/editor/magnifier/quill_raw_editor_state_magnifier_ext.dart
@@ -1,0 +1,27 @@
+part of '../raw_editor/raw_editor_state.dart';
+
+extension QuillRawEditorStateMagnifierExt on QuillRawEditorState {
+  void _hideMagnifier() {
+    if (_selectionOverlay == null) return;
+    _selectionOverlay?.hideMagnifier();
+  }
+
+  void _showMagnifier(ui.Offset positionToShow) {
+    if (_hasFocus == false) return;
+    if (_selectionOverlay == null) return;
+    final position = renderEditor.getPositionForOffset(positionToShow);
+    if (_selectionOverlay!.magnifierIsVisible) {
+      _selectionOverlay!
+          .updateMagnifier(position, positionToShow, renderEditor);
+    } else {
+      _selectionOverlay!.showMagnifier(position, positionToShow, renderEditor);
+    }
+  }
+
+  void _updateMagnifier(ui.Offset positionToShow) =>
+      showMagnifier(positionToShow);
+
+  TextMagnifierConfiguration get _magnifierConfiguration =>
+      widget.configurations.magnifierConfiguration ??
+      TextMagnifier.adaptiveMagnifierConfiguration;
+}

--- a/lib/src/editor/magnifier/text_selection_magnifier_ext.dart
+++ b/lib/src/editor/magnifier/text_selection_magnifier_ext.dart
@@ -4,7 +4,7 @@ final MagnifierController _magnifierController = MagnifierController();
 
 /// Restore the selection context menu after the magnifier is dismissed.
 /// Fix: https://github.com/singerdmx/flutter-quill/issues/2046
-bool _restoreToolbar = false;
+bool _restoreToolbarAfterMagnifier = false;
 
 extension EditorTextSelectionOverlayMagnifierExt on EditorTextSelectionOverlay {
   // build magnifier info
@@ -44,10 +44,10 @@ extension EditorTextSelectionOverlayMagnifierExt on EditorTextSelectionOverlay {
   void _showMagnifier(MagnifierInfo initialMagnifierInfo) {
     // Hide toolbar
     if (toolbar != null) {
-      _restoreToolbar = true;
+      _restoreToolbarAfterMagnifier = true;
       hideToolbar();
     } else {
-      _restoreToolbar = false;
+      _restoreToolbarAfterMagnifier = false;
     }
 
     // Update magnifier Info
@@ -108,8 +108,8 @@ extension EditorTextSelectionOverlayMagnifierExt on EditorTextSelectionOverlay {
       return;
     }
     _magnifierController.hide();
-    if (_restoreToolbar) {
-      _restoreToolbar = false;
+    if (_restoreToolbarAfterMagnifier) {
+      _restoreToolbarAfterMagnifier = false;
       showToolbar();
     }
   }

--- a/lib/src/editor/magnifier/text_selection_magnifier_ext.dart
+++ b/lib/src/editor/magnifier/text_selection_magnifier_ext.dart
@@ -1,0 +1,116 @@
+part of '../widgets/text/text_selection.dart';
+
+final MagnifierController _magnifierController = MagnifierController();
+
+/// Restore the selection context menu after the magnifier is dismissed.
+/// Fix: https://github.com/singerdmx/flutter-quill/issues/2046
+bool _restoreToolbar = false;
+
+extension EditorTextSelectionOverlayMagnifierExt on EditorTextSelectionOverlay {
+  // build magnifier info
+  MagnifierInfo _buildMagnifier(
+      {required RenderEditor renderEditable,
+      required Offset globalGesturePosition,
+      required TextPosition currentTextPosition}) {
+    final globalRenderEditableTopLeft =
+        renderEditable.localToGlobal(Offset.zero);
+    final localCaretRect =
+        renderEditable.getLocalRectForCaret(currentTextPosition);
+
+    final lineAtOffset = renderEditable.getLineAtOffset(currentTextPosition);
+    final positionAtEndOfLine = TextPosition(
+      offset: lineAtOffset.extentOffset,
+      affinity: TextAffinity.upstream,
+    );
+
+    // Default affinity is downstream.
+    final positionAtBeginningOfLine = TextPosition(
+      offset: lineAtOffset.baseOffset,
+    );
+
+    final lineBoundaries = Rect.fromPoints(
+      renderEditable.getLocalRectForCaret(positionAtBeginningOfLine).topCenter,
+      renderEditable.getLocalRectForCaret(positionAtEndOfLine).bottomCenter,
+    );
+
+    return MagnifierInfo(
+      fieldBounds: globalRenderEditableTopLeft & renderEditable.size,
+      globalGesturePosition: globalGesturePosition,
+      caretRect: localCaretRect.shift(globalRenderEditableTopLeft),
+      currentLineBoundaries: lineBoundaries.shift(globalRenderEditableTopLeft),
+    );
+  }
+
+  void _showMagnifier(MagnifierInfo initialMagnifierInfo) {
+    // Hide toolbar
+    if (toolbar != null) {
+      _restoreToolbar = true;
+      hideToolbar();
+    } else {
+      _restoreToolbar = false;
+    }
+
+    // Update magnifier Info
+    _magnifierInfo.value = initialMagnifierInfo;
+
+    final builtMagnifier = magnifierConfiguration.magnifierBuilder(
+      context,
+      _magnifierController,
+      _magnifierInfo,
+    );
+
+    if (builtMagnifier == null) return;
+
+    _magnifierController.show(
+      context: context,
+      below: magnifierConfiguration.shouldDisplayHandlesInMagnifier
+          ? null
+          : _handles?.elementAtOrNull(0),
+      builder: (_) => builtMagnifier,
+    );
+  }
+
+  void _updateMagnifier(MagnifierInfo magnifierInfo) {
+    if (_magnifierController.overlayEntry == null) {
+      return;
+    }
+    _magnifierInfo.value = magnifierInfo;
+  }
+
+  // TODO: Why we're having private and public methods for showMagnifier, and updateMagnifier?
+  //      Is this internal API that is for public use?
+  //      Once we know the reason, explain and document it.
+
+  void showMagnifier(
+      TextPosition position, Offset offset, RenderEditor editor) {
+    _showMagnifier(
+      _buildMagnifier(
+        currentTextPosition: position,
+        globalGesturePosition: offset,
+        renderEditable: editor,
+      ),
+    );
+  }
+
+  void updateMagnifier(
+      TextPosition position, Offset offset, RenderEditor editor) {
+    _updateMagnifier(
+      _buildMagnifier(
+        currentTextPosition: position,
+        globalGesturePosition: offset,
+        renderEditable: editor,
+      ),
+    );
+  }
+
+  void hideMagnifier() {
+    if (_magnifierController.overlayEntry == null) {
+      return;
+    }
+    _magnifierController.hide();
+    if (_restoreToolbar) {
+      _restoreToolbar = false;
+      showToolbar();
+    }
+  }
+}

--- a/lib/src/editor/raw_editor/raw_editor.dart
+++ b/lib/src/editor/raw_editor/raw_editor.dart
@@ -1,19 +1,9 @@
-import 'dart:ui' show Offset;
-
-import 'package:flutter/widgets.dart'
-    show
-        AnimationController,
-        BuildContext,
-        ScrollController,
-        State,
-        StatefulWidget,
-        TextSelectionDelegate,
-        Widget,
-        immutable;
+import 'package:flutter/widgets.dart';
 
 import '../../common/structs/offset_value.dart';
 import '../../controller/quill_controller.dart';
 import '../editor.dart';
+import '../magnifier/quill_magnifier_controller.dart';
 import '../widgets/text/text_selection.dart';
 import 'config/raw_editor_configurations.dart';
 import 'raw_editor_state.dart';
@@ -73,7 +63,7 @@ class QuillEditorGlyphHeights {
 /// Base interface for the editor state which defines contract used by
 /// various mixins.
 abstract class EditorState extends State<QuillRawEditor>
-    implements TextSelectionDelegate {
+    implements TextSelectionDelegate, QuillMagnifierController {
   ScrollController get scrollController;
 
   RenderEditor get renderEditor;
@@ -94,12 +84,6 @@ abstract class EditorState extends State<QuillRawEditor>
   bool showToolbar();
 
   void requestKeyboard();
-
-  void showMagnifier(Offset positionToShow);
-
-  void updateMagnifier(Offset positionToShow);
-
-  void hideMagnifier();
 
   void toggleToolbar([bool hideHandles = true]);
 }

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -43,6 +43,8 @@ import 'raw_editor_state_text_input_client_mixin.dart';
 import 'raw_editor_text_boundaries.dart';
 import 'scribble_focusable.dart';
 
+part '../magnifier/quill_raw_editor_state_magnifier_ext.dart';
+
 class QuillRawEditorState extends EditorState
     with
         AutomaticKeepAliveClientMixin<QuillRawEditor>,
@@ -1114,8 +1116,7 @@ class QuillRawEditorState extends EditorState
           ? null
           : (context) =>
               widget.configurations.contextMenuBuilder!(context, this),
-      magnifierConfiguration: widget.configurations.magnifierConfiguration ??
-          TextMagnifier.adaptiveMagnifierConfiguration,
+      magnifierConfiguration: _magnifierConfiguration,
     );
   }
 
@@ -1505,26 +1506,13 @@ class QuillRawEditorState extends EditorState
   bool get shareEnabled => false;
 
   @override
-  void hideMagnifier() {
-    if (_selectionOverlay == null) return;
-    _selectionOverlay?.hideMagnifier();
-  }
+  void hideMagnifier() => _hideMagnifier();
 
   @override
-  void showMagnifier(ui.Offset positionToShow) {
-    if (_hasFocus == false) return;
-    if (_selectionOverlay == null) return;
-    final position = renderEditor.getPositionForOffset(positionToShow);
-    if (_selectionOverlay!.magnifierIsVisible) {
-      _selectionOverlay!
-          .updateMagnifier(position, positionToShow, renderEditor);
-    } else {
-      _selectionOverlay!.showMagnifier(position, positionToShow, renderEditor);
-    }
-  }
+  void showMagnifier(ui.Offset positionToShow) =>
+      _showMagnifier(positionToShow);
 
   @override
-  void updateMagnifier(ui.Offset positionToShow) {
-    showMagnifier(positionToShow);
-  }
+  void updateMagnifier(ui.Offset positionToShow) =>
+      _updateMagnifier(positionToShow);
 }


### PR DESCRIPTION
## Description

*Cleanup #2026 by extracting the new methods, members, and checks to separate files when possible*

Not for merge yet, I'm uncertain about some of the changes made, waiting response from the contributor, also the new TODOs introduced in this PR need to be cleaned up before merging.

This PR does separate anything related to the magnifier feature in one manageable place in a simple way. Still need more improvements.

Even after the cleanup, the new code is still not qualified enough as I'm unable to understand some of the changes made. There might be inconsistency issues.

## Related Issues

- *Related #2026*
- *Related #2049*
- *Related #2111*
- *Related #2116*
- *Related #2124*

## Type of Change

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [x] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [x] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.
