### PR TITLE
custom HTTP headers for network images

### DIFF
--- a/flutter_quill_extensions/lib/src/editor/image/image_embed.dart
+++ b/flutter_quill_extensions/lib/src/editor/image/image_embed.dart
@@ -50,6 +50,7 @@ class QuillEditorImageEmbedBuilder extends EmbedBuilder {
       width: width,
       assetsPrefix: QuillSharedExtensionsConfigurations.get(context: context)
           .assetsPrefix,
+      networkImageHeaders: configurations.networkImageHeaders,
     );
 
     final imageSaverService =

--- a/flutter_quill_extensions/lib/src/editor/image/models/image_configurations.dart
+++ b/flutter_quill_extensions/lib/src/editor/image/models/image_configurations.dart
@@ -17,6 +17,7 @@ class QuillEditorImageEmbedConfigurations {
     this.imageProviderBuilder,
     this.imageErrorWidgetBuilder,
     this.onImageClicked,
+    this.networkImageHeaders,
   }) : _onImageRemovedCallback = onImageRemovedCallback;
 
   /// [onImageRemovedCallback] is called when an image is
@@ -105,6 +106,28 @@ class QuillEditorImageEmbedConfigurations {
   /// By default will show `ImageOptionsMenu` dialog. If you want to handle what happens
   /// to the image when it's clicked, you can pass a callback to this property.
   final void Function(String imageSource)? onImageClicked;
+
+  /// Custom HTTP Headers to be used when fetching images from the network
+  /// This is useful when you want to add custom headers to the image request
+  /// For example, you can add an Authorization header to the request
+  /// to fetch images from a private server
+  /// ```dart
+  /// final headers = {
+  ///  'Authorization': 'Bearer $token',
+  /// };
+  /// ```
+  /// Then pass the headers to the configurations
+  /// ```dart
+  /// final imageConfigurations = QuillEditorImageEmbedConfigurations(
+  ///  networkImageHeaders: headers,
+  /// );
+  /// ```
+  /// The headers will be used when fetching images from the network
+  /// and will be passed to the `NetworkImage` provider
+  /// ```dart
+  /// final imageProvider = NetworkImage(imageUrl, headers: networkImageHeaders);
+  /// ```
+  final Map<String, String>? networkImageHeaders;
 
   static ImageEmbedBuilderOnRemovedCallback get defaultOnImageRemovedCallback {
     return (imageUrl) async {

--- a/flutter_quill_extensions/lib/src/editor/image/widgets/image.dart
+++ b/flutter_quill_extensions/lib/src/editor/image/widgets/image.dart
@@ -37,6 +37,7 @@ ImageProvider getImageProviderByImageSource(
   String imageSource, {
   required ImageEmbedBuilderProviderBuilder? imageProviderBuilder,
   required String assetsPrefix,
+  required Map<String, String>? networkImageHeaders,
   required BuildContext context,
 }) {
   if (imageProviderBuilder != null) {
@@ -48,7 +49,7 @@ ImageProvider getImageProviderByImageSource(
   }
 
   if (isHttpBasedUrl(imageSource)) {
-    return NetworkImage(imageSource);
+    return NetworkImage(imageSource, headers: networkImageHeaders);
   }
 
   if (imageSource.startsWith(assetsPrefix)) {
@@ -57,7 +58,7 @@ ImageProvider getImageProviderByImageSource(
 
   // File image
   if (kIsWeb) {
-    return NetworkImage(imageSource);
+    return NetworkImage(imageSource, headers: networkImageHeaders);
   }
   return FileImage(File(imageSource));
 }
@@ -71,12 +72,14 @@ Image getImageWidgetByImageSource(
   double? width,
   double? height,
   AlignmentGeometry alignment = Alignment.center,
+  Map<String, String>? networkImageHeaders,
 }) {
   return Image(
     image: getImageProviderByImageSource(
       context: context,
       imageSource,
       imageProviderBuilder: imageProviderBuilder,
+      networkImageHeaders: networkImageHeaders,
       assetsPrefix: assetsPrefix,
     ),
     width: width,

--- a/flutter_quill_extensions/lib/src/editor/image/widgets/image.dart
+++ b/flutter_quill_extensions/lib/src/editor/image/widgets/image.dart
@@ -37,7 +37,7 @@ ImageProvider getImageProviderByImageSource(
   String imageSource, {
   required ImageEmbedBuilderProviderBuilder? imageProviderBuilder,
   required String assetsPrefix,
-  required Map<String, String>? networkImageHeaders,
+  Map<String, String>? networkImageHeaders,
   required BuildContext context,
 }) {
   if (imageProviderBuilder != null) {


### PR DESCRIPTION
<!-- 

Thank you for contributing.

Provide a description of your changes below and a general summary in the title.

Consider reading the Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md.

The changes of `CHANGELOG.md` and package version in `pubspec.yaml` are automated.

-->

## Description
Allow users to pass custom HTTP headers when accessing network images.

## Related Issues


<!--

Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/singerdmx/flutter-quill/issues). Indicate, which of these issues are resolved or fixed by this PR.

-->

<!-- *e.g.* -->

- *Related #1243*

## Type of Change

<!--- 

Put an x in all the boxes that apply:

- [x] **Example:**

-->

- [x] ✨ **New feature:** Adds new functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.

## Suggestions

<!-- Optional -->