### PR TITLE
Prevented indentation when the TAB key is pressed on a hardware keyboard during IME input

### DIFF
--- a/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
@@ -26,6 +26,7 @@ class EditorKeyboardShortcuts extends StatelessWidget {
     required this.controller,
     required this.readOnly,
     required this.enableAlwaysIndentOnTab,
+    required this.isImeComposingActive,
     required this.characterEvents,
     required this.spaceEvents,
     this.onKeyPressed,
@@ -36,6 +37,7 @@ class EditorKeyboardShortcuts extends StatelessWidget {
 
   final bool readOnly;
   final bool enableAlwaysIndentOnTab;
+  final bool isImeComposingActive;
   final QuillController controller;
   @experimental
   final KeyEventResult? Function(KeyEvent event, Node? node)? onKeyPressed;
@@ -78,6 +80,10 @@ class EditorKeyboardShortcuts extends StatelessWidget {
   }
 
   KeyEventResult _onKeyEvent(node, KeyEvent event) {
+    // Don't handle key if IME is active.
+    if (isImeComposingActive) {
+      return KeyEventResult.ignored;
+    }
     final onKey = onKeyPressed;
     if (onKey != null) {
       // Find the current node the user is on.

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -499,6 +499,7 @@ class QuillRawEditorState extends EditorState
           controller: controller,
           readOnly: widget.config.readOnly,
           enableAlwaysIndentOnTab: widget.config.enableAlwaysIndentOnTab,
+          isImeComposingActive: isImeComposingActive,
           customShortcuts: widget.config.customShortcuts,
           customActions: widget.config.customActions,
           child: child,

--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -24,6 +24,15 @@ mixin RawEditorStateTextInputClientMixin on EditorState
     }
   }
 
+  bool get isImeComposingActive {
+    final isComposingValid =
+        _lastKnownRemoteTextEditingValue?.composing.isValid ?? false;
+    final isSelectionValid =
+        _lastKnownRemoteTextEditingValue?.selection.isValid ?? false;
+
+    return isComposingValid && isSelectionValid;
+  }
+
   TextEditingValue? get _lastKnownRemoteTextEditingValue =>
       __lastKnownRemoteTextEditingValue;
 


### PR DESCRIPTION
## Description

During IME input, keyboard shortcuts should be disabled and processing should be delegated to the IME. Otherwise, shortcuts within the IME become disabled, and editor-side shortcuts, such as indentation, are executed even though input has not been finalized in the IME. This behavior does not occur in other native applications that use IME.

To retrieve the IME state, a property to obtain the IME input status has been added to `RawEditorStateTextInputClientMixin`, and its value is passed to `EditorKeyboardShortcuts`.

Steps to Reproduce:
Press the TAB key while inputting with IME.

Expected Behavior:
Moves within the IME candidate selection.

Current Behavior:
`EditorKeyboardShortcuts` is executed, and the indentation process is triggered.

## Related Issues

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
