### PR TITLE
chore: fix deprecations of Flutter 3.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Avoid using deprecated APIs in Flutter 3.27.0.
-- Resolve analysis warnings for Flutter 3.27 and Dart 3.6.
+- Avoid using deprecated APIs in Flutter 3.27.0:
+    - Migrate from `withOpacity` to `withValues` according to [Color wide gamut - Opacity migration](https://docs.flutter.dev/release/breaking-changes/wide-gamut-framework#opacity).
+    - Avoid using the deprecated `Color.value` getter.
+- Ignore `unreachable_switch_default` warning (introduced in Dart 3.6).
 - Update `intl` dependency to support versions `0.19.0` and `0.20.0`.
 
 ## [11.0.0-dev.14] - 2024-11-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Avoid using deprecated APIs in Flutter 3.27.0.
-- Resolved analysis warnings for Flutter 3.27 and Dart 3.6.
+- Resolve analysis warnings for Flutter 3.27 and Dart 3.6.
+- Update `intl` dependency to support versions `0.19.0` and `0.20.0`.
 
 ## [11.0.0-dev.14] - 2024-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Avoid using deprecated APIs in Flutter 3.27.0.
+- Resolved analysis warnings for Flutter 3.27 and Dart 3.6.
+
 ## [11.0.0-dev.14] - 2024-11-24
 
 ### Changed

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,9 @@
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+# TODO: Included for backward compatibility, remove when the minimum Dart SDK is 3.6.0
+  errors:
+    unreachable_switch_default: ignore
 linter:
   rules:
     always_declare_return_types: true

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -13,18 +13,18 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector_linux
-      sha256: b2b91daf8a68ecfa4a01b778a6f52edef9b14ecd506e771488ea0f2e0784198b
+      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+1"
+    version: "0.9.3+2"
   file_selector_macos:
     dependency: transitive
     description:
@@ -222,10 +222,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_quill_delta_from_html
-      sha256: "288f879bd11f9b6857868e7b198e69918530bd63d196ead6d8a9ee780b4b44d2"
+      sha256: "63873b5391b56daa999ce8fa7dd23dfd7d0417a70e00a647ba450f4a8988afd0"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.2"
+    version: "1.4.3"
   flutter_quill_extensions:
     dependency: "direct main"
     description:
@@ -302,10 +302,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "8faba09ba361d4b246dc0a17cb4289b3324c2b9f6db7b3d457ee69106a86bd32"
+      sha256: fa8141602fde3f7e2f81dbf043613eb44dfa325fa0bcf93c0f142c9f7a2c193e
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+17"
+    version: "0.8.12+18"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -366,18 +366,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -438,10 +438,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   photo_view:
     dependency: transitive
     description:
@@ -470,58 +470,58 @@ packages:
     dependency: transitive
     description:
       name: quill_native_bridge_android
-      sha256: df94b59081dfded10052b61fd4bb80a013499029841d3f64b753b117c8db9dc3
+      sha256: b75c7e6ede362a7007f545118e756b1f19053994144ec9eda932ce5e54a57569
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1-dev.5"
+    version: "0.0.1+2"
   quill_native_bridge_ios:
     dependency: transitive
     description:
       name: quill_native_bridge_ios
-      sha256: "2bec0c95558eea85f422767c6ddab87ef774cf5fe4222e295a436a169d314ecc"
+      sha256: d23de3cd7724d482fe2b514617f8eedc8f296e120fb297368917ac3b59d8099f
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1-dev.6"
+    version: "0.0.1"
   quill_native_bridge_linux:
     dependency: transitive
     description:
       name: quill_native_bridge_linux
-      sha256: d226004634b69119007dffb95c88e06698644c1b3adfe984b78024129e223426
+      sha256: "5fcc60cab2ab9079e0746941f05c5ca5fec85cc050b738c8c8b9da7c09da17eb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1-dev.4"
+    version: "0.0.1"
   quill_native_bridge_macos:
     dependency: transitive
     description:
       name: quill_native_bridge_macos
-      sha256: "9bbe855cc2248f098732794a4861852fede97a384299b02646cb3dbfbc996a87"
+      sha256: "1c0631bd1e2eee765a8b06017c5286a4e829778f4585736e048eb67c97af8a77"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1-dev.5"
+    version: "0.0.1"
   quill_native_bridge_platform_interface:
     dependency: transitive
     description:
       name: quill_native_bridge_platform_interface
-      sha256: fdfc1001c9a152eb5789916f55da97a3de548ccd41fe3cdd0bfcc371bdf41d10
+      sha256: "2d71b6c5106db0a4b1d788640d1b949ccdd0e570b5a5e0384f7b28be9630a94a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1-dev.5"
+    version: "0.0.1"
   quill_native_bridge_web:
     dependency: transitive
     description:
       name: quill_native_bridge_web
-      sha256: ad8076ad740318b3cf6b9a043d3dc206bb2e1383e5371cbe09711b9c609b64a0
+      sha256: e7e55047d68f1a88574c26dbe3f12988f49d07740590d8fc6280028bbde5b908
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1-dev.6"
+    version: "0.0.1"
   quill_native_bridge_windows:
     dependency: transitive
     description:
       name: quill_native_bridge_windows
-      sha256: "62583f68dd426aa9a98a0582631780db44d0c6708625d27f84cc87bf02e49ea3"
+      sha256: "60e50d74238f22ceb43113d9a42b6627451dab9fc27f527b979a32051cf1da45"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1-dev.4"
+    version: "0.0.1"
   quiver:
     dependency: transitive
     description:
@@ -563,10 +563,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "0bd04f5bb74fcd6ff0606a888a30e917af9bd52820b178eaa464beb11dca84b6"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -627,10 +627,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: e43b677296fadce447e987a2f519dcf5f6d1e527dc35d01ffab4fff5b8a7063e
+      sha256: "16a513b6c12bb419304e72ea0ae2ab4fed569920d1c7cb850263fe3acc824626"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.2"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -643,10 +643,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "769549c999acdb42b8bcfa7c43d72bf79a382ca7441ab18a808e101149daf672"
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -699,10 +699,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_avfoundation
-      sha256: "0b146e5d82e886ff43e5a46c6bcbe390761b802864a6e2503eb612d69a405dfa"
+      sha256: "33224c19775fd244be2d6e3dbd8e1826ab162877bd61123bf71890772119a2b7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.3"
+    version: "2.6.5"
   video_player_platform_interface:
     dependency: transitive
     description:
@@ -723,10 +723,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "14.3.0"
   web:
     dependency: transitive
     description:
@@ -739,10 +739,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "84ba388638ed7a8cb3445a320c8273136ab2631cd5f2c57888335504ddab1bc2"
+      sha256: "8b338d4486ab3fbc0ba0db9f9b4f5239b6697fcee427939a40e720cbb9ee0a69"
       url: "https://pub.dev"
     source: hosted
-    version: "5.8.0"
+    version: "5.9.0"
 sdks:
   dart: ">=3.6.0-0 <4.0.0"
   flutter: ">=3.24.0"

--- a/flutter_quill_extensions/CHANGELOG.md
+++ b/flutter_quill_extensions/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Avoid using deprecated APIs in Flutter 3.27.0.
+- Resolved analysis warnings for Flutter 3.27 and Dart 3.6.
+
 ## [11.0.0-dev.4] - 2024-11-24
 
 > [!IMPORTANT]

--- a/flutter_quill_extensions/CHANGELOG.md
+++ b/flutter_quill_extensions/CHANGELOG.md
@@ -12,8 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Avoid using deprecated APIs in Flutter 3.27.0.
-- Resolve analysis warnings for Flutter 3.27 and Dart 3.6.
+- Ignore `unreachable_switch_default` warning (introduced in Dart 3.6).
 
 ## [11.0.0-dev.4] - 2024-11-24
 

--- a/flutter_quill_extensions/CHANGELOG.md
+++ b/flutter_quill_extensions/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Avoid using deprecated APIs in Flutter 3.27.0.
-- Resolved analysis warnings for Flutter 3.27 and Dart 3.6.
+- Resolve analysis warnings for Flutter 3.27 and Dart 3.6.
 
 ## [11.0.0-dev.4] - 2024-11-24
 

--- a/flutter_quill_extensions/analysis_options.yaml
+++ b/flutter_quill_extensions/analysis_options.yaml
@@ -1,5 +1,9 @@
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+# TODO: Included for backward compatibility, remove when the minimum Dart SDK is 3.6.0
+  errors:
+    unreachable_switch_default: ignore
 linter:
   rules:
     always_declare_return_types: true

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -239,7 +239,7 @@ class QuillEditorState extends State<QuillEditor>
       cursorOpacityAnimates = true;
       cursorColor ??= selectionTheme.cursorColor ?? cupertinoTheme.primaryColor;
       selectionColor = selectionTheme.selectionColor ??
-          cupertinoTheme.primaryColor.withOpacity(0.40);
+          cupertinoTheme.primaryColor.withValues(alpha: 0.40);
       cursorRadius ??= const Radius.circular(2);
       cursorOffset = Offset(
           iOSHorizontalOffset / MediaQuery.devicePixelRatioOf(context), 0);
@@ -249,7 +249,7 @@ class QuillEditorState extends State<QuillEditor>
       cursorOpacityAnimates = false;
       cursorColor ??= selectionTheme.cursorColor ?? theme.colorScheme.primary;
       selectionColor = selectionTheme.selectionColor ??
-          theme.colorScheme.primary.withOpacity(0.40);
+          theme.colorScheme.primary.withValues(alpha: 0.40);
     }
 
     final showSelectionToolbar = configurations.enableInteractiveSelection &&

