### PR TITLE
Feat: support for customize `onKey` events

### DIFF
--- a/lib/src/editor/config/editor_configurations.dart
+++ b/lib/src/editor/config/editor_configurations.dart
@@ -7,6 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart' show experimental;
 
 import '../../controller/quill_controller.dart';
+import '../../document/nodes/node.dart';
 import '../../editor_toolbar_shared/config/quill_shared_configurations.dart';
 import '../../toolbar/theme/quill_dialog_theme.dart';
 import '../editor_builder.dart';
@@ -60,6 +61,7 @@ class QuillEditorConfigurations extends Equatable {
     this.onSingleLongTapStart,
     this.onSingleLongTapMoveUpdate,
     this.onSingleLongTapEnd,
+    this.onKeyPressed,
     @Deprecated(
         'Use space/char shortcut events instead - enableMarkdownStyleConversion will be removed in future releases.')
     this.enableMarkdownStyleConversion = true,
@@ -152,6 +154,28 @@ class QuillEditorConfigurations extends Equatable {
   ///);
   ///```
   final List<SpaceShortcutEvent> spaceShortcutEvents;
+
+  /// A handler for keys that are pressed when the editor is focused.
+  ///
+  /// # Example:
+  /// assume that you want to avoid of the editor removes any character, then
+  /// you can try this:
+  ///
+  ///```dart
+  ///
+  ///configurations: QuillEditorConfigurations(
+  ///   onKeyPressed: (event, node) {
+  ///     if (event.logicalKey == LogicalKeyboardKey.backspace) {
+  ///         debugPrint('Hello there');
+  ///         return KeyEventResult.handled;
+  ///     }
+  ///     // if you already don't need add more conditions, you can return
+  ///     // null to let to the editor execute the other internal events
+  ///     return null;
+  ///   },
+  ///)
+  ///```
+  final KeyEventResult? Function(KeyEvent event, Node? node)? onKeyPressed;
 
   /// Whether the text can be changed.
   ///
@@ -484,6 +508,7 @@ class QuillEditorConfigurations extends Equatable {
     bool? autoFocus,
     bool? isOnTapOutsideEnabled,
     Function(PointerDownEvent event, FocusNode focusNode)? onTapOutside,
+    KeyEventResult? Function(KeyEvent event, Node? node)? onKeyPressed,
     bool? showCursor,
     bool? paintCursorAboveText,
     bool? enableInteractiveSelection,
@@ -539,6 +564,7 @@ class QuillEditorConfigurations extends Equatable {
       checkBoxReadOnly: checkBoxReadOnly ?? this.checkBoxReadOnly,
       disableClipboard: disableClipboard ?? this.disableClipboard,
       scrollable: scrollable ?? this.scrollable,
+      onKeyPressed: onKeyPressed ?? this.onKeyPressed,
       scrollBottomInset: scrollBottomInset ?? this.scrollBottomInset,
       characterShortcutEvents:
           characterShortcutEvents ?? this.characterShortcutEvents,

--- a/lib/src/editor/config/editor_configurations.dart
+++ b/lib/src/editor/config/editor_configurations.dart
@@ -176,8 +176,8 @@ class QuillEditorConfigurations extends Equatable {
   ///           ..skip(_controller.selection.baseOffset - 1);
   ///     // Get the current [Operation] where the caret is on
   ///     final cur = iterator.next();
-  ///     // Check if the caret is on a Operation that is not text
-  ///     if (cur.data is! String && cur.data != null) {
+  ///     final isOperationWithEmbed = cur.data is! String && cur.data != null;  
+  ///     if (isOperationWithEmbed) {
   ///         // If it is, then ignore this [KeyEvent] to avoid the user
   ///         // removes that [Embed Object]
   ///         return KeyEventResult.handled;

--- a/lib/src/editor/config/editor_configurations.dart
+++ b/lib/src/editor/config/editor_configurations.dart
@@ -61,6 +61,7 @@ class QuillEditorConfigurations extends Equatable {
     this.onSingleLongTapStart,
     this.onSingleLongTapMoveUpdate,
     this.onSingleLongTapEnd,
+    @experimental
     this.onKeyPressed,
     @Deprecated(
         'Use space/char shortcut events instead - enableMarkdownStyleConversion will be removed in future releases.')

--- a/lib/src/editor/config/editor_configurations.dart
+++ b/lib/src/editor/config/editor_configurations.dart
@@ -163,7 +163,7 @@ class QuillEditorConfigurations extends Equatable {
   ///     - Desktop
   ///
   /// # Example:
-  /// assume that we want to avoid the user removes any **Embed Object**, then we can try:
+  /// To prevent the user from removing any **Embed Object**, try:
   ///
   ///```dart
   ///onKeyPressed: (event, node) {
@@ -174,12 +174,11 @@ class QuillEditorConfigurations extends Equatable {
   ///     // and jump directly before the position
   ///     final iterator = DeltaIterator(_controller.document.toDelta())
   ///           ..skip(_controller.selection.baseOffset - 1);
-  ///     // Get the current [Operation] where the caret is on
+  ///     // Get the [Operation] where the caret is on
   ///     final cur = iterator.next();
   ///     final isOperationWithEmbed = cur.data is! String && cur.data != null;  
   ///     if (isOperationWithEmbed) {
-  ///         // If it is, then ignore this [KeyEvent] to avoid the user
-  ///         // removes that [Embed Object]
+  ///         // Ignore this [KeyEvent] to prevent the user from removing the [Embed Object].
   ///         return KeyEventResult.handled;
   ///     }
   ///   }

--- a/lib/src/editor/config/editor_configurations.dart
+++ b/lib/src/editor/config/editor_configurations.dart
@@ -167,11 +167,9 @@ class QuillEditorConfigurations extends Equatable {
   ///
   ///```dart
   ///onKeyPressed: (event, node) {
-  ///   // Check if the node is a line or a block (you can add your custom type checking)
   ///   if (event.logicalKey == LogicalKeyboardKey.backspace &&
   ///       (node is Line || node is Block)) {
-  ///     // We need to use [DeltaIterator] to go to the current position
-  ///     // and jump directly before the position
+  ///     // Use [DeltaIterator] to jump directly to the position before the current.
   ///     final iterator = DeltaIterator(_controller.document.toDelta())
   ///           ..skip(_controller.selection.baseOffset - 1);
   ///     // Get the [Operation] where the caret is on

--- a/lib/src/editor/config/editor_configurations.dart
+++ b/lib/src/editor/config/editor_configurations.dart
@@ -159,7 +159,7 @@ class QuillEditorConfigurations extends Equatable {
   ///
   /// ### Supported by:
   ///
-  ///     - Web
+  ///     - Web (Does not work on mobile devices)
   ///     - Desktop
   ///
   /// # Example:

--- a/lib/src/editor/config/editor_configurations.dart
+++ b/lib/src/editor/config/editor_configurations.dart
@@ -175,6 +175,7 @@ class QuillEditorConfigurations extends Equatable {
   ///   },
   ///)
   ///```
+  @experimental
   final KeyEventResult? Function(KeyEvent event, Node? node)? onKeyPressed;
 
   /// Whether the text can be changed.

--- a/lib/src/editor/config/editor_configurations.dart
+++ b/lib/src/editor/config/editor_configurations.dart
@@ -176,7 +176,7 @@ class QuillEditorConfigurations extends Equatable {
   ///           ..skip(_controller.selection.baseOffset - 1);
   ///     // Get the [Operation] where the caret is on
   ///     final cur = iterator.next();
-  ///     final isOperationWithEmbed = cur.data is! String && cur.data != null;  
+  ///     final isOperationWithEmbed = cur.data is! String && cur.data != null;
   ///     if (isOperationWithEmbed) {
   ///         // Ignore this [KeyEvent] to prevent the user from removing the [Embed Object].
   ///         return KeyEventResult.handled;

--- a/lib/src/editor/config/editor_configurations.dart
+++ b/lib/src/editor/config/editor_configurations.dart
@@ -157,6 +157,11 @@ class QuillEditorConfigurations extends Equatable {
 
   /// A handler for keys that are pressed when the editor is focused.
   ///
+  /// ### Supported by:
+  ///
+  ///     - Web
+  ///     - Desktop
+  ///
   /// # Example:
   /// assume that we want to avoid the user removes any **Embed Object**, then we can try:
   ///
@@ -178,7 +183,6 @@ class QuillEditorConfigurations extends Equatable {
   ///           // removes that [Embed Object]
   ///           return KeyEventResult.handled;
   ///       }
-  ///       return KeyEventResult.handled;
   ///     }
   ///     // Apply custom logic or return null to use default events
   ///     return null;

--- a/lib/src/editor/config/editor_configurations.dart
+++ b/lib/src/editor/config/editor_configurations.dart
@@ -61,8 +61,7 @@ class QuillEditorConfigurations extends Equatable {
     this.onSingleLongTapStart,
     this.onSingleLongTapMoveUpdate,
     this.onSingleLongTapEnd,
-    @experimental
-    this.onKeyPressed,
+    @experimental this.onKeyPressed,
     @Deprecated(
         'Use space/char shortcut events instead - enableMarkdownStyleConversion will be removed in future releases.')
     this.enableMarkdownStyleConversion = true,
@@ -165,7 +164,7 @@ class QuillEditorConfigurations extends Equatable {
   ///configurations: QuillEditorConfigurations(
   ///   onKeyPressed: (event, node) {
   ///     // Check if the node is a line or a block (you can add your custom type checking)
-  ///     if (event.logicalKey == LogicalKeyboardKey.backspace && 
+  ///     if (event.logicalKey == LogicalKeyboardKey.backspace &&
   ///         (node is Line || node is Block)) {
   ///       // We need to use [DeltaIterator] to go to the current position
   ///       // and jump directly before the position

--- a/lib/src/editor/config/editor_configurations.dart
+++ b/lib/src/editor/config/editor_configurations.dart
@@ -159,19 +159,29 @@ class QuillEditorConfigurations extends Equatable {
   /// A handler for keys that are pressed when the editor is focused.
   ///
   /// # Example:
-  /// assume that you want to avoid of the editor removes any character, then
-  /// you can try this:
+  /// assume that we want to avoid the user removes any **Embed Object**, then we can try:
   ///
   ///```dart
-  ///
   ///configurations: QuillEditorConfigurations(
   ///   onKeyPressed: (event, node) {
-  ///     if (event.logicalKey == LogicalKeyboardKey.backspace) {
-  ///         debugPrint('Hello there');
-  ///         return KeyEventResult.handled;
+  ///     // Check if the node is a line or a block (you can add your custom type checking)
+  ///     if (event.logicalKey == LogicalKeyboardKey.backspace && 
+  ///         (node is Line || node is Block)) {
+  ///       // We need to use [DeltaIterator] to go to the current position
+  ///       // and jump directly before the position
+  ///       final iterator = DeltaIterator(_controller.document.toDelta())
+  ///             ..skip(_controller.selection.baseOffset - 1);
+  ///       // Get the current [Operation] where the caret is on
+  ///       final cur = iterator.next();
+  ///       // Check if the caret is on a Operation that is not text
+  ///       if (cur.data is! String && cur.data != null) {
+  ///           // If it is, then ignore this [KeyEvent] to avoid the user
+  ///           // removes that [Embed Object]
+  ///           return KeyEventResult.handled;
+  ///       }
+  ///       return KeyEventResult.handled;
   ///     }
-  ///     // if you already don't need add more conditions, you can return
-  ///     // null to let to the editor execute the other internal events
+  ///     // Apply custom logic or return null to use default events
   ///     return null;
   ///   },
   ///)

--- a/lib/src/editor/config/editor_configurations.dart
+++ b/lib/src/editor/config/editor_configurations.dart
@@ -166,28 +166,26 @@ class QuillEditorConfigurations extends Equatable {
   /// assume that we want to avoid the user removes any **Embed Object**, then we can try:
   ///
   ///```dart
-  ///configurations: QuillEditorConfigurations(
-  ///   onKeyPressed: (event, node) {
-  ///     // Check if the node is a line or a block (you can add your custom type checking)
-  ///     if (event.logicalKey == LogicalKeyboardKey.backspace &&
-  ///         (node is Line || node is Block)) {
-  ///       // We need to use [DeltaIterator] to go to the current position
-  ///       // and jump directly before the position
-  ///       final iterator = DeltaIterator(_controller.document.toDelta())
-  ///             ..skip(_controller.selection.baseOffset - 1);
-  ///       // Get the current [Operation] where the caret is on
-  ///       final cur = iterator.next();
-  ///       // Check if the caret is on a Operation that is not text
-  ///       if (cur.data is! String && cur.data != null) {
-  ///           // If it is, then ignore this [KeyEvent] to avoid the user
-  ///           // removes that [Embed Object]
-  ///           return KeyEventResult.handled;
-  ///       }
+  ///onKeyPressed: (event, node) {
+  ///   // Check if the node is a line or a block (you can add your custom type checking)
+  ///   if (event.logicalKey == LogicalKeyboardKey.backspace &&
+  ///       (node is Line || node is Block)) {
+  ///     // We need to use [DeltaIterator] to go to the current position
+  ///     // and jump directly before the position
+  ///     final iterator = DeltaIterator(_controller.document.toDelta())
+  ///           ..skip(_controller.selection.baseOffset - 1);
+  ///     // Get the current [Operation] where the caret is on
+  ///     final cur = iterator.next();
+  ///     // Check if the caret is on a Operation that is not text
+  ///     if (cur.data is! String && cur.data != null) {
+  ///         // If it is, then ignore this [KeyEvent] to avoid the user
+  ///         // removes that [Embed Object]
+  ///         return KeyEventResult.handled;
   ///     }
-  ///     // Apply custom logic or return null to use default events
-  ///     return null;
-  ///   },
-  ///)
+  ///   }
+  ///   // Apply custom logic or return null to use default events
+  ///   return null;
+  ///},
   ///```
   @experimental
   final KeyEventResult? Function(KeyEvent event, Node? node)? onKeyPressed;

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -298,6 +298,7 @@ class QuillEditorState extends State<QuillEditor>
               characterShortcutEvents:
                   widget.configurations.characterShortcutEvents,
               spaceShortcutEvents: widget.configurations.spaceShortcutEvents,
+              onKeyPressed: widget.configurations.onKeyPressed,
               customLeadingBuilder:
                   widget.configurations.customLeadingBlockBuilder,
               focusNode: widget.focusNode,

--- a/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
@@ -148,28 +148,26 @@ class QuillRawEditorConfigurations extends Equatable {
   /// assume that we want to avoid the user removes any **Embed Object**, then we can try:
   ///
   ///```dart
-  ///configurations: QuillEditorConfigurations(
-  ///   onKeyPressed: (event, node) {
-  ///     // Check if the node is a line or a block (you can add your custom type checking)
-  ///     if (event.logicalKey == LogicalKeyboardKey.backspace &&
-  ///         (node is Line || node is Block)) {
-  ///       // We need to use [DeltaIterator] to go to the current position
-  ///       // and jump directly before the position
-  ///       final iterator = DeltaIterator(_controller.document.toDelta())
-  ///             ..skip(_controller.selection.baseOffset - 1);
-  ///       // Get the current [Operation] where the caret is on
-  ///       final cur = iterator.next();
-  ///       // Check if the caret is on a Operation that is not text
-  ///       if (cur.data is! String && cur.data != null) {
-  ///           // If it is, then ignore this [KeyEvent] to avoid the user
-  ///           // removes that [Embed Object]
-  ///           return KeyEventResult.handled;
-  ///       }
+  ///onKeyPressed: (event, node) {
+  ///   // Check if the node is a line or a block (you can add your custom type checking)
+  ///   if (event.logicalKey == LogicalKeyboardKey.backspace &&
+  ///       (node is Line || node is Block)) {
+  ///     // We need to use [DeltaIterator] to go to the current position
+  ///     // and jump directly before the position
+  ///     final iterator = DeltaIterator(_controller.document.toDelta())
+  ///           ..skip(_controller.selection.baseOffset - 1);
+  ///     // Get the current [Operation] where the caret is on
+  ///     final cur = iterator.next();
+  ///     // Check if the caret is on a Operation that is not text
+  ///     if (cur.data is! String && cur.data != null) {
+  ///         // If it is, then ignore this [KeyEvent] to avoid the user
+  ///         // removes that [Embed Object]
+  ///         return KeyEventResult.handled;
   ///     }
-  ///     // Apply custom logic or return null to use default events
-  ///     return null;
-  ///   },
-  ///)
+  ///   }
+  ///   // Apply custom logic or return null to use default events
+  ///   return null;
+  ///},
   ///```
   @experimental
   final KeyEventResult? Function(KeyEvent event, Node? node)? onKeyPressed;

--- a/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
@@ -98,8 +98,9 @@ class QuillRawEditorConfigurations extends Equatable {
   ///
   /// Supported by:
   ///
-  ///    - Web
+  ///    - Web (Does not work on mobile devices)
   ///    - Desktop
+  ///
   /// ### Example
   ///```dart
   /// // you can get also the default implemented shortcuts

--- a/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
@@ -1,33 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart' show Brightness, Uint8List, immutable;
-import 'package:flutter/material.dart'
-    show
-        AdaptiveTextSelectionToolbar,
-        PointerDownEvent,
-        TextCapitalization,
-        TextInputAction,
-        TextMagnifierConfiguration;
-import 'package:flutter/widgets.dart'
-    show
-        Action,
-        BuildContext,
-        Color,
-        ContentInsertionConfiguration,
-        EdgeInsets,
-        EdgeInsetsGeometry,
-        FocusNode,
-        Intent,
-        KeyEvent,
-        KeyEventResult,
-        MouseCursor,
-        ScrollController,
-        ScrollPhysics,
-        ShortcutActivator,
-        SystemMouseCursors,
-        TextFieldTapRegion,
-        TextSelectionControls,
-        ValueChanged,
-        Widget;
+import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
 import '../../../controller/quill_controller.dart';
@@ -78,6 +51,7 @@ class QuillRawEditorConfigurations extends Equatable {
     this.customActions,
     this.expands = false,
     this.isOnTapOutsideEnabled = true,
+    @experimental
     this.onKeyPressed,
     @Deprecated(
         'Use space/char shortcut events instead - enableMarkdownStyleConversion will be removed in future releases')

--- a/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
@@ -150,11 +150,9 @@ class QuillRawEditorConfigurations extends Equatable {
   ///
   ///```dart
   ///onKeyPressed: (event, node) {
-  ///   // Check if the node is a line or a block (you can add your custom type checking)
   ///   if (event.logicalKey == LogicalKeyboardKey.backspace &&
   ///       (node is Line || node is Block)) {
-  ///     // We need to use [DeltaIterator] to go to the current position
-  ///     // and jump directly before the position
+  ///     // Use [DeltaIterator] to jump directly to the position before the current.
   ///     final iterator = DeltaIterator(_controller.document.toDelta())
   ///           ..skip(_controller.selection.baseOffset - 1);
   ///     // Get the [Operation] where the caret is on

--- a/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
@@ -158,7 +158,7 @@ class QuillRawEditorConfigurations extends Equatable {
   ///           ..skip(_controller.selection.baseOffset - 1);
   ///     // Get the [Operation] where the caret is on
   ///     final cur = iterator.next();
-  ///     final isOperationWithEmbed = cur.data is! String && cur.data != null;  
+  ///     final isOperationWithEmbed = cur.data is! String && cur.data != null;
   ///     if (isOperationWithEmbed) {
   ///         // Ignore this [KeyEvent] to prevent the user from removing the [Embed Object].
   ///         return KeyEventResult.handled;

--- a/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
@@ -158,8 +158,8 @@ class QuillRawEditorConfigurations extends Equatable {
   ///           ..skip(_controller.selection.baseOffset - 1);
   ///     // Get the current [Operation] where the caret is on
   ///     final cur = iterator.next();
-  ///     // Check if the caret is on a Operation that is not text
-  ///     if (cur.data is! String && cur.data != null) {
+  ///     final isOperationWithEmbed = cur.data is! String && cur.data != null;  
+  ///     if (isOperationWithEmbed) {
   ///         // If it is, then ignore this [KeyEvent] to avoid the user
   ///         // removes that [Embed Object]
   ///         return KeyEventResult.handled;

--- a/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
@@ -98,7 +98,7 @@ class QuillRawEditorConfigurations extends Equatable {
   ///
   /// Supported by:
   ///
-  ///    - Web (Does not work on mobile devices)
+  ///    - Web
   ///    - Desktop
   ///
   /// ### Example
@@ -142,7 +142,7 @@ class QuillRawEditorConfigurations extends Equatable {
   ///
   /// ### Supported by:
   ///
-  ///     - Web
+  ///     - Web (Does not work on mobile devices)
   ///     - Desktop
   ///
   /// # Example:

--- a/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
@@ -139,6 +139,11 @@ class QuillRawEditorConfigurations extends Equatable {
 
   /// A handler for keys that are pressed when the editor is focused.
   ///
+  /// ### Supported by:
+  ///
+  ///     - Web
+  ///     - Desktop
+  ///
   /// # Example:
   /// assume that we want to avoid the user removes any **Embed Object**, then we can try:
   ///
@@ -160,7 +165,6 @@ class QuillRawEditorConfigurations extends Equatable {
   ///           // removes that [Embed Object]
   ///           return KeyEventResult.handled;
   ///       }
-  ///       return KeyEventResult.handled;
   ///     }
   ///     // Apply custom logic or return null to use default events
   ///     return null;

--- a/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
@@ -51,8 +51,7 @@ class QuillRawEditorConfigurations extends Equatable {
     this.customActions,
     this.expands = false,
     this.isOnTapOutsideEnabled = true,
-    @experimental
-    this.onKeyPressed,
+    @experimental this.onKeyPressed,
     @Deprecated(
         'Use space/char shortcut events instead - enableMarkdownStyleConversion will be removed in future releases')
     this.enableMarkdownStyleConversion = true,
@@ -147,7 +146,7 @@ class QuillRawEditorConfigurations extends Equatable {
   ///configurations: QuillEditorConfigurations(
   ///   onKeyPressed: (event, node) {
   ///     // Check if the node is a line or a block (you can add your custom type checking)
-  ///     if (event.logicalKey == LogicalKeyboardKey.backspace && 
+  ///     if (event.logicalKey == LogicalKeyboardKey.backspace &&
   ///         (node is Line || node is Block)) {
   ///       // We need to use [DeltaIterator] to go to the current position
   ///       // and jump directly before the position

--- a/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
@@ -145,7 +145,7 @@ class QuillRawEditorConfigurations extends Equatable {
   ///     - Desktop
   ///
   /// # Example:
-  /// assume that we want to avoid the user removes any **Embed Object**, then we can try:
+  /// To prevent the user from removing any **Embed Object**, try:
   ///
   ///```dart
   ///onKeyPressed: (event, node) {
@@ -156,12 +156,11 @@ class QuillRawEditorConfigurations extends Equatable {
   ///     // and jump directly before the position
   ///     final iterator = DeltaIterator(_controller.document.toDelta())
   ///           ..skip(_controller.selection.baseOffset - 1);
-  ///     // Get the current [Operation] where the caret is on
+  ///     // Get the [Operation] where the caret is on
   ///     final cur = iterator.next();
   ///     final isOperationWithEmbed = cur.data is! String && cur.data != null;  
   ///     if (isOperationWithEmbed) {
-  ///         // If it is, then ignore this [KeyEvent] to avoid the user
-  ///         // removes that [Embed Object]
+  ///         // Ignore this [KeyEvent] to prevent the user from removing the [Embed Object].
   ///         return KeyEventResult.handled;
   ///     }
   ///   }

--- a/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
@@ -28,6 +28,7 @@ import 'package:flutter/widgets.dart'
         TextSelectionControls,
         ValueChanged,
         Widget;
+import 'package:meta/meta.dart';
 
 import '../../../controller/quill_controller.dart';
 import '../../../document/nodes/node.dart';
@@ -183,6 +184,7 @@ class QuillRawEditorConfigurations extends Equatable {
   ///   },
   ///)
   ///```
+  @experimental
   final KeyEventResult? Function(KeyEvent event, Node? node)? onKeyPressed;
 
   /// Additional space around the editor contents.

--- a/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
@@ -17,17 +17,20 @@ import 'package:flutter/widgets.dart'
         EdgeInsetsGeometry,
         FocusNode,
         Intent,
+        KeyEvent,
+        KeyEventResult,
+        MouseCursor,
         ScrollController,
         ScrollPhysics,
         ShortcutActivator,
+        SystemMouseCursors,
         TextFieldTapRegion,
         TextSelectionControls,
         ValueChanged,
-        Widget,
-        MouseCursor,
-        SystemMouseCursors;
+        Widget;
 
 import '../../../controller/quill_controller.dart';
+import '../../../document/nodes/node.dart';
 import '../../../editor/embed/embed_editor_builder.dart';
 import '../../../editor/raw_editor/raw_editor.dart';
 import '../../../editor/raw_editor/raw_editor_state.dart';
@@ -74,6 +77,7 @@ class QuillRawEditorConfigurations extends Equatable {
     this.customActions,
     this.expands = false,
     this.isOnTapOutsideEnabled = true,
+    this.onKeyPressed,
     @Deprecated(
         'Use space/char shortcut events instead - enableMarkdownStyleConversion will be removed in future releases')
     this.enableMarkdownStyleConversion = true,
@@ -158,6 +162,28 @@ class QuillRawEditorConfigurations extends Equatable {
   ///);
   ///```
   final List<SpaceShortcutEvent> spaceShortcutEvents;
+
+  /// A handler for keys that are pressed when the editor is focused.
+  ///
+  /// # Example:
+  /// assume that you want to avoid of the editor removes any character, then
+  /// you can try this:
+  ///
+  ///```dart
+  ///
+  ///configurations: QuillEditorConfigurations(
+  ///   onKeyPressed: (event, node) {
+  ///     if (event.logicalKey == LogicalKeyboardKey.backspace) {
+  ///         debugPrint('Hello there');
+  ///         return KeyEventResult.handled;
+  ///     }
+  ///     // if you already don't need add more conditions, you can return
+  ///     // null to let to the editor execute the other internal events
+  ///     return null;
+  ///   },
+  ///)
+  ///```
+  final KeyEventResult? Function(KeyEvent event, Node? node)? onKeyPressed;
 
   /// Additional space around the editor contents.
   final EdgeInsetsGeometry padding;

--- a/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_configurations.dart
@@ -141,19 +141,29 @@ class QuillRawEditorConfigurations extends Equatable {
   /// A handler for keys that are pressed when the editor is focused.
   ///
   /// # Example:
-  /// assume that you want to avoid of the editor removes any character, then
-  /// you can try this:
+  /// assume that we want to avoid the user removes any **Embed Object**, then we can try:
   ///
   ///```dart
-  ///
   ///configurations: QuillEditorConfigurations(
   ///   onKeyPressed: (event, node) {
-  ///     if (event.logicalKey == LogicalKeyboardKey.backspace) {
-  ///         debugPrint('Hello there');
-  ///         return KeyEventResult.handled;
+  ///     // Check if the node is a line or a block (you can add your custom type checking)
+  ///     if (event.logicalKey == LogicalKeyboardKey.backspace && 
+  ///         (node is Line || node is Block)) {
+  ///       // We need to use [DeltaIterator] to go to the current position
+  ///       // and jump directly before the position
+  ///       final iterator = DeltaIterator(_controller.document.toDelta())
+  ///             ..skip(_controller.selection.baseOffset - 1);
+  ///       // Get the current [Operation] where the caret is on
+  ///       final cur = iterator.next();
+  ///       // Check if the caret is on a Operation that is not text
+  ///       if (cur.data is! String && cur.data != null) {
+  ///           // If it is, then ignore this [KeyEvent] to avoid the user
+  ///           // removes that [Embed Object]
+  ///           return KeyEventResult.handled;
+  ///       }
+  ///       return KeyEventResult.handled;
   ///     }
-  ///     // if you already don't need add more conditions, you can return
-  ///     // null to let to the editor execute the other internal events
+  ///     // Apply custom logic or return null to use default events
   ///     return null;
   ///   },
   ///)

--- a/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
@@ -80,7 +80,7 @@ class EditorKeyboardShortcuts extends StatelessWidget {
   KeyEventResult _onKeyEvent(node, KeyEvent event) {
     final onKey = onKeyPressed;
     if (onKey != null) {
-      // we need to found the current node what the user is on
+      // Find the current node the user is on.
       final node =
           controller.document.queryChild(controller.selection.baseOffset).node;
       final result = onKey.call(event, node);

--- a/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
@@ -37,6 +37,7 @@ class EditorKeyboardShortcuts extends StatelessWidget {
   final bool readOnly;
   final bool enableAlwaysIndentOnTab;
   final QuillController controller;
+  @experimental
   final KeyEventResult? Function(KeyEvent event, Node? node)? onKeyPressed;
   final List<CharacterShortcutEvent> characterEvents;
   final List<SpaceShortcutEvent> spaceEvents;

--- a/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
@@ -78,11 +78,12 @@ class EditorKeyboardShortcuts extends StatelessWidget {
   }
 
   KeyEventResult _onKeyEvent(node, KeyEvent event) {
-    if (onKeyPressed != null) {
+    final onKey = onKeyPressed;
+    if (onKey != null) {
       // we need to found the current node what the user is on
       final node =
           controller.document.queryChild(controller.selection.baseOffset).node;
-      final result = onKeyPressed!.call(event, node);
+      final result = onKey.call(event, node);
       if (result != null) return result;
     }
     // Don't handle key if there is a meta key pressed.

--- a/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
@@ -10,6 +10,7 @@ import '../../../document/document.dart';
 import '../../../document/nodes/block.dart';
 import '../../../document/nodes/leaf.dart' as leaf;
 import '../../../document/nodes/line.dart';
+import '../../../document/nodes/node.dart';
 import '../../widgets/keyboard_listener.dart';
 import '../config/events/character_shortcuts_events.dart';
 import '../config/events/space_shortcut_events.dart';
@@ -27,6 +28,7 @@ class EditorKeyboardShortcuts extends StatelessWidget {
     required this.enableAlwaysIndentOnTab,
     required this.characterEvents,
     required this.spaceEvents,
+    this.onKeyPressed,
     this.customShortcuts,
     this.customActions,
     super.key,
@@ -35,6 +37,7 @@ class EditorKeyboardShortcuts extends StatelessWidget {
   final bool readOnly;
   final bool enableAlwaysIndentOnTab;
   final QuillController controller;
+  final KeyEventResult? Function(KeyEvent event, Node? node)? onKeyPressed;
   final List<CharacterShortcutEvent> characterEvents;
   final List<SpaceShortcutEvent> spaceEvents;
   final Map<ShortcutActivator, Intent>? customShortcuts;
@@ -74,6 +77,13 @@ class EditorKeyboardShortcuts extends StatelessWidget {
   }
 
   KeyEventResult _onKeyEvent(node, KeyEvent event) {
+    if (onKeyPressed != null) {
+      // we need to found the current node what the user is on
+      final node =
+          controller.document.queryChild(controller.selection.baseOffset).node;
+      final result = onKeyPressed!.call(event, node);
+      if (result != null) return result;
+    }
     // Don't handle key if there is a meta key pressed.
     if (HardwareKeyboard.instance.isAltPressed ||
         HardwareKeyboard.instance.isControlPressed ||

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -533,6 +533,7 @@ class QuillRawEditorState extends EditorState
         data: _styles!,
         child: EditorKeyboardShortcuts(
           actions: _shortcutActionsManager.actions,
+          onKeyPressed: widget.configurations.onKeyPressed,
           characterEvents: widget.configurations.characterShortcutEvents,
           spaceEvents: widget.configurations.spaceShortcutEvents,
           constraints: constraints,


### PR DESCRIPTION
## Description

A new parameter was added with the name `onKeyPressed`, which as its name indicates, calls this function every time a key on the keyboard is pressed.

#### Why was this done?

This is because previously the user never had the opportunity to prevent a key from executing its default function, because we handled all this internally.

It was decided to pass two parameters in this function, the `KeyEvent` and a `Node` that corresponds to the current node that is in selection.

### Example

If we want to prevent all `Embed Objects` from being deleted, we would only have to create a function such that:

```dart
QuillEditor(
  controller: _controller,
  configurations: QuillEditorConfigurations(
     onKeyPressed: (event, node) {
       if (event.logicalKey == LogicalKeyboardKey.backspace && (node is Line || node is Block)) {
          final iterator = DeltaIterator(_controller.document.toDelta())
               ..skip(_controller.selection.baseOffset - 1);
          final cur = iterator.next();
          if (cur.data is! String && cur.data != null) {
             return KeyEventResult.handled;
          }
       }
       return null;
     },
  ),
)
```

## Related Issues

- *Fix #2308*

- [x] ✨ **New feature:** Adds new functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Code refactor:** Code restructuring that does not affect behavior.
- [ ] ❌ **Breaking change:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** Adds new tests or modifies existing tests.
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Changes to build or deploy processes.