### PR TITLE
fix(extensions)!: drop support for YouTube iframeView for non-web platforms, remove youtube_player_flutter dependency, throw warnings for anything related to YoutubeVideoApp in development mode

### DIFF
--- a/example/lib/screens/quill/my_quill_editor.dart
+++ b/example/lib/screens/quill/my_quill_editor.dart
@@ -129,7 +129,7 @@ class MyQuillEditor extends StatelessWidget {
                   ),
                   videoEmbedConfigurations: QuillEditorVideoEmbedConfigurations(
                     customVideoBuilder: (videoUrl, readOnly) {
-                      // Check for YouTube Video URL and return your
+                      // Example: Check for YouTube Video URL and return your
                       // YouTube video widget here.
 
                       // Otherwise return null to fallback to the defualt logic

--- a/example/lib/screens/quill/my_quill_editor.dart
+++ b/example/lib/screens/quill/my_quill_editor.dart
@@ -128,11 +128,14 @@ class MyQuillEditor extends StatelessWidget {
                     },
                   ),
                   videoEmbedConfigurations: QuillEditorVideoEmbedConfigurations(
-                    // Loading YouTube videos on Desktop is not supported yet
-                    // when using iframe platform view
-                    youtubeVideoSupportMode: isDesktopApp
-                        ? YoutubeVideoSupportMode.customPlayerWithDownloadUrl
-                        : YoutubeVideoSupportMode.iframeView,
+                    customVideoBuilder: (videoUrl, readOnly) {
+                      // Check for YouTube Video URL and return your
+                      // YouTube video widget here.
+
+                      // Otherwise return null to fallback to the defualt logic
+                      return null;
+                    },
+                    ignoreYouTubeSupport: true,
                   ),
                 )),
           TimeStampEmbedBuilderWidget(),

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,7 +12,6 @@ import flutter_inappwebview_macos
 import gal
 import irondash_engine_context
 import path_provider_foundation
-import quill_native_bridge
 import share_plus
 import sqflite
 import super_native_extensions