--- a/lib/src/editor/style_widgets/checkbox_point.dart
+++ b/lib/src/editor/style_widgets/checkbox_point.dart
@@ -35,15 +35,15 @@ class QuillCheckboxPointState extends State<QuillCheckboxPoint> {
     final fillColor = widget.value
         ? (widget.enabled
             ? theme.colorScheme.primary
-            : theme.colorScheme.onSurface.withOpacity(0.5))
+            : theme.colorScheme.onSurface.withValues(alpha: 0.5))
         : theme.colorScheme.surface;
     final borderColor = widget.value
         ? (widget.enabled
             ? theme.colorScheme.primary
-            : theme.colorScheme.onSurface.withOpacity(0))
+            : theme.colorScheme.onSurface.withValues(alpha: 0))
         : (widget.enabled
-            ? theme.colorScheme.onSurface.withOpacity(0.5)
-            : theme.colorScheme.onSurface.withOpacity(0.3));
+            ? theme.colorScheme.onSurface.withValues(alpha: 0.5)
+            : theme.colorScheme.onSurface.withValues(alpha: 0.3));
     final child = Container(
       alignment: AlignmentDirectional.centerEnd,
       padding: EdgeInsetsDirectional.only(end: widget.size / 2),

--- a/lib/src/editor/widgets/cursor.dart
+++ b/lib/src/editor/widgets/cursor.dart
@@ -232,7 +232,7 @@ class CursorCont extends ChangeNotifier {
   }
 
   void _onColorTick() {
-    color.value = _style.color.withOpacity(_blinkOpacityController.value);
+    color.value = _style.color.withValues(alpha: _blinkOpacityController.value);
     blink.value = show.value && _blinkOpacityController.value > 0;
   }
 }

