### PR TITLE
fix: replace flutter_keyboard_visibility with flutter_keyboard_visibility_temp_fork to support Flutter/Wasm target

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart'
@@ -9,10 +8,6 @@ import 'package:flutter_localizations/flutter_localizations.dart'
 import 'package:flutter_quill/flutter_quill.dart' show Document;
 import 'package:flutter_quill/translations.dart' show FlutterQuillLocalizations;
 import 'package:flutter_quill_extensions/flutter_quill_extensions.dart';
-import 'package:hydrated_bloc/hydrated_bloc.dart'
-    show HydratedBloc, HydratedStorage;
-import 'package:path_provider/path_provider.dart'
-    show getApplicationDocumentsDirectory;
 
 import 'screens/home/widgets/home_screen.dart';
 import 'screens/quill/quill_screen.dart';
@@ -25,11 +20,6 @@ import 'screens/settings/widgets/settings_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  HydratedBloc.storage = await HydratedStorage.build(
-    storageDirectory: kIsWeb
-        ? HydratedStorage.webStorageDirectory
-        : await getApplicationDocumentsDirectory(),
-  );
   // ignore: deprecated_member_use
   FlutterQuillExtensions.useSuperClipboardPlugin();
   runApp(const MyApp());

--- a/example/lib/screens/settings/cubit/settings_cubit.dart
+++ b/example/lib/screens/settings/cubit/settings_cubit.dart
@@ -1,25 +1,15 @@
 import 'package:flutter/material.dart' show ThemeMode;
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:hydrated_bloc/hydrated_bloc.dart' show HydratedCubit;
 
 part 'settings_state.dart';
 part 'settings_cubit.freezed.dart';
 part 'settings_cubit.g.dart';
 
