### PR TITLE
revert: "Resolved issue with broken IME composing rect in Windows desktop"

### DIFF
--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -113,8 +113,8 @@ mixin RawEditorStateTextInputClientMixin on EditorState
   }
 
   void _updateComposingRectIfNeeded() {
-    final composingRange = _lastKnownRemoteTextEditingValue?.composing ?? 
-                            textEditingValue.composing;
+    final composingRange = _lastKnownRemoteTextEditingValue?.composing ??
+        textEditingValue.composing;
     if (hasConnection) {
       assert(mounted);
       final offset = composingRange.isValid ? composingRange.start : 0;

--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -112,19 +112,9 @@ mixin RawEditorStateTextInputClientMixin on EditorState
     _textInputConnection!.show();
   }
 
-  TextRange _getComposingRange() {
-    if (_lastKnownRemoteTextEditingValue != null &&
-        _lastKnownRemoteTextEditingValue?.composing.isValid == true) {
-      return _lastKnownRemoteTextEditingValue!.composing;
-    } else if (textEditingValue.composing.isValid == true) {
-      return textEditingValue.composing;
-    } else {
-      return widget.controller.selection;
-    }
-  }
-
   void _updateComposingRectIfNeeded() {
-    final composingRange = _getComposingRange();
+    final composingRange = _lastKnownRemoteTextEditingValue?.composing ?? 
+                            textEditingValue.composing;
     if (hasConnection) {
       assert(mounted);
       final offset = composingRange.isValid ? composingRange.start : 0;


### PR DESCRIPTION
## Description

These changes were reverted because they are causing issues when using the indentation attribute. I can't say if they are causing other parts to fail, but they are definitely not allowing the editor to work stably.

@agata  if you are going to redo your PR fixing this IME issue, please make sure to test if the IME works along with everything else in the editor (selection, typing, applying block and inline attributes, etc.) to make sure the change is really stable.

_No related: I've noticed that on the web this fails randomly too._

## Related Issues

- *Fix #2253*

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions

Before merging any new changes into the main release, we should consider whether these changes work completely without damaging the other existing functionality within the package.

We should establish some step-by-step guide before merging which PR to first check whether the changes really do not alter the correct functioning of the editor.