### PR TITLE
Bug fix: Removing check not allowing spell check on web

### DIFF
--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -481,7 +481,6 @@ class _TextLineState extends State<TextLine> {
         !widget.readOnly &&
         !widget.line.style.attributes.containsKey('code-block') &&
         !widget.line.style.attributes.containsKey('placeholder') &&
-        !kIsWeb &&
         !isPlaceholderLine) {
       final service = SpellCheckerServiceProvider.instance;
       final spellcheckedSpans = service.checkSpelling(textNode.value);


### PR DESCRIPTION
## Description

Fix: Enable spell check for Web.

For some reason, this call was locked for web builds.
Removing this lock, and running multiple tests without problems.
Using the spell check package adds a lot to the size, but it's not a problem.

## Related Issues

Found: https://github.com/singerdmx/flutter-quill/issues/2164

## Type of Change

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [ X ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.