--- a/lib/src/editor/widgets/default_styles.dart
+++ b/lib/src/editor/widgets/default_styles.dart
@@ -260,7 +260,7 @@ class DefaultStyles {
 
     final inlineCodeStyle = TextStyle(
       fontSize: 14,
-      color: themeData.colorScheme.primary.withOpacity(0.8),
+      color: themeData.colorScheme.primary.withValues(alpha: 0.8),
       fontFamily: fontFamily,
     );
 
@@ -424,7 +424,7 @@ class DefaultStyles {
           defaultTextStyle.style.copyWith(
             fontSize: 20,
             height: 1.5,
-            color: Colors.grey.withOpacity(0.6),
+            color: Colors.grey.withValues(alpha: 0.6),
           ),
           baseHorizontalSpacing,
           VerticalSpacing.zero,
@@ -439,7 +439,7 @@ class DefaultStyles {
         null,
       ),
       quote: DefaultTextBlockStyle(
-        TextStyle(color: baseStyle.color!.withOpacity(0.6)),
+        TextStyle(color: baseStyle.color!.withValues(alpha: 0.6)),
         baseHorizontalSpacing,
         baseVerticalSpacing,
         const VerticalSpacing(6, 2),
@@ -451,7 +451,7 @@ class DefaultStyles {
       ),
       code: DefaultTextBlockStyle(
           TextStyle(
-            color: Colors.blue.shade900.withOpacity(0.9),
+            color: Colors.blue.shade900.withValues(alpha: 0.9),
             fontFamily: fontFamily,
             fontSize: 13,
             height: 1.15,

--- a/lib/src/editor/widgets/float_cursor.dart
+++ b/lib/src/editor/widgets/float_cursor.dart
@@ -21,7 +21,7 @@ class FloatingCursorPainter {
 
   void paint(Canvas canvas) {
     final floatingCursorRect = this.floatingCursorRect;
-    final floatingCursorColor = style.color.withOpacity(0.75);
+    final floatingCursorColor = style.color.withValues(alpha: 0.75);
     if (floatingCursorRect == null) return;
     canvas.drawRRect(
       RRect.fromRectAndRadius(floatingCursorRect, _kFloatingCaretRadius),

--- a/lib/src/editor/widgets/link.dart
+++ b/lib/src/editor/widgets/link.dart
@@ -209,7 +209,7 @@ class _CupertinoAction extends StatelessWidget {
             Icon(
               icon,
               size: theme.iconTheme.size,
-              color: theme.colorScheme.onSurface.withOpacity(0.75),
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.75),
             )
           ],
         ),
@@ -267,7 +267,7 @@ class _MaterialAction extends StatelessWidget {
       leading: Icon(
         icon,
         size: theme.iconTheme.size,
-        color: theme.colorScheme.onSurface.withOpacity(0.75),
+        color: theme.colorScheme.onSurface.withValues(alpha: 0.75),
       ),
       title: Text(title),
       onTap: onPressed,

--- a/lib/src/editor/widgets/text/text_block.dart
+++ b/lib/src/editor/widgets/text/text_block.dart
@@ -290,7 +290,7 @@ class EditableTextBlock extends StatelessWidget {
           return null;
         }
         return defaultStyles.code!.style.copyWith(
-          color: defaultStyles.code!.style.color!.withOpacity(0.4),
+          color: defaultStyles.code!.style.color!.withValues(alpha: 0.4),
         );
       }(),
       width: () {

--- a/lib/src/editor_toolbar_shared/color.dart
+++ b/lib/src/editor_toolbar_shared/color.dart
@@ -17,6 +17,18 @@ Color hexToColor(String? hexString) {
   return Color(int.tryParse(buffer.toString(), radix: 16) ?? 0xFF000000);
 }
 
+// Without the hash sign (`#`).
 String colorToHex(Color color) {
-  return color.value.toRadixString(16).padLeft(8, '0').toUpperCase();
+  int floatToInt8(double x) => (x * 255.0).round() & 0xff;
+
+  final alpha = floatToInt8(color.a);
+  final red = floatToInt8(color.r);
+  final green = floatToInt8(color.g);
+  final blue = floatToInt8(color.b);
+
+  return '${alpha.toRadixString(16).padLeft(2, '0')}'
+          '${red.toRadixString(16).padLeft(2, '0')}'
+          '${green.toRadixString(16).padLeft(2, '0')}'
+          '${blue.toRadixString(16).padLeft(2, '0')}'
+      .toUpperCase();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   quiver: ^3.2.0
   meta: ^1.7.0
   html: ^0.15.0
-  intl: ^0.19.0
+  intl: '>=0.19.0 <0.21.0'
 
   flutter_colorpicker: ^1.1.0
 

--- a/test/editor_toolbar_shared/color_test.dart
+++ b/test/editor_toolbar_shared/color_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_quill/src/editor_toolbar_shared/color.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('colorToHex converts to hex correctly', () {
+    const testCases = [
+      _ColorTestCase(color: Color(0xFFFF0000), expectedHex: 'FFFF0000'),
+      _ColorTestCase(color: Color(0xFF00FF00), expectedHex: 'FF00FF00'),
+      _ColorTestCase(color: Color(0xFF0000FF), expectedHex: 'FF0000FF'),
+      _ColorTestCase(color: Color(0x00000000), expectedHex: '00000000'),
+      _ColorTestCase(
+          color: Color(0x80FFFFFF),
+          expectedHex: '80FFFFFF'), // 50% transparent white
+      _ColorTestCase(color: Color(0x12345678), expectedHex: '12345678'),
+      _ColorTestCase(color: Color(0xFF000000), expectedHex: 'FF000000'),
+      _ColorTestCase(color: Color(0xFFFFFFFF), expectedHex: 'FFFFFFFF'),
+      _ColorTestCase(color: Colors.black, expectedHex: 'FF000000'),
+      _ColorTestCase(color: Colors.white, expectedHex: 'FFFFFFFF'),
+      _ColorTestCase(color: Colors.transparent, expectedHex: '00000000'),
+    ];
+    for (final testCase in testCases) {
+      expect(colorToHex(testCase.color), equals(testCase.expectedHex));
+    }
+  });
+}
+
+class _ColorTestCase {
+  const _ColorTestCase({
+    required this.color,
+    required this.expectedHex,
+  });
+
+  final Color color;
+  final String expectedHex;
+}


### PR DESCRIPTION
## Description

*Migrate deprecations of Flutter 3.27, fix analysis warnings, update the example's `pubspec.lock`, and update outdated `intl` constraint.*

## Related Issues

- *Fix #2409*

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [x] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [x] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
