### PR TITLE
fix: allow all correct URLs to be formatted

### DIFF
--- a/lib/src/rules/insert.dart
+++ b/lib/src/rules/insert.dart
@@ -343,7 +343,6 @@ class AutoFormatMultipleLinksRule extends InsertRule {
   /// This pattern is used to match a links within a text segment.
   ///
   /// It works for the following testing URLs:
-  // www.google.com
   // http://google.com
   // https://www.google.com
   // http://beginner.example.edu/#act
@@ -364,9 +363,9 @@ class AutoFormatMultipleLinksRule extends InsertRule {
   // URL generator tool (https://www.randomlists.com/urls) is used.
 
   static const _oneLineLinkPattern =
-      r'^https?:\/\/[\w\-]+(\.[\w\-]+)*(:\d+)?(\/.*)?$';
+      r'^https?:\/\/[\w\-]+(\.[\w\-]+)*(:\d+)?([\/\?#].*)?$';
   static const _detectLinkPattern =
-      r'https?:\/\/[\w\-]+(\.[\w\-]+)*(:\d+)?(\/[^\s]*)?';
+      r'https?:\/\/[\w\-]+(\.[\w\-]+)*(:\d+)?([\/\?#][^\s]*)?';
 
   /// It requires a valid link in one link
   RegExp get oneLineLinkRegExp => RegExp(

--- a/test/rules/insert_test.dart
+++ b/test/rules/insert_test.dart
@@ -286,4 +286,45 @@ void main() {
           reason: 'Insertion within link label updates label');
     });
   });
+
+  group('AutoFormatMultipleLinksRule', () {
+    const rule = AutoFormatMultipleLinksRule();
+
+    final validLinks = [
+      'http://google.com',
+      'https://www.google.com',
+      'http://beginner.example.edu/#act',
+      'http://beginner.example.edu#act',
+      'https://birth.example.net/beds/ants.php#bait',
+      'http://example.com/babies',
+      'https://www.example.com/',
+      'https://attack.example.edu/?acoustics=blade&bed=bed',
+      'https://attack.example.edu?acoustics=blade&bed=bed',
+      'http://basketball.example.com/',
+      'https://birthday.example.com/birthday',
+      'http://www.example.com/',
+      'https://example.com/addition/action',
+      'http://example.com/',
+      'https://bite.example.net/#adjustment',
+      'https://bite.example.net#adjustment',
+      'http://www.example.net/badge.php?bedroom=anger',
+      'https://brass.example.com/?anger=branch&actor=amusement#adjustment',
+      'https://brass.example.com?anger=branch&actor=amusement#adjustment',
+      'http://www.example.com/?action=birds&brass=apparatus',
+      'http://www.example.com?action=birds&brass=apparatus',
+      'https://example.net/',
+    ];
+
+    test('Insert link in text', () {
+      final delta = Delta()..insert('\n');
+      final document = Document.fromDelta(delta);
+
+      for (final link in validLinks) {
+        expect(
+          rule.apply(document, 0, data: link, len: 0),
+          Delta()..insert(link, {'link': link}),
+        );
+      }
+    });
+  });
 }


### PR DESCRIPTION
## Description

Quill editor has a rule named `AutoFormatMultipleLinksRule` that auto format HTTP(s) links, however there was a small caveat where path was mandatory if characters others than A-Z were used. 

The problem is that the URL can contain fragments and query params without requiring an extra `/` as per RFC 3986 on URL structure:

```
scheme://host[:port][/path][?query][#fragment]
``` 

Examples of what the rule was handling before the fix: 

- ✅ http://beginner.example.edu/#act => {link: http://beginner.example.edu/#act}
- ❌ http://beginner.example.edu#act => {link: http://beginner.example.edu}
- ✅ https://brass.example.com/?anger=branch => {link: https://brass.example.com/?anger=branch}
- ❌ https://brass.example.com?anger=branch&actor=amusement#adjustment => {link: https://brass.example.com}

Proposed PR allows query params and fragments to be used even without a `/` character beforehand, thus respecting what the RFC is stating.

Also, I removed the non-prefixed URL from the comments because as opposed to what what was said, it didn't work: 

```dart
/// It works for the following testing URLs:
// www.google.com 
```