### PR TITLE
fix(example): build failure on Android with latest version of Android Studio Ladybug

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -29,8 +29,12 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+      sourceCompatibility = JavaVersion.VERSION_17
+      targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,6 @@
 org.gradle.jvmargs=-Xmx4G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "com.android.application" version '8.3.1' apply false
+    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 
 include ":app"

--- a/flutter_quill_extensions/pubspec.yaml
+++ b/flutter_quill_extensions/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
 
   # Plugins
   video_player: ^2.9.2
-  # TODO: A warning causing build failure https://github.com/flutter/packages/blob/4afc383a6db56cb969af5d8ad02a1a0220758b66/packages/video_player/video_player_android/android/build.gradle#L34
+  # TODO: A warning causing build failure due to usage of `-Werror` related to Java 8 support.
   # Related https://github.com/flutter/packages/pull/7795
   video_player_android: ^2.7.9
   url_launcher: ^6.2.1

--- a/flutter_quill_extensions/pubspec.yaml
+++ b/flutter_quill_extensions/pubspec.yaml
@@ -41,10 +41,7 @@ dependencies:
   youtube_explode_dart: ^2.2.1
 
   # Plugins
-  video_player: ^2.9.2
-  # TODO: A warning causing build failure due to usage of `-Werror` related to Java 8 support.
-  # Related https://github.com/flutter/packages/pull/7795
-  video_player_android: ^2.7.9
+  video_player: ^2.8.1
   url_launcher: ^6.2.1
   super_clipboard: ^0.8.22
   gal: ^2.3.0

--- a/flutter_quill_extensions/pubspec.yaml
+++ b/flutter_quill_extensions/pubspec.yaml
@@ -41,7 +41,10 @@ dependencies:
   youtube_explode_dart: ^2.2.1
 
   # Plugins
-  video_player: ^2.8.1
+  video_player: ^2.9.2
+  # TODO: A warning causing build failure https://github.com/flutter/packages/blob/4afc383a6db56cb969af5d8ad02a1a0220758b66/packages/video_player/video_player_android/android/build.gradle#L34
+  # Related https://github.com/flutter/packages/pull/7795
+  video_player_android: ^2.7.9
   url_launcher: ^6.2.1
   super_clipboard: ^0.8.22
   gal: ^2.3.0


### PR DESCRIPTION
## Description

*Fix build failure when running the Android example.*

Updating Android Studio to the latest version (Ladybug 2024.2.1) will cause compilation issues since the minimum Gradle version that supports Java 21 (which is the new bundled JDK with Android Studio) is at least 8.5 or newer, updating Gradle requires updating Android Gradle Plugin and some related build configuration on Android, some plugins do require targeting at least Java 17, also building the app with Java 21 will give you warnings since support for Java 8 has been deprecated and will be removed in future releases. Flutter plugins is currently updating to target Java 11. 

~~`video_player` causes build failure if warnings are found, updating the minimum version of `video_player` and `video_player_android` to fix this issue.~~ Reverted the change, instead developers are required to run `flutter pub upgrade`

## Related Issues

- *Related https://github.com/flutter/flutter/issues/156111*

## Type of Change

<!--- 

Put an x in all the boxes that apply:

- [x] **Example:**

-->

- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [x] 🗑️ **Chore:** Routine tasks, or maintenance.
- [x] ✅ **Build configuration change:** Changes to build or deploy processes.