### PR TITLE
Update example to support image pasting on web

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,9 +6,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_quill_example/quill_delta_sample.dart';
+import 'package:flutter_quill_example/stabs/web_utils.dart';
 import 'package:flutter_quill_extensions/flutter_quill_extensions.dart';
 import 'package:path/path.dart' as path;
-import 'dart:html' as html;
 
 void main() => runApp(const MainApp());
 
@@ -48,13 +48,14 @@ class _HomePageState extends State<HomePage> {
         enableExternalRichPaste: true,
         onImagePaste: (imageBytes) async {
           if (kIsWeb) {
+            // Create a WebUtils instance
+            final WebUtils webUtils = WebUtils();
+
+            // Create a URL for the image
+            final imageUrl = webUtils.createImageUrl(imageBytes);
+
             // Create a Blob from the image bytes
-            final blob = html.Blob([imageBytes], 'image/png');
-
-            // Create a temporary URL for the blob
-            final url = html.Url.createObjectUrlFromBlob(blob);
-
-            return url;
+            return imageUrl;
           }
           // Save the image somewhere and return the image URL that will be
           // stored in the Quill Delta JSON (the document).

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_quill_example/quill_delta_sample.dart';
 import 'package:flutter_quill_extensions/flutter_quill_extensions.dart';
 import 'package:path/path.dart' as path;
+import 'dart:html' as html;
 
 void main() => runApp(const MainApp());
 
@@ -47,8 +48,13 @@ class _HomePageState extends State<HomePage> {
         enableExternalRichPaste: true,
         onImagePaste: (imageBytes) async {
           if (kIsWeb) {
-            // Dart IO is unsupported on the web.
-            return null;
+            // Create a Blob from the image bytes
+            final blob = html.Blob([imageBytes], 'image/png');
+
+            // Create a temporary URL for the blob
+            final url = html.Url.createObjectUrlFromBlob(blob);
+
+            return url;
           }
           // Save the image somewhere and return the image URL that will be
           // stored in the Quill Delta JSON (the document).

--- a/example/lib/stabs/real_web_utils.dart
+++ b/example/lib/stabs/real_web_utils.dart
@@ -1,0 +1,12 @@
+import 'web_utils.dart';
+import 'dart:html' as html;
+
+WebUtils getWebUtils() => RealWebUtils();
+
+class RealWebUtils implements WebUtils {
+  @override
+  String createImageUrl(List<int> imageBytes) {
+    final blob = html.Blob([imageBytes], 'image/png');
+    return html.Url.createObjectUrlFromBlob(blob);
+  }
+}

--- a/example/lib/stabs/stub_web_utils.dart
+++ b/example/lib/stabs/stub_web_utils.dart
@@ -1,0 +1,10 @@
+import 'web_utils.dart';
+
+WebUtils getWebUtils() => StubWebUtils();
+
+class StubWebUtils implements WebUtils {
+  @override
+  String createImageUrl(List<int> imageBytes) {
+    return '';
+  }
+}

--- a/example/lib/stabs/web_utils.dart
+++ b/example/lib/stabs/web_utils.dart
@@ -1,0 +1,7 @@
+import 'stub_web_utils.dart' if (dart.library.js) 'real_web_utils.dart';
+
+abstract class WebUtils {
+  String createImageUrl(List<int> imageBytes);
+
+  factory WebUtils() => getWebUtils();
+}


### PR DESCRIPTION
## Description

Update the example main.dart to demonstrate the support of image pasting on web by using in-built dart:html

https://github.com/user-attachments/assets/acc0d8b6-755b-4697-a9d6-1bc7fe7a8098


```dart
  // Create a Blob from the image bytes
  final blob = html.Blob([imageBytes], 'image/png');

  // Create a temporary URL for the blob
  final url = html.Url.createObjectUrlFromBlob(blob);

  return url;
```

## Type of Change

- [x] ✨ **Feature:** New functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