-class SettingsCubit extends HydratedCubit<SettingsState> {
+class SettingsCubit extends Cubit<SettingsState> {
   SettingsCubit() : super(const SettingsState());
 
   void updateSettings(SettingsState newSettingsState) {
     emit(newSettingsState);
-  }
-
-  @override
-  SettingsState? fromJson(Map<String, dynamic> json) {
-    return SettingsState.fromJson(json);
-  }
-
-  @override
-  Map<String, dynamic>? toJson(SettingsState state) {
-    return state.toJson();
   }
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -27,7 +27,6 @@ dependencies:
   # Bloc libraries
   bloc: ^8.1.4
   flutter_bloc: ^8.1.5
-  hydrated_bloc: ^9.1.5
 
   # Freezed
   freezed_annotation: ^2.4.1

--- a/lib/src/controller/quill_controller.dart
+++ b/lib/src/controller/quill_controller.dart
@@ -1,6 +1,5 @@
 import 'dart:math' as math;
 
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/services.dart' show ClipboardData, Clipboard;
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart' show experimental;
@@ -21,9 +20,6 @@ import '../toolbar/config/simple_toolbar_configurations.dart';
 import 'quill_controller_configurations.dart';
 import 'quill_controller_rich_paste.dart';
 
-import 'web/quill_controller_web_stub.dart'
-    if (dart.library.html) 'web/quill_controller_web_real.dart';
-
 typedef ReplaceTextCallback = bool Function(int index, int len, Object? data);
 typedef DeleteCallback = void Function(int cursorPosition, bool forward);
 
@@ -40,11 +36,7 @@ class QuillController extends ChangeNotifier {
     this.readOnly = false,
     this.editorFocusNode,
   })  : _document = document,
-        _selection = selection {
-    if (kIsWeb) {
-      initializeWebPasteEvent();
-    }
-  }
+        _selection = selection;
 
   factory QuillController.basic(
           {QuillControllerConfigurations configurations =
@@ -476,9 +468,6 @@ class QuillController extends ChangeNotifier {
     }
 
     _isDisposed = true;
-    if (kIsWeb) {
-      cancelWebPasteEvent();
-    }
     super.dispose();
   }
 

--- a/lib/src/controller/web/quill_controller_web_real.dart
+++ b/lib/src/controller/web/quill_controller_web_real.dart
@@ -1,38 +1,40 @@
+// TODO: This might be removed from here or moved to quill_native_bridge
+
 // This file should not be exported as the APIs in it are meant for internal usage only
 
-import 'dart:async' show StreamSubscription;
+// import 'dart:async' show StreamSubscription;
 
-import 'package:web/web.dart';
+// import 'package:web/web.dart';
 
-import '../quill_controller.dart';
-// ignore: unused_import
-import '../quill_controller_rich_paste.dart';
+// import '../quill_controller.dart';
+// // ignore: unused_import
+// import '../quill_controller_rich_paste.dart';
 
-/// Paste event for the web.
-///
-/// Will be `null` when [QuillControllerWeb.initializeWebPasteEvent] was not called
-/// or the subscription was canceled due to calling [QuillControllerWeb.cancelWebPasteEvent]
-///
-/// See: https://developer.mozilla.org/en-US/docs/Web/API/Element/paste_event
-StreamSubscription? _webPasteEventSubscription;
+// /// Paste event for the web.
+// ///
+// /// Will be `null` when [QuillControllerWeb.initializeWebPasteEvent] was not called
+// /// or the subscription was canceled due to calling [QuillControllerWeb.cancelWebPasteEvent]
+// ///
+// /// See: https://developer.mozilla.org/en-US/docs/Web/API/Element/paste_event
+// StreamSubscription? _webPasteEventSubscription;
 
-extension QuillControllerWeb on QuillController {
-  void initializeWebPasteEvent() {
-    _webPasteEventSubscription =
-        EventStreamProviders.pasteEvent.forTarget(window.document).listen((e) {
-      // TODO: See if we can support markdown paste
-      final html = e.clipboardData?.getData('text/html');
-      if (html == null) {
-        return;
-      }
-      // TODO: Temporarily disable the rich text pasting feature as a workaround
-      //    due to issue https://github.com/singerdmx/flutter-quill/issues/2220
-      // pasteHTML(html: html);
-    });
-  }
+// extension QuillControllerWeb on QuillController {
+//   void initializeWebPasteEvent() {
+//     _webPasteEventSubscription =
+//         EventStreamProviders.pasteEvent.forTarget(window.document).listen((e) {
+//       // TODO: See if we can support markdown paste
+//       final html = e.clipboardData?.getData('text/html');
+//       if (html == null) {
+//         return;
+//       }
+//       // TODO: Temporarily disable the rich text pasting feature as a workaround
+//       //    due to issue https://github.com/singerdmx/flutter-quill/issues/2220
+//       // pasteHTML(html: html);
+//     });
+//   }
 
-  void cancelWebPasteEvent() {
-    _webPasteEventSubscription?.cancel();
-    _webPasteEventSubscription = null;
-  }
-}
+//   void cancelWebPasteEvent() {
+//     _webPasteEventSubscription?.cancel();
+//     _webPasteEventSubscription = null;
+//   }
+// }

--- a/lib/src/controller/web/quill_controller_web_real.dart
+++ b/lib/src/controller/web/quill_controller_web_real.dart
@@ -1,4 +1,8 @@
 // TODO: This might be removed from here or moved to quill_native_bridge
+//  commented in https://github.com/singerdmx/flutter-quill/pull/2293
+//  removed due to bug https://github.com/singerdmx/flutter-quill/issues/2220
+//  added to solve https://github.com/singerdmx/flutter-quill/issues/1998#issuecomment-2361599854
+
 
 // This file should not be exported as the APIs in it are meant for internal usage only
 
@@ -22,7 +26,6 @@
 //   void initializeWebPasteEvent() {
 //     _webPasteEventSubscription =
 //         EventStreamProviders.pasteEvent.forTarget(window.document).listen((e) {
-//       // TODO: See if we can support markdown paste
 //       final html = e.clipboardData?.getData('text/html');
 //       if (html == null) {
 //         return;

--- a/lib/src/controller/web/quill_controller_web_real.dart
+++ b/lib/src/controller/web/quill_controller_web_real.dart
@@ -3,7 +3,6 @@
 //  removed due to bug https://github.com/singerdmx/flutter-quill/issues/2220
 //  added to solve https://github.com/singerdmx/flutter-quill/issues/1998#issuecomment-2361599854
 
-
 // This file should not be exported as the APIs in it are meant for internal usage only
 
 // import 'dart:async' show StreamSubscription;

--- a/lib/src/controller/web/quill_controller_web_stub.dart
+++ b/lib/src/controller/web/quill_controller_web_stub.dart
@@ -1,20 +1,23 @@
-// This file should not be exported as the APIs in it are meant for internal usage only
+// See quill_controller_web_real.dart if you want to know why this is not removed yet 
+// will be addressed in future releases.
 
-import '../quill_controller.dart';
+// // This file should not be exported as the APIs in it are meant for internal usage only
 
-// This is a mock implementation to compile the app on non-web platforms.
-// The real implementation is quill_controller_web_real.dart
+// import '../quill_controller.dart';
 
-extension QuillControllerWeb on QuillController {
-  void initializeWebPasteEvent() {
-    throw UnsupportedError(
-      'The initializeWebPasteEvent() method should be called only on web.',
-    );
-  }
+// // This is a mock implementation to compile the app on non-web platforms.
+// // The real implementation is quill_controller_web_real.dart
 
-  void cancelWebPasteEvent() {
-    throw UnsupportedError(
-      'The closeWebPasteEvent() method should be called only on web.',
-    );
-  }
-}
+// extension QuillControllerWeb on QuillController {
+//   void initializeWebPasteEvent() {
+//     throw UnsupportedError(
+//       'The initializeWebPasteEvent() method should be called only on web.',
+//     );
+//   }
+
+//   void cancelWebPasteEvent() {
+//     throw UnsupportedError(
+//       'The closeWebPasteEvent() method should be called only on web.',
+//     );
+//   }
+// }

--- a/lib/src/controller/web/quill_controller_web_stub.dart
+++ b/lib/src/controller/web/quill_controller_web_stub.dart
@@ -1,4 +1,4 @@
-// See quill_controller_web_real.dart if you want to know why this is not removed yet 
+// See quill_controller_web_real.dart if you want to know why this is not removed yet
 // will be addressed in future releases.
 
 // // This file should not be exported as the APIs in it are meant for internal usage only

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -10,7 +10,7 @@ import 'package:flutter/rendering.dart' show RenderAbstractViewport;
 import 'package:flutter/scheduler.dart' show SchedulerBinding;
 import 'package:flutter/services.dart'
     show Clipboard, HardwareKeyboard, SystemChannels, TextInputControl;
-import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart'
+import 'package:flutter_keyboard_visibility_temp_fork/flutter_keyboard_visibility_temp_fork.dart'
     show KeyboardVisibilityController;
 
 import '../../common/structs/horizontal_spacing.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,6 @@ dependencies:
   equatable: ^2.0.5
   meta: ^1.10.0
   html: ^0.15.4
-  web: ^1.0.0
 
   flutter_colorpicker: ^1.1.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,7 +61,7 @@ dependencies:
 
   # Plugins
   url_launcher: ^6.2.4
-  flutter_keyboard_visibility: ^6.0.0
+  flutter_keyboard_visibility_temp_fork: ^0.1.1
   quill_native_bridge: '>=10.5.14 <=10.6.2'
 
 dev_dependencies:


### PR DESCRIPTION
## Description

*Replace [flutter_keyboard_visibility](https://pub.dev/packages/flutter_keyboard_visibility) with [flutter_keyboard_visibility_temp_fork](https://pub.dev/packages/flutter_keyboard_visibility_temp_fork) to support [Flutter/Wasm](https://docs.flutter.dev/platform-integration/web/wasm) target.*

This is not a future-proof solution and we should replace the plugin, we might have our own solution in `quill_native_bridge` or develop a separate plugin.

## Related Issues

<!-- *e.g.* -->
- *Fix #1889*
- *Partial fix https://github.com/MisterJimson/flutter_keyboard_visibility/issues/163*
- *Related #2290*

## Type of Change

<!--- 

Put an x in all the boxes that apply:

- [x] **Example:**

-->

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.