### PR TITLE
Fix clipboard image pasting

### DIFF
--- a/lib/src/controller/quill_controller.dart
+++ b/lib/src/controller/quill_controller.dart
@@ -582,18 +582,6 @@ class QuillController extends ChangeNotifier {
       }
     }
 
-    // Snapshot the input before using `await`.
-    // See https://github.com/flutter/flutter/issues/11427
-    final plainText = (await Clipboard.getData(Clipboard.kTextPlain))?.text;
-    if (plainText != null) {
-      final plainTextToPaste = await getTextToPaste(plainText);
-      if (pastePlainTextOrDelta(plainTextToPaste,
-          pastePlainText: _pastePlainText, pasteDelta: _pasteDelta)) {
-        updateEditor?.call();
-        return true;
-      }
-    }
-
     final clipboardService = ClipboardServiceProvider.instance;
 
     final onImagePaste = clipboardConfig?.onImagePaste;
@@ -609,6 +597,8 @@ class QuillController extends ChangeNotifier {
             BlockEmbed.image(imageUrl),
             null,
           );
+          updateEditor?.call();
+          return true;
         }
       }
     }
@@ -625,7 +615,23 @@ class QuillController extends ChangeNotifier {
             BlockEmbed.image(gifUrl),
             null,
           );
+          updateEditor?.call();
+          return true;
         }
+      }
+    }
+
+    // Only process plain text if no image/gif was pasted.
+    // Snapshot the input before using `await`.
+    // See https://github.com/flutter/flutter/issues/11427
+    final plainText = (await Clipboard.getData(Clipboard.kTextPlain))?.text;
+
+    if (plainText != null) {
+      final plainTextToPaste = await getTextToPaste(plainText);
+      if (pastePlainTextOrDelta(plainTextToPaste,
+          pastePlainText: _pastePlainText, pasteDelta: _pasteDelta)) {
+        updateEditor?.call();
+        return true;
       }
     }
 


### PR DESCRIPTION
## Description

Fix clipboard image pasting by checking if "onImagePaste" and/or "onGifPaste" handlers are provided in the clipboardConfig before handling the plainText (since it is not null if image/gif is present).

## Related Issues

- Fix #2383
- Fix #2323

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.

## Video demonstration:

Behavior before:

https://github.com/user-attachments/assets/f2125bea-804b-42ba-a20d-2793d642a25f

Behavior after:

https://github.com/user-attachments/assets/9faeafb4-b9f2-43a6-8322-0f84535b3e0d

