### PR TITLE
Fix: Resolved issue with broken IME composing rect in Windows desktop(re-implementation)

### DIFF
--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -117,10 +117,12 @@ mixin RawEditorStateTextInputClientMixin on EditorState
         textEditingValue.composing;
     if (hasConnection) {
       assert(mounted);
-      final offset = composingRange.isValid ? composingRange.start : 0;
-      final composingRect =
-          renderEditor.getLocalRectForCaret(TextPosition(offset: offset));
-      _textInputConnection!.setComposingRect(composingRect);
+      if (composingRange.isValid) {
+        final offset = composingRange.start;
+        final composingRect =
+            renderEditor.getLocalRectForCaret(TextPosition(offset: offset));
+        _textInputConnection!.setComposingRect(composingRect);
+      }
       SchedulerBinding.instance
           .addPostFrameCallback((_) => _updateComposingRectIfNeeded());
     }


### PR DESCRIPTION
## Description

I have re-implemented the changes from #2239 that were previously reverted. In this implementation, when the ComposingRange has an invalid position, the position is no longer updated in TextInputConnection. During the composing phase, the correct ComposingRange is generally retrieved, and the display position is determined based on that information, so no issues occur. The exception that caused the revert has also been resolved. I have confirmed that this behavior works correctly across Windows, Mac, Web, iOS, and Android.

Before:
https://github.com/user-attachments/assets/3afd158f-73f1-45ba-b56e-56ff4c9b965a

After:
https://github.com/user-attachments/assets/e9246da5-6ed0-416d-b358-36bc83f74c62

## Related Issues

- #2264
- #2239

## Type of Change

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions
