### PR TITLE
fix: Color picker hex field

### DIFF
--- a/lib/src/toolbar/buttons/color/color_dialog.dart
+++ b/lib/src/toolbar/buttons/color/color_dialog.dart
@@ -39,13 +39,13 @@ class ColorPickerDialogState extends State<ColorPickerDialog> {
   @override
   void initState() {
     super.initState();
-    hexController =
-        TextEditingController(text: color_picker.colorToHex(selectedColor));
     if (widget.isToggledColor) {
       selectedColor = widget.isBackground
           ? hexToColor(widget.selectionStyle.attributes['background']?.value)
           : hexToColor(widget.selectionStyle.attributes['color']?.value);
     }
+    hexController =
+        TextEditingController(text: color_picker.colorToHex(selectedColor));
   }
 
   @override


### PR DESCRIPTION
<!-- 
Briefly describe your changes and summarize in the title.
Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md
Package versioning is automated.
Add updates to `Unreleased` in `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
-->

## Description

Currently, when you pick a color from the toolbar(either font or background color), the hex field in the color picker value has always the same value. This fix will make the field display the current value.

## Related Issues

<!--
Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/singerdmx/flutter-quill/issues). Indicate, which of these issues are resolved or fixed by this PR.
*e.g.*
- *Fix #123*
- *Related #456*
-->

## Type of Change

<!---
Check the boxes that apply with x and leave the others empty. For example:
- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without changing current behavior.
-->

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
