### PR TITLE
fix: link menu action Cupertino modal popup now does NOT use root nav

### DIFF
--- a/lib/src/editor/widgets/link.dart
+++ b/lib/src/editor/widgets/link.dart
@@ -150,6 +150,7 @@ class QuillTextLink {
 Future<LinkMenuAction> _showCupertinoLinkMenu(
     BuildContext context, String link) async {
   final result = await showCupertinoModalPopup<LinkMenuAction>(
+    useRootNavigator: false,
     context: context,
     builder: (ctx) {
       return CupertinoActionSheet(


### PR DESCRIPTION
## Description
This is to fix a bug where when using nested navigators the modal popup wouldn't pop (instead, the underlying pages would). This also brings the behaviour into parity with the Android/Material equivalent.

## Related Issues
- *Fix #1170*

## Type of Change
- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.