### PR TITLE
Fix: customStyleBuilder is not accumulating styles

### DIFF
--- a/lib/src/editor/widgets/delegate.dart
+++ b/lib/src/editor/widgets/delegate.dart
@@ -10,7 +10,8 @@ import '../editor.dart';
 import '../raw_editor/raw_editor.dart';
 import 'text/text_selection.dart';
 
-typedef CustomStyleBuilder = TextStyle Function(Attribute attribute);
+typedef CustomStyleBuilder = TextStyle Function(
+    Attribute attribute, TextStyle style);
 
 typedef CustomRecognizerBuilder = GestureRecognizer? Function(
     Attribute attribute, Leaf leaf);

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -413,7 +413,7 @@ class _TextLineState extends State<TextLine> {
       final attr = attributes[key];
       if (attr != null) {
         /// Custom Attribute
-        final customAttr = widget.customStyleBuilder!.call(attr);
+        final customAttr = widget.customStyleBuilder!.call(attr, textStyle);
         textStyle = textStyle.merge(customAttr);
       }
     }


### PR DESCRIPTION
## Description

Fix issue where the `customStyleBuilder` does not accumulate styles when multiple attributes are applied to the same text.

## Related Issues

*Fix #2425*

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [x] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
