### PR TITLE
Chore: deprecate embed table feature

### DIFF
--- a/example/lib/screens/quill/my_quill_toolbar.dart
+++ b/example/lib/screens/quill/my_quill_toolbar.dart
@@ -302,7 +302,6 @@ class MyQuillToolbar extends StatelessWidget {
                       : onImageInsert,
                 ),
               ),
-              tableButtonOptions: const QuillToolbarTableButtonOptions(),
             ),
           ),
         );

--- a/flutter_quill_extensions/lib/src/editor/table/table_cell_embed.dart
+++ b/flutter_quill_extensions/lib/src/editor/table/table_cell_embed.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
 @experimental
+@Deprecated('TableCellWidget will no longer used and it will be removed in future releases')
 class TableCellWidget extends StatefulWidget {
   const TableCellWidget({
     required this.cellId,

--- a/flutter_quill_extensions/lib/src/editor/table/table_cell_embed.dart
+++ b/flutter_quill_extensions/lib/src/editor/table/table_cell_embed.dart
@@ -3,7 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
 @experimental
-@Deprecated('TableCellWidget will no longer used and it will be removed in future releases')
+@Deprecated(
+    'TableCellWidget will no longer used and it will be removed in future releases')
 class TableCellWidget extends StatefulWidget {
   const TableCellWidget({
     required this.cellId,
@@ -21,6 +22,7 @@ class TableCellWidget extends StatefulWidget {
   State<TableCellWidget> createState() => _TableCellWidgetState();
 }
 
+// ignore: deprecated_member_use_from_same_package
 class _TableCellWidgetState extends State<TableCellWidget> {
   late final TextEditingController controller;
   late final FocusNode node;

--- a/flutter_quill_extensions/lib/src/editor/table/table_cell_embed.dart
+++ b/flutter_quill_extensions/lib/src/editor/table/table_cell_embed.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:meta/meta.dart';
 
+@experimental
 class TableCellWidget extends StatefulWidget {
   const TableCellWidget({
     required this.cellId,

--- a/flutter_quill_extensions/lib/src/editor/table/table_embed.dart
+++ b/flutter_quill_extensions/lib/src/editor/table/table_embed.dart
@@ -9,7 +9,8 @@ import 'table_cell_embed.dart';
 import 'table_models.dart';
 
 @experimental
-@Deprecated('CustomTableEmbed will no longer used and it will be removed in future releases')
+@Deprecated(
+    'CustomTableEmbed will no longer used and it will be removed in future releases')
 class CustomTableEmbed extends CustomBlockEmbed {
   const CustomTableEmbed(String value) : super(tableType, value);
 
@@ -223,6 +224,7 @@ class _TableWidgetState extends State<TableWidget> {
         if (key != 'id') {
           final columnId = key;
           final data = value;
+          // ignore: deprecated_member_use_from_same_package
           rowCells.add(TableCellWidget(
             cellId: rowKey,
             onTap: (node) {

--- a/flutter_quill_extensions/lib/src/editor/table/table_embed.dart
+++ b/flutter_quill_extensions/lib/src/editor/table/table_embed.dart
@@ -9,6 +9,7 @@ import 'table_cell_embed.dart';
 import 'table_models.dart';
 
 @experimental
+@Deprecated('CustomTableEmbed will no longer used and it will be removed in future releases')
 class CustomTableEmbed extends CustomBlockEmbed {
   const CustomTableEmbed(String value) : super(tableType, value);
 
@@ -45,7 +46,9 @@ class QuillEditorTableEmbedBuilder extends EmbedBuilder {
   }
 }
 
-@Deprecated('TableWidget will no longer used and it will be removed in future releases')
+@experimental
+@Deprecated(
+    'TableWidget will no longer used and it will be removed in future releases')
 class TableWidget extends StatefulWidget {
   const TableWidget({
     required this.tableData,

--- a/flutter_quill_extensions/lib/src/editor/table/table_embed.dart
+++ b/flutter_quill_extensions/lib/src/editor/table/table_embed.dart
@@ -3,10 +3,12 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill/quill_delta.dart';
+import 'package:meta/meta.dart';
 import '../../common/utils/quill_table_utils.dart';
 import 'table_cell_embed.dart';
 import 'table_models.dart';
 
+@experimental
 class CustomTableEmbed extends CustomBlockEmbed {
   const CustomTableEmbed(String value) : super(tableType, value);
 
@@ -20,6 +22,7 @@ class CustomTableEmbed extends CustomBlockEmbed {
 
 //Embed builder
 
+@experimental
 class QuillEditorTableEmbedBuilder extends EmbedBuilder {
   @override
   String get key => 'table';
@@ -34,6 +37,7 @@ class QuillEditorTableEmbedBuilder extends EmbedBuilder {
     TextStyle textStyle,
   ) {
     final tableData = node.value.data;
+    // ignore: deprecated_member_use_from_same_package
     return TableWidget(
       tableData: tableData,
       controller: controller,
@@ -41,6 +45,7 @@ class QuillEditorTableEmbedBuilder extends EmbedBuilder {
   }
 }
 
+@Deprecated('TableWidget will no longer used and it will be removed in future releases')
 class TableWidget extends StatefulWidget {
   const TableWidget({
     required this.tableData,
@@ -54,6 +59,7 @@ class TableWidget extends StatefulWidget {
   State<TableWidget> createState() => _TableWidgetState();
 }
 
+// ignore: deprecated_member_use_from_same_package
 class _TableWidgetState extends State<TableWidget> {
   TableModel _tableModel = TableModel(columns: {}, rows: {});
   String _selectedColumnId = '';

--- a/flutter_quill_extensions/lib/src/editor/table/table_models.dart
+++ b/flutter_quill_extensions/lib/src/editor/table/table_models.dart
@@ -1,3 +1,6 @@
+import 'package:meta/meta.dart';
+
+@experimental
 class TableModel {
   TableModel({required this.columns, required this.rows});
 
@@ -42,6 +45,7 @@ class TableModel {
   }
 }
 
+@experimental
 class ColumnModel {
   ColumnModel({required this.id, required this.position});
 
@@ -62,6 +66,7 @@ class ColumnModel {
   }
 }
 
+@experimental
 class RowModel {
   // Key is column ID, value is cell content
 

--- a/flutter_quill_extensions/lib/src/flutter_quill_embeds.dart
+++ b/flutter_quill_extensions/lib/src/flutter_quill_embeds.dart
@@ -4,7 +4,6 @@ import 'package:meta/meta.dart' show immutable;
 
 import 'editor/image/image_embed.dart';
 import 'editor/image/models/image_configurations.dart';
-import 'editor/table/table_embed.dart';
 import 'editor/video/models/video_configurations.dart';
 import 'editor/video/models/video_web_configurations.dart';
 import 'editor/video/video_embed.dart';
@@ -62,7 +61,10 @@ class FlutterQuillEmbeds {
         QuillEditorVideoEmbedBuilder(
           configurations: videoEmbedConfigurations,
         ),
-      QuillEditorTableEmbedBuilder(),
+      // We disable the table feature is in experimental phase
+      // and it does not work as we expect
+      // https://github.com/singerdmx/flutter-quill/pull/2238#pullrequestreview-2312706901
+      // QuillEditorTableEmbedBuilder(),
     ];
   }
 

--- a/flutter_quill_extensions/lib/src/flutter_quill_embeds.dart
+++ b/flutter_quill_extensions/lib/src/flutter_quill_embeds.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_quill/flutter_quill.dart' as fq;
-import 'package:meta/meta.dart' show immutable;
+import 'package:meta/meta.dart' show experimental, immutable;
 
 import 'editor/image/image_embed.dart';
 import 'editor/image/models/image_configurations.dart';
@@ -120,6 +120,7 @@ class FlutterQuillEmbeds {
     QuillToolbarVideoButtonOptions? videoButtonOptions =
         const QuillToolbarVideoButtonOptions(),
     QuillToolbarCameraButtonOptions? cameraButtonOptions,
+    @experimental
     @Deprecated(
         'tableButtonOptions will no longer used by now, and probably will be removed in future releases.')
     QuillToolbarTableButtonOptions? tableButtonOptions,

--- a/flutter_quill_extensions/lib/src/flutter_quill_embeds.dart
+++ b/flutter_quill_extensions/lib/src/flutter_quill_embeds.dart
@@ -13,7 +13,6 @@ import 'toolbar/camera/models/camera_configurations.dart';
 import 'toolbar/image/image_button.dart';
 import 'toolbar/image/models/image_configurations.dart';
 import 'toolbar/table/models/table_configurations.dart';
-import 'toolbar/table/table_button.dart';
 import 'toolbar/video/models/video_configurations.dart';
 import 'toolbar/video/video_button.dart';
 
@@ -121,6 +120,8 @@ class FlutterQuillEmbeds {
     QuillToolbarVideoButtonOptions? videoButtonOptions =
         const QuillToolbarVideoButtonOptions(),
     QuillToolbarCameraButtonOptions? cameraButtonOptions,
+    @Deprecated(
+        'tableButtonOptions will no longer used by now, and probably will be removed in future releases.')
     QuillToolbarTableButtonOptions? tableButtonOptions,
   }) =>
       [
@@ -141,12 +142,6 @@ class FlutterQuillEmbeds {
               QuillToolbarCameraButton(
                 controller: controller,
                 options: cameraButtonOptions,
-              ),
-        if (tableButtonOptions != null)
-          (controller, toolbarIconSize, iconTheme, dialogTheme) =>
-              QuillToolbarTableButton(
-                controller: controller,
-                options: tableButtonOptions,
               ),
       ];
 }

--- a/flutter_quill_extensions/lib/src/toolbar/table/models/table_configurations.dart
+++ b/flutter_quill_extensions/lib/src/toolbar/table/models/table_configurations.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_quill/flutter_quill.dart';
-import 'package:meta/meta.dart' show immutable;
+import 'package:meta/meta.dart' show experimental, immutable;
 
+@experimental
 @Deprecated(
     'QuillToolbarTableButtonExtraOptions is not stable at this moment and it should not be used. Probably will be removed in future releases')
 class QuillToolbarTableButtonExtraOptions
@@ -13,6 +14,7 @@ class QuillToolbarTableButtonExtraOptions
 }
 
 @immutable
+@experimental
 @Deprecated(
     'QuillToolbarTableButton is not stable at this moment and it should not be used. Probably will be removed in future releases')
 class QuillToolbarTableButtonOptions extends QuillToolbarBaseButtonOptions<

--- a/flutter_quill_extensions/lib/src/toolbar/table/models/table_configurations.dart
+++ b/flutter_quill_extensions/lib/src/toolbar/table/models/table_configurations.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:meta/meta.dart' show immutable;
 
+@Deprecated(
+    'QuillToolbarTableButtonExtraOptions is not stable at this moment and it should not be used. Probably will be removed in future releases')
 class QuillToolbarTableButtonExtraOptions
     extends QuillToolbarBaseButtonExtraOptions {
   const QuillToolbarTableButtonExtraOptions({
@@ -11,6 +13,8 @@ class QuillToolbarTableButtonExtraOptions
 }
 
 @immutable
+@Deprecated(
+    'QuillToolbarTableButton is not stable at this moment and it should not be used. Probably will be removed in future releases')
 class QuillToolbarTableButtonOptions extends QuillToolbarBaseButtonOptions<
     QuillToolbarTableButtonOptions, QuillToolbarTableButtonExtraOptions> {
   const QuillToolbarTableButtonOptions({

--- a/flutter_quill_extensions/lib/src/toolbar/table/table_button.dart
+++ b/flutter_quill_extensions/lib/src/toolbar/table/table_button.dart
@@ -5,6 +5,8 @@ import 'package:flutter_quill/translations.dart';
 import '../../common/utils/quill_table_utils.dart';
 import 'models/table_configurations.dart';
 
+@Deprecated(
+    'QuillToolbarTableButton will no longer be used by now and will be removed in future releases')
 class QuillToolbarTableButton extends StatelessWidget {
   const QuillToolbarTableButton({
     required this.controller,

--- a/flutter_quill_extensions/lib/src/toolbar/table/table_button.dart
+++ b/flutter_quill_extensions/lib/src/toolbar/table/table_button.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill/translations.dart';
+import 'package:meta/meta.dart';
 
 import '../../common/utils/quill_table_utils.dart';
 import 'models/table_configurations.dart';
 
+@experimental
 @Deprecated(
     'QuillToolbarTableButton will no longer be used by now and will be removed in future releases')
 class QuillToolbarTableButton extends StatelessWidget {

--- a/flutter_quill_extensions/lib/src/toolbar/table/table_button.dart
+++ b/flutter_quill_extensions/lib/src/toolbar/table/table_button.dart
@@ -8,7 +8,7 @@ import 'models/table_configurations.dart';
 
 @experimental
 @Deprecated(
-    'QuillToolbarTableButton will no longer be used by now and will be removed in future releases')
+    'QuillToolbarTableButton will no longer used and will be removed in future releases')
 class QuillToolbarTableButton extends StatelessWidget {
   const QuillToolbarTableButton({
     required this.controller,


### PR DESCRIPTION
## Description

It was decided to disable embed tables for the moment.

Why was this decision made? It's not hard to see. Not only are there notable visual errors, but also in the logic itself of adding columns, rows, and even where the popup that allows us to add new tables to the document should appear.

This feature was implemented at a very early stage and should not have been allowed to be implemented as if it were a totally stable feature without bugs (or at least not many). The best thing for the moment, instead of removing it, is to disable it so that the end user does NOT have access to it and allows us to improve it to a point where we can verify that it is stable and can be implemented along with the other features.

![Captura de pantalla_2024-09-20_19-01-07](https://github.com/user-attachments/assets/a53374c8-940d-4ff6-9cc3-4623396b635e)

![Captura de pantalla_2024-09-20_19-01-25](https://github.com/user-attachments/assets/2bef2b80-8812-4c04-87f0-de0237f71bfc)

A PR will be coming soon to try to improve this implementation. However, there are priorities and we have to solve the problems that most affect the editor (such as the problem with the indent attribute and even the performance, which is quite bad on web and mobile).

## Related Issues

- *Related  #2193*
- *Related #2130*

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [x] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.