### PR TITLE
ci: remove quill_native_bridge from automated publishing workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,9 +36,6 @@ jobs:
       - name: 📦 Install flutter_quill_test dependencies
         run: flutter pub get -C flutter_quill_test
 
-      - name: 📦 Install quill_native_bridge dependencies
-        run: flutter pub get -C quill_native_bridge
-
       - name: 🔍 Run Flutter analysis
         run: flutter analyze
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,6 +105,3 @@ jobs:
         run: flutter pub publish --force
         working-directory: ./flutter_quill_test/
 
-      - name: 📤 Publish quill_native_bridge
-        run: flutter pub publish --force
-        working-directory: ./quill_native_bridge/


### PR DESCRIPTION
## Description

*Remove `quill_native_bridge` from the automated publishing workflow.*

`quill_native_bridge` will no longer have the same version as `flutter_quill` and will be separated (while remaining in the same repo).

When publishing a new version, `quill_native_bridge` doesn't get a new version publishing automatically.

See #2230 and #2262 for more details about why this decision was made.

`quill_native_integration` will replace `quill_native_bridge` soon. This is not a breaking change as this package is for internal use only.

## Related Issues

- *Related #2262*
- *Related #2230*

## Type of Change

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [x] 🗑️ **Chore:** Routine tasks, or maintenance.
- [x] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions

<!-- Optional -->