### PR TITLE
hide magnifier when entire toolbar overlay is hidden

### DIFF
--- a/lib/src/editor/widgets/text/text_selection.dart
+++ b/lib/src/editor/widgets/text/text_selection.dart
@@ -356,6 +356,9 @@ class EditorTextSelectionOverlay {
       _handles![1].remove();
       _handles = null;
     }
+    if (_magnifierController.overlayEntry != null) {
+      _magnifierController.hide();
+    }
     if (toolbar != null) {
       hideToolbar();
     }


### PR DESCRIPTION
## Description

I have many users enjoying this feature - but have a couple dozen or so stuck magnifier complaints as well. I took a look at the code and there are a couple of paths where the selectionOverlay is dismissed via a call to hide() that takes care of the toolbar menu but not the magnifier. When hide() is called directly, not in the regular disposal path, the selectionOverlay is removed before the call to remove the magnifier. In those cases, the magnifier will be left floating on the screen. This PR fixes that scenario.


## Related Issues

* Fix #2379

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