@@ -27,7 +26,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
   IrondashEngineContextPlugin.register(with: registry.registrar(forPlugin: "IrondashEngineContextPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
-  QuillNativeBridgePlugin.register(with: registry.registrar(forPlugin: "QuillNativeBridgePlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   SuperNativeExtensionsPlugin.register(with: registry.registrar(forPlugin: "SuperNativeExtensionsPlugin"))

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -18,8 +18,6 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - quill_native_bridge (0.0.1):
-    - FlutterMacOS
   - share_plus (0.0.1):
     - FlutterMacOS
   - sqflite (0.0.3):
@@ -42,7 +40,6 @@ DEPENDENCIES:
   - gal (from `Flutter/ephemeral/.symlinks/plugins/gal/darwin`)
   - irondash_engine_context (from `Flutter/ephemeral/.symlinks/plugins/irondash_engine_context/macos`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
-  - quill_native_bridge (from `Flutter/ephemeral/.symlinks/plugins/quill_native_bridge/macos`)
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - sqflite (from `Flutter/ephemeral/.symlinks/plugins/sqflite/darwin`)
   - super_native_extensions (from `Flutter/ephemeral/.symlinks/plugins/super_native_extensions/macos`)
@@ -70,8 +67,6 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/irondash_engine_context/macos
   path_provider_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
-  quill_native_bridge:
-    :path: Flutter/ephemeral/.symlinks/plugins/quill_native_bridge/macos
   share_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   sqflite:
@@ -93,7 +88,6 @@ SPEC CHECKSUMS:
   irondash_engine_context: da62996ee25616d2f01bbeb85dc115d813359478
   OrderedSet: aaeb196f7fef5a9edf55d89760da9176ad40b93c
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  quill_native_bridge: 1a3a4bfab7cbe4ed0232a17d8aae201a3ce6d302
   share_plus: 36537c04ce0c3e3f5bd297ce4318b6d5ee5fd6cf
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
   super_native_extensions: 85efee3a7495b46b04befcfc86ed12069264ebf3

--- a/flutter_quill_extensions/README.md
+++ b/flutter_quill_extensions/README.md
@@ -50,10 +50,7 @@ The package uses the following plugins:
    platform-specific setup.
 2. [`image_picker`](https://pub.dev/packages/image_picker) for picking images.
    See the [Installation](https://pub.dev/packages/image_picker#installation) section.
-3. [`youtube_player_flutter`](https://pub.dev/packages/youtube_player_flutter) which
-   uses [`flutter_inappwebview`](https://pub.dev/packages/flutter_inappwebview) which has a requirement setup on web.
-   See the [Installation - Web support](https://pub.dev/packages/flutter_inappwebview#installation---web-support).
-4. [`super_clipboard`](https://pub.dev/packages/super_clipboard) which needs some setup on Android only, it's used to
+3. [`super_clipboard`](https://pub.dev/packages/super_clipboard) which needs some setup on Android only, it's used to
    support copying images and pasting them into editor, it's also required to support rich text pasting feature on
    non-web platforms, Open the [Android Support](https://pub.dev/packages/super_clipboard#android-support) page for
    instructions.

--- a/flutter_quill_extensions/lib/src/common/utils/utils.dart
+++ b/flutter_quill_extensions/lib/src/common/utils/utils.dart
@@ -25,6 +25,10 @@ bool isImageBase64(String imageUrl) {
   return !isHttpBasedUrl(imageUrl) && isBase64(imageUrl);
 }
 
+@Deprecated(
+  'Will be removed in future releases. See https://github.com/singerdmx/flutter-quill/issues/2284'
+  ' and https://github.com/singerdmx/flutter-quill/issues/2276',
+)
 bool isYouTubeUrl(String videoUrl) {
   try {
     final uri = Uri.parse(videoUrl);

--- a/flutter_quill_extensions/lib/src/editor/video/models/video_configurations.dart
+++ b/flutter_quill_extensions/lib/src/editor/video/models/video_configurations.dart
@@ -7,7 +7,13 @@ import 'youtube_video_support_mode.dart';
 class QuillEditorVideoEmbedConfigurations {
   const QuillEditorVideoEmbedConfigurations({
     this.onVideoInit,
-    // ignore: deprecated_member_use_from_same_package
+    @Deprecated(
+      'Loading youtube videos is no longer built-in feature of flutter_quill_extensions.\n'
+      'See https://github.com/singerdmx/flutter-quill/issues/2284.\n'
+      'Try to use the experimental `customVideoBuilder` property to implement\n'
+      'your own YouTube logic using packages such as '
+      'https://pub.dev/packages/youtube_video_player or https://pub.dev/packages/youtube_player_flutter',
+    )
     this.youtubeVideoSupportMode = YoutubeVideoSupportMode.disabled,
     this.ignoreYouTubeSupport = false,
     this.customVideoBuilder,

--- a/flutter_quill_extensions/lib/src/editor/video/models/video_configurations.dart
+++ b/flutter_quill_extensions/lib/src/editor/video/models/video_configurations.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/widgets.dart' show GlobalKey;
-import 'package:meta/meta.dart' show immutable;
+import 'package:flutter/widgets.dart' show GlobalKey, Widget;
+import 'package:meta/meta.dart' show experimental, immutable;
 
 import 'youtube_video_support_mode.dart';
 
@@ -7,7 +7,10 @@ import 'youtube_video_support_mode.dart';
 class QuillEditorVideoEmbedConfigurations {
   const QuillEditorVideoEmbedConfigurations({
     this.onVideoInit,
-    this.youtubeVideoSupportMode = YoutubeVideoSupportMode.iframeView,
+    // ignore: deprecated_member_use_from_same_package
+    this.youtubeVideoSupportMode = YoutubeVideoSupportMode.disabled,
+    this.ignoreYouTubeSupport = false,
+    this.customVideoBuilder,
   });
 
   /// [onVideoInit] is a callback function that gets triggered when
@@ -27,5 +30,49 @@ class QuillEditorVideoEmbedConfigurations {
 
   /// Specifies how YouTube videos should be loaded if the video URL
   /// is YouTube video.
+  @Deprecated(
+    'Loading youtube videos is no longer built-in feature of flutter_quill_extensions.\n'
+    'See https://github.com/singerdmx/flutter-quill/issues/2284.\n'
+    'Try to use the experimental `customVideoBuilder` property to implement\n'
+    'your own YouTube logic using packages such as '
+    'https://pub.dev/packages/youtube_video_player or https://pub.dev/packages/youtube_player_flutter',
+  )
   final YoutubeVideoSupportMode youtubeVideoSupportMode;
+
+  /// Pass `true` to ignore anything related to YouTube which will disable
+  /// This functionality is without any warnings.
+  ///
+  /// Making it `true`, means that the video embed widget will no longer
+  /// check for the video URL and expect it a valid and a standrad video URL.
+  ///
+  /// This property will be removed in future releases once YouTube support is
+  /// removed.
+  ///
+  /// Use [customVideoBuilder] to load youtube videos.
+  @experimental
+  @Deprecated(
+    'Will be removed in future releases. Exist to allow users to ignore warnings.',
+  )
+  final bool ignoreYouTubeSupport;
+
+  /// [customVideoBuilder] is a callback function that receives the
+  /// video URL and a read-only flag. This allows users to define
+  /// their own logic for rendering video widgets, enabling support
+  /// for various video platforms, such as YouTube.
+  ///
+  /// Example usage:
+  /// ```dart
+  ///   customVideoBuilder: (videoUrl, readOnly) {
+  ///     // Return `null` to fallback to defualt logic of QuillEditorVideoEmbedBuilder
+  ///
+  ///     // Return a custom video widget based on the videoUrl
+  ///     return CustomVideoWidget(videoUrl: videoUrl, readOnly: readOnly);
+  ///   },
+  /// ```
+  ///
+  /// It's a quick solution as response to https://github.com/singerdmx/flutter-quill/issues/2284
+  ///
+  /// **Might be removed or changed in future releases.**
+  @experimental
+  final Widget? Function(String videoUrl, bool readOnly)? customVideoBuilder;
 }

--- a/flutter_quill_extensions/lib/src/editor/video/models/video_web_configurations.dart
+++ b/flutter_quill_extensions/lib/src/editor/video/models/video_web_configurations.dart
@@ -7,5 +7,6 @@ class QuillEditorWebVideoEmbedConfigurations {
     this.constraints,
   });
 
+  @Deprecated('This property is no longer used.')
   final BoxConstraints? constraints;
 }

--- a/flutter_quill_extensions/lib/src/editor/video/models/youtube_video_support_mode.dart
+++ b/flutter_quill_extensions/lib/src/editor/video/models/youtube_video_support_mode.dart
@@ -1,8 +1,19 @@
-/// Enum represents the different modes for handling YouTube video support.
+import 'package:meta/meta.dart';
+
+/// **Will be removed soon in future releases**.
+@experimental
+@Deprecated(
+  'YouTube video support will be removed soon and completely in the next releases.',
+)
 enum YoutubeVideoSupportMode {
+  /// **Will be removed soon in future releases**.
   /// Disable loading of YouTube videos.
+  /// **Will be removed soon in future releases**.
+  @Deprecated('Loading YouTube videos is already disabled by default.')
   disabled,
 
+  /// **Will be removed soon in future releases**.
+  ///
   /// Load the video using the official YouTube IFrame API.
   /// See [YouTube IFrame API](https://developers.google.com/youtube/iframe_api_reference) for more details.
   ///
@@ -10,10 +21,34 @@ enum YoutubeVideoSupportMode {
   /// The WebView might not be supported on Desktop and will throw an exception
   ///
   /// See [Flutter InAppWebview Support for Flutter Desktop](https://github.com/pichillilorenzo/flutter_inappwebview/issues/460)
+  ///
+  /// **Important**: We had to remove [flutter_inappwebview](https://pub.dev/packages/flutter_inappwebview)
+  /// and [youtube_player_flutter](https://pub.dev/packages/youtube_player_flutter)
+  /// as non breaking change since most users are unable to build the project,
+  /// preventing them from using
+  ///
+  /// **Will be removed soon in future releases**.
+  @Deprecated(
+    'This functionality has been removed to fix build failure issues. See https://github.com/singerdmx/flutter-quill/issues/2284 for discussion.',
+  )
   iframeView,
 
+  /// **Will be removed soon in future releases**.
+  ///
   /// Load the video using a custom video player by fetching the YouTube video URL.
   /// Note: This might violate YouTube's terms of service.
   /// See [YouTube Terms of Service](https://www.youtube.com/static?template=terms) for more details.
+  ///
+  /// **WARNING**: We highly suggest to not use this solution,
+  /// can cause issues with YouTube Terms of Service and require a extra dependency for all users.
+  /// YouTube servers can reject requests and respond with `Sign in to confirm you’re not a bot`
+  /// See related issue: https://github.com/Hexer10/youtube_explode_dart/issues/282
+  ///
+  /// **Will be removed soon in future releases**.
+  @Deprecated(
+    'Can cause issues with YouTube Terms of Service and require a extra dependency for all users - Will be removed soon.\n'
+    'YouTube servers can reject requests and respond with "Sign in to confirm you’re not a bot"\n'
+    'See related issue https://github.com/Hexer10/youtube_explode_dart/issues/282\n',
+  )
   customPlayerWithDownloadUrl,
 }

--- a/flutter_quill_extensions/lib/src/editor/video/video_embed.dart
+++ b/flutter_quill_extensions/lib/src/editor/video/video_embed.dart
@@ -33,10 +33,35 @@ class QuillEditorVideoEmbedBuilder extends EmbedBuilder {
     assert(!kIsWeb, 'Please provide video EmbedBuilder for Web');
 
     final videoUrl = node.value.data;
-    if (isYouTubeUrl(videoUrl)) {
+
+    final customVideoBuilder = configurations.customVideoBuilder;
+    if (customVideoBuilder != null) {
+      final videoWidget = customVideoBuilder(videoUrl, readOnly);
+      if (videoWidget != null) {
+        return videoWidget;
+      }
+    }
+
+    // ignore: deprecated_member_use_from_same_package
+    if (isYouTubeUrl(videoUrl) && !configurations.ignoreYouTubeSupport) {
+      assert(() {
+        debugPrint(
+          "It seems that you're loading a youtube video URL.\n"
+          'Loading YouTube videos is no longer built-in feature as part of flutter_quill_extensions.\n'
+          'This message will only appear in development mode. See https://github.com/singerdmx/flutter-quill/issues/2284\n'
+          'Consider using the experimental property `QuillEditorVideoEmbedConfigurations.customVideoBuilder` in your configuration.\n'
+          'This message will only included in development mode.\n',
+        );
+        return true;
+      }());
+
+      /// Will be removed soon in future releases
+
+      // ignore: deprecated_member_use_from_same_package
       return YoutubeVideoApp(
         videoUrl: videoUrl,
         readOnly: readOnly,
+        // ignore: deprecated_member_use_from_same_package
         youtubeVideoSupportMode: configurations.youtubeVideoSupportMode,
       );
     }

--- a/flutter_quill_extensions/lib/src/editor/video/video_web_embed.dart
+++ b/flutter_quill_extensions/lib/src/editor/video/video_web_embed.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:universal_html/html.dart' as html;
-import 'package:youtube_player_flutter/youtube_player_flutter.dart'
-    show YoutubePlayer;
 
 import '../../common/utils/dart_ui/dart_ui_fake.dart'
     if (dart.library.js_interop) '../../common/utils/dart_ui/dart_ui_real.dart'
@@ -10,6 +8,7 @@ import '../../common/utils/dart_ui/dart_ui_fake.dart'
 import '../../common/utils/element_utils/element_web_utils.dart';
 import '../../common/utils/utils.dart';
 import 'models/video_web_configurations.dart';
+import 'youtube_video_url.dart';
 
 class QuillEditorWebVideoEmbedBuilder extends EmbedBuilder {
   const QuillEditorWebVideoEmbedBuilder({
@@ -34,8 +33,10 @@ class QuillEditorWebVideoEmbedBuilder extends EmbedBuilder {
     TextStyle textStyle,
   ) {
     var videoUrl = node.value.data;
+    // ignore: deprecated_member_use_from_same_package
     if (isYouTubeUrl(videoUrl)) {
-      final youtubeID = YoutubePlayer.convertUrlToId(videoUrl);
+      // ignore: deprecated_member_use_from_same_package
+      final youtubeID = convertVideoUrlToId(videoUrl);
       if (youtubeID != null) {
         videoUrl = 'https://www.youtube.com/embed/$youtubeID';
       }

--- a/flutter_quill_extensions/lib/src/editor/video/widgets/youtube_video_app.dart
+++ b/flutter_quill_extensions/lib/src/editor/video/widgets/youtube_video_app.dart
@@ -3,11 +3,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart' show DefaultStyles;
 import 'package:url_launcher/url_launcher_string.dart';
 import 'package:youtube_explode_dart/youtube_explode_dart.dart';
-import 'package:youtube_player_flutter/youtube_player_flutter.dart';
 
 import '../models/youtube_video_support_mode.dart';
+import '../youtube_video_url.dart';
 import 'video_app.dart';
 
+/// **Will be removed soon in future releases**.
+@Deprecated(
+  'Will be removed in future releases. See https://github.com/singerdmx/flutter-quill/issues/2284',
+)
 class YoutubeVideoApp extends StatefulWidget {
   const YoutubeVideoApp({
     required this.videoUrl,
@@ -24,9 +28,8 @@ class YoutubeVideoApp extends StatefulWidget {
   YoutubeVideoAppState createState() => YoutubeVideoAppState();
 }
 
+// ignore: deprecated_member_use_from_same_package
 class YoutubeVideoAppState extends State<YoutubeVideoApp> {
-  YoutubePlayerController? _youtubeIframeController;
-
   /// On some platforms such as desktop, Webview is not supported yet
   /// as a result the youtube video player package is not supported too
   /// this future will be not null and fetch the video url to load it using
@@ -35,7 +38,8 @@ class YoutubeVideoAppState extends State<YoutubeVideoApp> {
 
   /// Null if the video URL is not a YouTube video
   String? get _videoId {
-    return YoutubePlayer.convertUrlToId(widget.videoUrl);
+    // ignore: deprecated_member_use_from_same_package
+    return convertVideoUrlToId(widget.videoUrl);
   }
 
   @override
@@ -46,16 +50,21 @@ class YoutubeVideoAppState extends State<YoutubeVideoApp> {
       return;
     }
     switch (widget.youtubeVideoSupportMode) {
+      // ignore: deprecated_member_use_from_same_package
       case YoutubeVideoSupportMode.disabled:
         break;
+      // ignore: deprecated_member_use_from_same_package
       case YoutubeVideoSupportMode.iframeView:
-        _youtubeIframeController = YoutubePlayerController(
-          initialVideoId: videoId,
-          flags: const YoutubePlayerFlags(
-            autoPlay: false,
-          ),
-        );
+        assert(() {
+          debugPrint(
+            'Youtube Iframe is no longer supported on non-web platforms.\n'
+            'See https://github.com/singerdmx/flutter-quill/issues/2284\n'
+            'This message will only included in development mode.\n',
+          );
+          return true;
+        }());
         break;
+      // ignore: deprecated_member_use_from_same_package
       case YoutubeVideoSupportMode.customPlayerWithDownloadUrl:
         _loadYoutubeVideoByDownloadUrlFuture =
             _loadYoutubeVideoWithVideoPlayerByVideoUrl();
@@ -85,37 +94,76 @@ class YoutubeVideoAppState extends State<YoutubeVideoApp> {
 
   @override
   Widget build(BuildContext context) {
+    assert(() {
+      debugPrint(
+        "WARNING: It seems that you're using YoutubeVideoApp widget from flutter_quill_extensions "
+        'which will be removed in future releases and will cause many issues.\n'
+        'Use `customVideoBuilder` in the configuration class of `QuillEditorVideoEmbedConfigurations`.\n'
+        'This message is only shown in development mode.\n'
+        'Refer to https://github.com/singerdmx/flutter-quill/issues/2284 if you need help.',
+      );
+      return true;
+    }());
     final defaultStyles = DefaultStyles.getInstance(context);
 
     switch (widget.youtubeVideoSupportMode) {
+      // ignore: deprecated_member_use_from_same_package
       case YoutubeVideoSupportMode.disabled:
-        throw UnsupportedError('YouTube video links are not supported');
-      case YoutubeVideoSupportMode.iframeView:
-        final youtubeController = _youtubeIframeController;
-
-        if (youtubeController == null) {
-          if (widget.readOnly) {
-            return _clickableVideoLinkText(defaultStyles: defaultStyles);
-          }
-
-          return RichText(
-            text: TextSpan(text: widget.videoUrl, style: defaultStyles.link),
+        // Don't remove this assert, it's required to ensure
+        // a smoother migration for users, will be only included in development mode
+        assert(() {
+          debugPrint(
+            'Loading Youtube Videos has been disabled in recent versions of flutter_quill_extensions.\n'
+            'See https://github.com/singerdmx/flutter-quill/issues/2284.\n'
+            'We highly suggest to use the experimental property `QuillEditorVideoEmbedConfigurations.customVideoBuilder`\n'
+            'in your configuration to handle YouTube video support.\n'
+            'This message will only included in development mode.\n',
           );
+          throw UnsupportedError(
+            'Loading YouTube videos is no longer supported in flutter_quill_extensions.'
+            'Take a look at the debug console for more details.\n'
+            'Refer to https://github.com/singerdmx/flutter-quill/issues/2284 if you need help.\n'
+            'This error will only happen in development mode, in production will return a clickable video link text.\n',
+          );
+        }());
+        return _clickableVideoLinkText(defaultStyles: defaultStyles);
+      // ignore: deprecated_member_use_from_same_package
+      case YoutubeVideoSupportMode.iframeView:
+        if (widget.readOnly) {
+          return _clickableVideoLinkText(defaultStyles: defaultStyles);
         }
-        return YoutubePlayerBuilder(
-          player: YoutubePlayer(
-            controller: youtubeController,
-            showVideoProgressIndicator: true,
-          ),
-          builder: (context, player) {
-            return player;
-          },
+
+        return RichText(
+          text: TextSpan(text: widget.videoUrl, style: defaultStyles.link),
         );
+      // ignore: deprecated_member_use_from_same_package
       case YoutubeVideoSupportMode.customPlayerWithDownloadUrl:
         assert(
           _loadYoutubeVideoByDownloadUrlFuture != null,
           'The load youtube video future should not null for "${widget.youtubeVideoSupportMode}" mode',
         );
+        assert(() {
+          debugPrint(
+            'WARNING: Using the YouTube video download URL can violate their terms of service.\n'
+            'This is already documented in customPlayerWithDownloadUrl option.\n'
+            'See https://github.com/singerdmx/flutter-quill/issues/2284.\n'
+            'We suggest to use the experimental property `QuillEditorVideoEmbedConfigurations.customVideoBuilder`\n'
+            'in your configuration to handle YouTube video support.\n'
+            'This message will only included in development mode.\n',
+          );
+          debugPrint(
+            'WARNING: Using customPlayerWithDownloadUrl might not work anymore '
+            'as YouTube servers can reject requests and respond with "Sign in to confirm you’re not a bot"\n'
+            'See https://github.com/Hexer10/youtube_explode_dart/issues/282\n'
+            'This message will only included in development mode.\n',
+          );
+          throw UnsupportedError(
+            'Loading YouTube videos is no longer supported in flutter_quill_extensions.'
+            'Take a look at the debug console for more details.\n'
+            'Refer to https://github.com/singerdmx/flutter-quill/issues/2284 if you need help.\n'
+            'This error will only happen in development mode, in producation, YouTube servers will respond with "Sign in to confirm you’re not a bot".\n',
+          );
+        }());
 
         return FutureBuilder<String>(
           future: _loadYoutubeVideoByDownloadUrlFuture,
@@ -133,11 +181,5 @@ class YoutubeVideoAppState extends State<YoutubeVideoApp> {
           },
         );
     }
-  }
-
-  @override
-  void dispose() {
-    _youtubeIframeController?.dispose();
-    super.dispose();
   }
 }

--- a/flutter_quill_extensions/lib/src/editor/video/youtube_video_url.dart
+++ b/flutter_quill_extensions/lib/src/editor/video/youtube_video_url.dart
@@ -1,0 +1,32 @@
+import 'package:meta/meta.dart';
+
+/// Function copied from https://github.com/sarbagyastha/youtube_player_flutter/blob/f8e1e79991066bcc70f0a7c93941ca0d54b7370e/packages/youtube_player_flutter/lib/src/player/youtube_player.dart#L154
+/// and is not written as part of this project.
+///
+/// Used as quick response for https://github.com/singerdmx/flutter-quill/issues/2284
+@experimental
+@internal
+@Deprecated(
+  'Will be removed in future releases, for now included as quick response to https://github.com/singerdmx/flutter-quill/issues/2284',
+)
+String? convertVideoUrlToId(String url, {bool trimWhitespaces = true}) {
+  if (!url.contains('http') && (url.length == 11)) return url;
+  if (trimWhitespaces) url = url.trim();
+
+  for (final exp in [
+    RegExp(
+        r'^https:\/\/(?:www\.|m\.)?youtube\.com\/watch\?v=([_\-a-zA-Z0-9]{11}).*$'),
+    RegExp(
+        r'^https:\/\/(?:music\.)?youtube\.com\/watch\?v=([_\-a-zA-Z0-9]{11}).*$'),
+    RegExp(
+        r'^https:\/\/(?:www\.|m\.)?youtube\.com\/shorts\/([_\-a-zA-Z0-9]{11}).*$'),
+    RegExp(
+        r'^https:\/\/(?:www\.|m\.)?youtube(?:-nocookie)?\.com\/embed\/([_\-a-zA-Z0-9]{11}).*$'),
+    RegExp(r'^https:\/\/youtu\.be\/([_\-a-zA-Z0-9]{11}).*$')
+  ]) {
+    final Match? match = exp.firstMatch(url);
+    if (match != null && match.groupCount >= 1) return match.group(1);
+  }
+
+  return null;
+}

--- a/flutter_quill_extensions/pubspec.yaml
+++ b/flutter_quill_extensions/pubspec.yaml
@@ -37,11 +37,11 @@ dependencies:
 
   flutter_quill: ^10.7.2
   photo_view: ^0.15.0
+  # TODO: Remove youtube_explode_dart
   youtube_explode_dart: ^2.2.1
 
   # Plugins
   video_player: ^2.8.1
-  youtube_player_flutter: ^9.0.1
   url_launcher: ^6.2.1
   super_clipboard: ^0.8.22
   gal: ^2.3.0


### PR DESCRIPTION
## Description

*Remove `youtube_player_flutter` and `flutter_inappwebview` from `flutter_quill_extensions`, and throw warnings to related classes and features.*

Discussed in #2284


Will give users an error **only in development mode** and warnings until the YouTube issue is solved by overriding `customVideoBuilder` and implementing a custom check to handle YouTube video URLs or also allow them to provide their own Video widget

![image](https://github.com/user-attachments/assets/151b50fa-7c5d-4f22-b421-1d4068332ffc)

<details><summary>Why throw exception inside assert instead of assert failure directly?</summary>
<p>

Assert usually gives very generic details on the screen and is confusing for most users, it indicates to them we have a bug in our code which can also be a usage issue, incorrect or missing configuration, or invalid/unexpected input

![image](https://github.com/user-attachments/assets/27317865-61d0-4f03-8551-ca71b95ff3e6)


Assert failure stack trace gives other details that are not related, making it harder to see the point of the issue. I prefer to not use assert failure extensively. Especially we're using assert without providing clear messages, making it more confusing.


</p>
</details> 

```dart
FlutterQuillEmbeds.editorBuilders(
  videoEmbedConfigurations: QuillEditorVideoEmbedConfigurations(
    // customVideoBuilder is experimental and can be removed or changed in future releases
    customVideoBuilder: (videoUrl, readOnly) {
      // Example: Check for YouTube Video URL and return your
      // YouTube video widget here.

      // Otherwise return null to fallback to the defualt logic
      return null;
    },
    // Optional and will be removed in future releases, exist to allow users to simply display the YouTube URL as link
    ignoreYouTubeSupport: true,
  ),
);
```


## Related Issues

- *Partial Fix #2284*
- *Fix #1888*
- *Fix #2280*
- *Related #2276*
- *Related #1916*
- *Related #989*

## Type of Change

<!--- 

Put an x in all the boxes that apply:

- [x] **Example:**

-->

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [x] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [x] 📝 **Documentation:** Updates or additions to documentation.
- [x] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions

Avoid adding dependencies or transitive plugins if there is no strong reason. Let's not add new features for at least the next year, fixing the current issues is hardly difficult enough as it's really time-consuming, especially with our state.

Currently, we're addressing `super_clipboard` issues by introducing our own simplified implementation in #2230, `flutter_keyboard_visibility` can be next, it hasn't been updated for a while, and support for [Flutter/WASM](https://docs.flutter.dev/platform-integration/web/wasm) is still missing and users expect it. 

If we want to use a plugin, checking the platforms in pub.dev is not enough even if the maintainer has specified the `platforms` property in `pubspec.yaml`, usually it's automatically detected. Even if a platform is supported, not all features are supported, `onGifPaste` was introduced in a PR and it appears that it's only supported on Android and iOS without documenting this or noticing.


[flutter_keyboard_visibility_web](https://github.com/MisterJimson/flutter_keyboard_visibility/blob/42ddef531e437cdd15b7baf270b64c8ae8ce8a28/flutter_keyboard_visibility_web/lib/flutter_keyboard_visibility_web.dart#L19-L23) doesn't support web yet and only require `web` package return `false`