### PR TITLE
chore(deps): update dev dependency flutter_lints to 5.0.0, solve warnings

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,5 @@
 include: package:flutter_lints/flutter.yaml
 
-analyzer:
 linter:
   rules:
     always_declare_return_types: true
@@ -30,3 +29,4 @@ linter:
     unnecessary_lambdas: true
     unnecessary_parenthesis: true
     unnecessary_string_interpolations: true
+    avoid_web_libraries_in_flutter: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,9 +1,6 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
-  errors:
-    undefined_prefixed_name: ignore
-    unsafe_html: ignore
 linter:
   rules:
     always_declare_return_types: true

--- a/dart_quill_delta/pubspec.yaml
+++ b/dart_quill_delta/pubspec.yaml
@@ -15,5 +15,6 @@ dependencies:
   quiver: ^3.2.1
 
 dev_dependencies:
+  # TODO: Using 4.0.0 to not require higher version of Dart SDK
   lints: ^4.0.0
   test: ^1.24.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -66,7 +66,7 @@ dependency_overrides:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^4.0.0
+  flutter_lints: ^5.0.0
   build_runner: ^2.4.8
   flutter_gen_runner: ^5.4.0
 

--- a/flutter_quill_extensions/analysis_options.yaml
+++ b/flutter_quill_extensions/analysis_options.yaml
@@ -1,9 +1,6 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
-  errors:
-    undefined_prefixed_name: ignore
-    unsafe_html: ignore
 linter:
   rules:
     always_declare_return_types: true

--- a/flutter_quill_extensions/analysis_options.yaml
+++ b/flutter_quill_extensions/analysis_options.yaml
@@ -1,6 +1,5 @@
 include: package:flutter_lints/flutter.yaml
 
-analyzer:
 linter:
   rules:
     always_declare_return_types: true
@@ -31,3 +30,4 @@ linter:
     unnecessary_lambdas: true
     unnecessary_parenthesis: true
     unnecessary_string_interpolations: true
+    avoid_web_libraries_in_flutter: true

--- a/flutter_quill_extensions/lib/flutter_quill_extensions.dart
+++ b/flutter_quill_extensions/lib/flutter_quill_extensions.dart
@@ -1,4 +1,4 @@
-library flutter_quill_extensions;
+library;
 
 // ignore: implementation_imports
 import 'package:flutter_quill/src/editor_toolbar_controller_shared/clipboard/clipboard_service_provider.dart';

--- a/flutter_quill_extensions/pubspec.yaml
+++ b/flutter_quill_extensions/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^4.0.0
+  flutter_lints: ^5.0.0
 
 flutter:
   uses-material-design: true

--- a/flutter_quill_test/analysis_options.yaml
+++ b/flutter_quill_test/analysis_options.yaml
@@ -1,9 +1,6 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
-  errors:
-    undefined_prefixed_name: ignore
-    unsafe_html: ignore
 linter:
   rules:
     always_declare_return_types: true

--- a/flutter_quill_test/analysis_options.yaml
+++ b/flutter_quill_test/analysis_options.yaml
@@ -1,6 +1,5 @@
 include: package:flutter_lints/flutter.yaml
 
-analyzer:
 linter:
   rules:
     always_declare_return_types: true
@@ -31,3 +30,4 @@ linter:
     unnecessary_lambdas: true
     unnecessary_parenthesis: true
     unnecessary_string_interpolations: true
+    avoid_web_libraries_in_flutter: true

--- a/flutter_quill_test/lib/flutter_quill_test.dart
+++ b/flutter_quill_test/lib/flutter_quill_test.dart
@@ -1,3 +1,3 @@
-library flutter_quill_test;
+library;
 
 export 'src/test/widget_tester_extension.dart';

--- a/flutter_quill_test/pubspec.yaml
+++ b/flutter_quill_test/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  flutter_lints: ^4.0.0
+  flutter_lints: ^5.0.0
 
 flutter:
   uses-material-design: true

--- a/lib/extensions.dart
+++ b/lib/extensions.dart
@@ -3,7 +3,7 @@
   'to expose certain internal APIs and should not be used directly, as it is subject to breaking changes.\n'
   'The replacement is flutter_quill_internal.dart which is also for internal use only.',
 )
-library flutter_quill.extensions;
+library;
 
 // This file contains exports that are meant to be used
 // internally and are not part of the public API as

--- a/lib/flutter_quill.dart
+++ b/lib/flutter_quill.dart
@@ -1,4 +1,4 @@
-library flutter_quill;
+library;
 
 export 'src/common/structs/horizontal_spacing.dart';
 export 'src/common/structs/image_url.dart';

--- a/lib/quill_delta.dart
+++ b/lib/quill_delta.dart
@@ -1,3 +1,3 @@
-library flutter_quill.delta;
+library;
 
 export 'package:dart_quill_delta/dart_quill_delta.dart';

--- a/lib/translations.dart
+++ b/lib/translations.dart
@@ -1,4 +1,4 @@
-library flutter_quill.translations;
+library;
 
 export 'src/l10n/extensions/localizations_ext.dart';
 export 'src/l10n/widgets/localizations.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,7 +65,7 @@ dependencies:
   quill_native_bridge: '>=10.5.14 <=10.6.2'
 
 dev_dependencies:
-  flutter_lints: ^4.0.0
+  flutter_lints: ^5.0.0
   flutter_test:
     sdk: flutter
   flutter_quill_test: ^10.0.0

--- a/quill_native_bridge/analysis_options.yaml
+++ b/quill_native_bridge/analysis_options.yaml
@@ -1,6 +1,5 @@
 include: package:flutter_lints/flutter.yaml
 
-analyzer:
 linter:
   rules:
     always_declare_return_types: true
@@ -30,3 +29,4 @@ linter:
     unnecessary_lambdas: true
     unnecessary_parenthesis: true
     unnecessary_string_interpolations: true
+    avoid_web_libraries_in_flutter: true

--- a/quill_native_bridge/pubspec.yaml
+++ b/quill_native_bridge/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^4.0.0
+  flutter_lints: ^5.0.0
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

*Update `lints` and `flutter_lints.` to version `5.0.0`*

- Add new rule `avoid_web_libraries_in_flutter` to prevent using dart built-in web libraries in non-web flutter plugin which might cause build failure for non-web platforms if conditional import is not used. This warning will only occur for web imports from Dart and doesn't support [web](https://pub.dev/packages/web). Building the example app in CI is still needed.
- Remove redundant `error` block ignore since it doesn't produce any errors or warnings anymore, seems outdated
- Use the latest version of `flutter_lints` (development dependency) for all packages except `dart_quill_delta`.

This is not a breaking change and is used only during development.

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [x] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.
