### PR TITLE
fix!: remove super_clipboard from flutter_quill_extensions and move it to quill_super_clipboard

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -39,7 +39,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.example"
-        minSdk = 23
+        minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutterVersionCode.toInteger()
         versionName = flutterVersionName

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -56,13 +56,6 @@
             android:name="flutterEmbedding"
             android:value="2" />
 
-        <!--  For `super_clipboard` plugin https://pub.dev/packages/super_clipboard -->
-        <provider
-            android:name="com.superlist.super_native_extensions.DataProvider"
-            android:authorities="com.example.example.SuperClipboardDataProvider"
-            android:exported="true"
-            android:grantUriPermissions="true" />
-
         <!-- For `quill_native_bridge` plugin https://github.com/FlutterQuill/quill-native-bridge/tree/main/quill_native_bridge#-platform-configuration -->
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/example/linux/flutter/generated_plugin_registrant.cc
+++ b/example/linux/flutter/generated_plugin_registrant.cc
@@ -8,8 +8,6 @@
 
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <file_selector_linux/file_selector_plugin.h>
-#include <irondash_engine_context/irondash_engine_context_plugin.h>
-#include <super_native_extensions/super_native_extensions_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -19,12 +17,6 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
-  g_autoptr(FlPluginRegistrar) irondash_engine_context_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "IrondashEngineContextPlugin");
-  irondash_engine_context_plugin_register_with_registrar(irondash_engine_context_registrar);
-  g_autoptr(FlPluginRegistrar) super_native_extensions_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "SuperNativeExtensionsPlugin");
-  super_native_extensions_plugin_register_with_registrar(super_native_extensions_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/example/linux/flutter/generated_plugins.cmake
+++ b/example/linux/flutter/generated_plugins.cmake
@@ -5,8 +5,6 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   desktop_drop
   file_selector_linux
-  irondash_engine_context
-  super_native_extensions
   url_launcher_linux
 )
 

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,29 +6,23 @@ import FlutterMacOS
 import Foundation
 
 import desktop_drop
-import device_info_plus
 import file_selector_macos
 import gal
-import irondash_engine_context
 import path_provider_foundation
 import quill_native_bridge_macos
 import share_plus
-import sqflite_darwin
-import super_native_extensions
+import sqflite
 import url_launcher_macos
 import video_player_avfoundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
