### PR TITLE
Focus and open context menu on right click if unfocused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Removed unicode from `QuillText` element that causes weird caret behavior on empty lines [#2453](https://github.com/singerdmx/flutter-quill/pull/2453).
+* Request focus on secondary click.
 
 ## [11.0.0] - 2025-02-16
 

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
 import '../common/utils/platform.dart';
@@ -554,6 +555,28 @@ class _QuillEditorSelectionGestureDetectorBuilder
       }
     } finally {
       _state._requestKeyboard();
+    }
+  }
+
+  /// onSingleTapUp for mouse right click
+  @override
+  void onSecondarySingleTapUp(TapUpDetails details) {
+    if (delegate.selectionEnabled &&
+        renderEditor != null &&
+        renderEditor!.selection.isCollapsed) {
+      renderEditor!.selectPositionAt(
+        from: details.globalPosition,
+        cause: SelectionChangedCause.longPress,
+      );
+    }
+
+    if (renderEditor?._hasFocus == false) {
+      _state._requestKeyboard();
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        super.onSecondarySingleTapUp(details);
+      });
+    } else {
+      super.onSecondarySingleTapUp(details);
     }
   }
 

--- a/lib/src/editor/widgets/delegate.dart
+++ b/lib/src/editor/widgets/delegate.dart
@@ -199,10 +199,12 @@ class EditorTextSelectionGestureDetectorBuilder {
   /// onSingleTapUp for mouse right click
   @protected
   void onSecondarySingleTapUp(TapUpDetails details) {
-    // added to show toolbar by right click
-    if (checkSelectionToolbarShouldShow(isAdditionalAction: true)) {
-      editor!.showToolbar();
-    }
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      // added to show toolbar by right click
+      if (checkSelectionToolbarShouldShow(isAdditionalAction: true)) {
+        editor!.showToolbar();
+      }
+    });
   }
 
   /// Handler for [EditorTextSelectionGestureDetector.onSingleTapCancel].

--- a/test/bug_fix_test.dart
+++ b/test/bug_fix_test.dart
@@ -162,6 +162,9 @@ void main() {
           await tester.tap(find.byType(QuillEditor),
               buttons: kSecondaryButton, kind: device);
           await tester.pumpAndSettle();
+          while (find.byType(AdaptiveTextSelectionToolbar).evaluate().isEmpty) {
+            await tester.pumpAndSettle();
+          }
 
           // Verify custom widget shows
           expect(find.byType(AdaptiveTextSelectionToolbar), findsAny);


### PR DESCRIPTION
## Description

If the editor is not focused and the user right clicks it, nothing currently happens. With these changes the editor is now focused and the context menu opened. Similar to how `TextField` works

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
