### PR TITLE
fix: update version range of quill_native_bridge to avoid using latest version of the package

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,7 +62,7 @@ dependencies:
   # Plugins
   url_launcher: ^6.2.4
   flutter_keyboard_visibility: ^6.0.0
-  quill_native_bridge: '>=0.0.1-alpha.0 <=10.5.14'
+  quill_native_bridge: '>=10.5.14 <=10.6.2'
 
 dev_dependencies:
   flutter_lints: ^4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,7 +62,7 @@ dependencies:
   # Plugins
   url_launcher: ^6.2.4
   flutter_keyboard_visibility: ^6.0.0
-  quill_native_bridge: ^10.5.14
+  quill_native_bridge: 10.5.14
 
 dev_dependencies:
   flutter_lints: ^4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,7 +62,7 @@ dependencies:
   # Plugins
   url_launcher: ^6.2.4
   flutter_keyboard_visibility: ^6.0.0
-  quill_native_bridge: 10.5.14
+  quill_native_bridge: '>=0.0.1-alpha.0 <=10.5.14'
 
 dev_dependencies:
   flutter_lints: ^4.0.0


### PR DESCRIPTION
## Description

*Use fixed version of `quill_native_bridge` to avoid using latest version of `quill_native_bridge` as #2230 is WIP and not merged yet.*

## Related Issues

- *Fix #2281*

## Type of Change


- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions

<!-- Optional -->