-  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
-  IrondashEngineContextPlugin.register(with: registry.registrar(forPlugin: "IrondashEngineContextPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   QuillNativeBridgePlugin.register(with: registry.registrar(forPlugin: "QuillNativeBridgePlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
-  SuperNativeExtensionsPlugin.register(with: registry.registrar(forPlugin: "SuperNativeExtensionsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))
 }

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1,15 +1,11 @@
 PODS:
   - desktop_drop (0.0.1):
     - FlutterMacOS
-  - device_info_plus (0.0.1):
-    - FlutterMacOS
   - file_selector_macos (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - gal (1.0.0):
     - Flutter
-    - FlutterMacOS
-  - irondash_engine_context (0.0.1):
     - FlutterMacOS
   - path_provider_foundation (0.0.1):
     - Flutter
@@ -21,8 +17,6 @@ PODS:
   - sqflite (0.0.3):
     - Flutter
     - FlutterMacOS
-  - super_native_extensions (0.0.1):
-    - FlutterMacOS
   - url_launcher_macos (0.0.1):
     - FlutterMacOS
   - video_player_avfoundation (0.0.1):
@@ -31,32 +25,25 @@ PODS:
 
 DEPENDENCIES:
   - desktop_drop (from `Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos`)
-  - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
   - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - gal (from `Flutter/ephemeral/.symlinks/plugins/gal/darwin`)
-  - irondash_engine_context (from `Flutter/ephemeral/.symlinks/plugins/irondash_engine_context/macos`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - quill_native_bridge_macos (from `Flutter/ephemeral/.symlinks/plugins/quill_native_bridge_macos/macos`)
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - sqflite (from `Flutter/ephemeral/.symlinks/plugins/sqflite/darwin`)
-  - super_native_extensions (from `Flutter/ephemeral/.symlinks/plugins/super_native_extensions/macos`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
   - video_player_avfoundation (from `Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin`)
 
 EXTERNAL SOURCES:
   desktop_drop:
     :path: Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos
-  device_info_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
   file_selector_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
   gal:
     :path: Flutter/ephemeral/.symlinks/plugins/gal/darwin
-  irondash_engine_context:
-    :path: Flutter/ephemeral/.symlinks/plugins/irondash_engine_context/macos
   path_provider_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
   quill_native_bridge_macos:
@@ -65,8 +52,6 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   sqflite:
     :path: Flutter/ephemeral/.symlinks/plugins/sqflite/darwin
-  super_native_extensions:
-    :path: Flutter/ephemeral/.symlinks/plugins/super_native_extensions/macos
   url_launcher_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
   video_player_avfoundation:
@@ -74,17 +59,14 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   desktop_drop: 69eeff437544aa619c8db7f4481b3a65f7696898
-  device_info_plus: ce1b7762849d3ec103d0e0517299f2db7ad60720
-  file_selector_macos: 54fdab7caa3ac3fc43c9fac4d7d8d231277f8cf2
+  file_selector_macos: cc3858c981fe6889f364731200d6232dac1d812d
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   gal: 61e868295d28fe67ffa297fae6dacebf56fd53e1
-  irondash_engine_context: da62996ee25616d2f01bbeb85dc115d813359478
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   quill_native_bridge_macos: f90985c5269ac7ba84d933605b463d96e5f544fe
   share_plus: 36537c04ce0c3e3f5bd297ce4318b6d5ee5fd6cf
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
-  super_native_extensions: 85efee3a7495b46b04befcfc86ed12069264ebf3
-  url_launcher_macos: 5f437abeda8c85500ceb03f5c1938a8c5a705399
+  url_launcher_macos: c82c93949963e55b228a30115bd219499a6fe404
   video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3
 
 PODFILE CHECKSUM: 7159dd71cf9f57a5669bb2dee7a5030dbcc0483f

--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -9,9 +9,7 @@
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <gal/gal_plugin_c_api.h>
-#include <irondash_engine_context/irondash_engine_context_plugin_c_api.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
-#include <super_native_extensions/super_native_extensions_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
@@ -21,12 +19,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   GalPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("GalPluginCApi"));
-  IrondashEngineContextPluginCApiRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("IrondashEngineContextPluginCApi"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
-  SuperNativeExtensionsPluginCApiRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("SuperNativeExtensionsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -6,9 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   desktop_drop
   file_selector_windows
   gal
-  irondash_engine_context
   share_plus
-  super_native_extensions
   url_launcher_windows
 )
 

--- a/flutter_quill_extensions/lib/flutter_quill_extensions.dart
+++ b/flutter_quill_extensions/lib/flutter_quill_extensions.dart
@@ -4,8 +4,6 @@ import 'package:flutter_quill/flutter_quill_internal.dart'
     show ClipboardServiceProvider;
 import 'package:meta/meta.dart' show experimental;
 
-import 'src/editor_toolbar_controller_shared/clipboard/super_clipboard_service.dart';
-
 export 'src/common/extensions/controller_ext.dart';
 export 'src/common/utils/utils.dart';
 export 'src/editor/image/image_embed.dart';
@@ -67,11 +65,13 @@ class FlutterQuillExtensions {
     'The functionality of super_clipboard is now built-in in recent versions of flutter_quill.\n'
     'To migrate, remove this function call and see '
     'https://pub.dev/packages/quill_native_bridge#-platform-configuration (optional for copying images on Android) to use quill_native_bridge implementation (the new default).\n'
-    'Or if you want to use super_clipboard implementation (support might discontinued in newer versions), use the package https://pub.dev/packages/quill_super_clipboard\n'
+    'Or if you want to use super_clipboard implementation (support might discontinued in newer versions), use the experimental package: https://pub.dev/packages/quill_super_clipboard\n'
     'See https://github.com/singerdmx/flutter-quill/pull/2230 for more details.',
   )
   @experimental
   static void useSuperClipboardPlugin() {
-    ClipboardServiceProvider.setInstance(SuperClipboardService());
+    throw UnimplementedError(
+      'The super_clipboard plugin is no longer a dependency. See the deprecation message of FlutterQuillExtensions.useSuperClipboardPlugin()',
+    );
   }
 }

--- a/flutter_quill_extensions/lib/src/editor_toolbar_controller_shared/clipboard/super_clipboard_service.dart
+++ b/flutter_quill_extensions/lib/src/editor_toolbar_controller_shared/clipboard/super_clipboard_service.dart
@@ -1,144 +1,16 @@
-import 'dart:async' show Completer;
-import 'dart:convert' show utf8;
+@Deprecated(
+  'The super_clipboard implementation has been moved into a separate package: https://pub.dev/packages/quill_super_clipboard and this class will be removed in future releases.\n'
+  'The new default implementation of flutter_quill is https://pub.dev/packages/quill_native_bridge and supports required features for rich text pasting.\n'
+  'Also see https://github.com/singerdmx/flutter-quill/pull/2230 and https://pub.dev/packages/quill_native_bridge#-platform-configuration',
+)
+library;
 
-import 'package:flutter/foundation.dart';
-import 'package:flutter_quill/flutter_quill_internal.dart'
-    show ClipboardService;
 import 'package:meta/meta.dart' show experimental;
 
-import 'package:super_clipboard/super_clipboard.dart';
-
-/// Implementation using the https://pub.dev/packages/super_clipboard plugin.
 @experimental
-class SuperClipboardService extends ClipboardService {
-  /// [Null] if the Clipboard API is not supported on this platform
-  /// https://pub.dev/packages/super_clipboard#usage
-  SystemClipboard? _getSuperClipboard() {
-    return SystemClipboard.instance;
-  }
-
-  SystemClipboard _getSuperClipboardOrThrow() {
-    final clipboard = _getSuperClipboard();
-    if (clipboard == null) {
-      // To avoid getting this exception, use _canProvide()
-      throw UnsupportedError(
-        'Clipboard API is not supported on this platform.',
-      );
-    }
-    return clipboard;
-  }
-
-  Future<bool> _canProvide({required DataFormat format}) async {
-    final clipboard = _getSuperClipboard();
-    if (clipboard == null) {
-      return false;
-    }
-    final reader = await clipboard.read();
-    return reader.canProvide(format);
-  }
-
-  Future<Uint8List> _provideFileAsBytes({
-    required SimpleFileFormat format,
-  }) async {
-    final clipboard = _getSuperClipboardOrThrow();
-    final reader = await clipboard.read();
-    final completer = Completer<Uint8List>();
-
-    reader.getFile(
-      format,
-      (file) async {
-        final bytes = await file.readAll();
-        completer.complete(bytes);
-      },
-      onError: completer.completeError,
-    );
-    final bytes = await completer.future;
-    return bytes;
-  }
-
-  Future<String> _provideFileAsString({
-    required SimpleFileFormat format,
-  }) async {
-    final fileBytes = await _provideFileAsBytes(format: format);
-    final fileText = utf8.decode(fileBytes);
-    return fileText;
-  }
-
-  /// According to super_clipboard docs, will return `null` if the value
-  /// is not available or the data is virtual (macOS and Windows)
-  Future<String?> _provideSimpleValueFormatAsString({
-    required SimpleValueFormat<String> format,
-  }) async {
-    final clipboard = _getSuperClipboardOrThrow();
-    final reader = await clipboard.read();
-    final value = await reader.readValue<String>(format);
-    return value;
-  }
-
-  @override
-  Future<String?> getHtmlText() async {
-    if (!(await _canProvide(format: Formats.htmlText))) {
-      return null;
-    }
-    return _provideSimpleValueFormatAsString(format: Formats.htmlText);
-  }
-
-  @override
-  Future<String?> getHtmlFile() async {
-    if (!(await _canProvide(format: Formats.htmlFile))) {
-      return null;
-    }
-    return await _provideFileAsString(format: Formats.htmlFile);
-  }
-
-  @override
-  Future<Uint8List?> getGifFile() async {
-    if (!(await _canProvide(format: Formats.gif))) {
-      return null;
-    }
-    return await _provideFileAsBytes(format: Formats.gif);
-  }
-
-  @override
-  Future<Uint8List?> getImageFile() async {
-    final canProvidePngFile = await _canProvide(format: Formats.png);
-    if (canProvidePngFile) {
-      return _provideFileAsBytes(format: Formats.png);
-    }
-    final canProvideJpegFile = await _canProvide(format: Formats.jpeg);
-    if (canProvideJpegFile) {
-      return _provideFileAsBytes(format: Formats.jpeg);
-    }
-    return null;
-  }
-
-  @override
-  Future<String?> getMarkdownFile() async {
-    // Formats.md is for markdown files
-    if (!(await _canProvide(format: Formats.md))) {
-      return null;
-    }
-    return await _provideFileAsString(format: Formats.md);
-  }
-
-  @override
-  Future<void> copyImage(Uint8List imageBytes) async {
-    final clipboard = SystemClipboard.instance;
-    if (clipboard == null) {
-      return;
-    }
-    final item = DataWriterItem()..add(Formats.png(imageBytes));
-    await clipboard.write([item]);
-  }
-
-  @override
-  Future<bool> get hasClipboardContent async {
-    final clipboard = _getSuperClipboard();
-    if (clipboard == null) {
-      return false;
-    }
-    final reader = await clipboard.read();
-    final availablePlatformFormats = reader.platformFormats;
-    return availablePlatformFormats.isNotEmpty;
-  }
-}
+@Deprecated(
+  'The super_clipboard implementation has been moved into a separate package: https://pub.dev/packages/quill_super_clipboard and this class will be removed in future releases.\n'
+  'The new default implementation of flutter_quill is https://pub.dev/packages/quill_native_bridge and supports required features for rich text pasting.\n'
+  'Also see https://github.com/singerdmx/flutter-quill/pull/2230 and https://pub.dev/packages/quill_native_bridge#-platform-configuration',
+)
+class SuperClipboardService {}

--- a/flutter_quill_extensions/pubspec.yaml
+++ b/flutter_quill_extensions/pubspec.yaml
@@ -43,7 +43,6 @@ dependencies:
   # Plugins
   video_player: ^2.8.1
   url_launcher: ^6.2.1
-  super_clipboard: ^0.8.22
   gal: ^2.3.0
   gal_linux: ^0.1.0
   image_picker: ^1.0.4


### PR DESCRIPTION
## Description

*Moving [`super_clipboard`](https://pub.dev/packages/super_clipboard) dependency from [flutter_quill_extensions](https://pub.dev/packages/flutter_quill_extensions) to [quill_super_clipboard](https://pub.dev/packages/quill_super_clipboard).*

## Minor breaking change

Unfortunately, this is a breaking change, while it doesn't require changes in Dart code, it requires removing the following from `AndroidManifest.xml` if was configured to launch the app:

```xml
<manifest>
    <application>
        ...
        <provider
            android:name="com.superlist.super_native_extensions.DataProvider"
            android:authorities="<your-package-name>.SuperClipboardDataProvider"
            android:exported="true"
            android:grantUriPermissions="true" >
        </provider>
        ...
    </application>
</manifest>
```

The new default implementation (#2230) uses [quill_native_bridge](https://pub.dev/packages/quill_native_bridge) which supports all the features that are used by `flutter_quill` and was made to avoid introducing a breaking change (changing the previous behavior), though I have missed that the required provider in `AndroidManifest.xml` is in [super_native_extensions](https://pub.dev/packages/super_native_extensions), removing `super_clipboard` also removes `super_native_extensions` and that plugin has the class `com.superlist.super_native_extensions.DataProvider` which doesn't exist anymore, you will be unable to run the app.


## Migration

Remove the following if used:

```dart
FlutterQuillExtensions.useSuperClipboardPlugin();
```

### A. Using the new default implementation

The [android configuration of `super_clipboard`](https://pub.dev/packages/super_clipboard#android-support) is no longer required.

The following snippet should be removed otherwise you will be unable to launch the app:

```xml
<provider
            android:name="com.superlist.super_native_extensions.DataProvider"
            android:authorities="<your-package-name>.SuperClipboardDataProvider"
            android:exported="true"
            android:grantUriPermissions="true" >
        </provider>
```

<details><summary>The error will be encountered when not removing this</summary>
<p>

```console
FATAL EXCEPTION: main
                                                                                                    Process: com.example.example, PID: 7599
                                                                                                    java.lang.RuntimeException: Unable to get provider com.superlist.super_native_extensions.DataProvider: java.lang.ClassNotFoundException: Didn't find class "com.superlist.super_native_extensions.DataProvider" on path: DexPathList[[zip file "/data/app/~~Yk9JiyN7v_IE-XPUxHRzoQ==/com.example.example-2lizZbVWfYqolC9W579Crg==/base.apk"],nativeLibraryDirectories=[/data/app/~~Yk9JiyN7v_IE-XPUxHRzoQ==/com.example.example-2lizZbVWfYqolC9W579Crg==/lib/arm64, /data/app/~~Yk9JiyN7v_IE-XPUxHRzoQ==/com.example.example-2lizZbVWfYqolC9W579Crg==/base.apk!/lib/arm64-v8a, /system/lib64, /system_ext/lib64]]
                                                                                                    	at android.app.ActivityThread.installProvider(ActivityThread.java:7770)
                                                                                                    	at android.app.ActivityThread.installContentProviders(ActivityThread.java:7276)
                                                                                                    	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6983)
                                                                                                    	at android.app.ActivityThread.-$$Nest$mhandleBindApplication(Unknown Source:0)
                                                                                                    	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2236)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:106)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:205)
                                                                                                    	at android.os.Looper.loop(Looper.java:294)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8177)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
                                                                                                    Caused by: java.lang.ClassNotFoundException: Didn't find class "com.superlist.super_native_extensions.DataProvider" on path: DexPathList[[zip file "/data/app/~~Yk9JiyN7v_IE-XPUxHRzoQ==/com.example.example-2lizZbVWfYqolC9W579Crg==/base.apk"],nativeLibraryDirectories=[/data/app/~~Yk9JiyN7v_IE-XPUxHRzoQ==/com.example.example-2lizZbVWfYqolC9W579Crg==/lib/arm64, /data/app/~~Yk9JiyN7v_IE-XPUxHRzoQ==/com.example.example-2lizZbVWfYqolC9W579Crg==/base.apk!/lib/arm64-v8a, /system/lib64, /system_ext/lib64]]
                                                                                                    	at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:259)
                                                                                                    	at java.lang.ClassLoader.loadClass(ClassLoader.java:379)
                                                                                                    	at java.lang.ClassLoader.loadClass(ClassLoader.java:312)
                                                                                                    	at android.app.AppComponentFactory.instantiateProvider(AppComponentFactory.java:147)
                                                                                                    	at androidx.core.app.CoreComponentFactory.instantiateProvider(CoreComponentFactory.java:66)
                                                                                                    	at android.app.ActivityThread.installProvider(ActivityThread.java:7754)
                                                                                                    	at android.app.ActivityThread.installContentProviders(ActivityThread.java:7276) 
                                                                                                    	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6983) 
                                                                                                    	at android.app.ActivityThread.-$$Nest$mhandleBindApplication(Unknown Source:0) 
                                                                                                    	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2236) 
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:106) 
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:205) 
                                                                                                    	at android.os.Looper.loop(Looper.java:294) 
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8177) 
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method) 
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552) 
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971) 
```

</p>
</details> 

See the [`quill_native_bridge` platform configuration](https://pub.dev/packages/quill_native_bridge#-platform-configuration) (optional for copying images on Android).

#### Other Optional changes

- Use the Flutter default `minSdkVersion`:

```kotlin
android {
  defaultConfig {
   minSdk = flutter.minSdkVersion
 }
}
```

- Use the Flutter default `ndkVersion`:

```kotlin
android {
  ndkVersion = flutter.ndkVersion
}
```

### B. Continue using the `super_clipboard` implementation

Use the new default implementation or if you want to continue using `super_clipboard`, use the package [quill_super_clipboard](https://pub.dev/packages/quill_super_clipboard) (**support might be discontinued in future releases**).

## Related Issues

- *Fix #2129 and related issues*
- *Related #2230*
- *Related #1914*

## Type of Change

- [x] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [x] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [x] 📝 **Documentation:** Updates or additions to documentation.
- [x] 🗑️ **Chore:** Routine tasks, or maintenance.
- [x] ✅ **Build configuration change:** Changes to build or deploy processes.
