### PR TITLE
Chore: added cache for toPlainText in Document to avoid unnecessary text computing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 
-* Cache for `toPlainText` in `Document` class to avoid unnecessary text computing []().
+* Cache for `toPlainText` in `Document` class to avoid unnecessary text computing [#2482](https://github.com/singerdmx/flutter-quill/pull/2482).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added 
+
+* Cache for `toPlainText` in `Document` class to avoid unnecessary text computing []().
+
 ### Fixed
 
 * Removed unicode from `QuillText` element that causes weird caret behavior on empty lines [#2453](https://github.com/singerdmx/flutter-quill/pull/2453).

--- a/lib/src/document/document.dart
+++ b/lib/src/document/document.dart
@@ -581,6 +581,7 @@ class Document {
         _root.childCount > 1) {
       _root.remove(node);
     }
+    _cachedPlainText = null;
   }
 
   bool isEmpty() {

--- a/lib/src/document/document.dart
+++ b/lib/src/document/document.dart
@@ -174,7 +174,7 @@ class Document {
     final formatDelta = _rules.apply(RuleType.format, this, index,
         len: len, attribute: attribute);
     if (formatDelta.isNotEmpty) {
-      compose(formatDelta, ChangeSource.local, false);
+      compose(formatDelta, ChangeSource.local);
       delta = delta.compose(formatDelta);
     }
 
@@ -438,7 +438,7 @@ class Document {
   /// of this document.
   ///
   /// In case the [change] is invalid, behavior of this method is unspecified.
-  void compose(Delta delta, ChangeSource changeSource, [bool reloadCacheText = true]) {
+  void compose(Delta delta, ChangeSource changeSource) {
     assert(!documentChangeObserver.isClosed);
     delta.trim();
     assert(delta.isNotEmpty);
@@ -470,9 +470,7 @@ class Document {
       throw StateError('_delta compose failed');
     }
     assert(_delta == _root.toDelta(), 'Compose failed');
-    if(reloadCacheText) {
-      _cachedPlainText = null;
-    }
+    _cachedPlainText = null;
     final change = DocChange(originalDelta, delta, changeSource);
     documentChangeObserver.add(change);
     history.handleDocChange(change);

--- a/lib/src/document/document.dart
+++ b/lib/src/document/document.dart
@@ -548,12 +548,10 @@ class Document {
   String toPlainText([
     Iterable<EmbedBuilder>? embedBuilders,
     EmbedBuilder? unknownEmbedBuilder,
-  ]) {
-    cachedPlainText ??= _root.children
-        .map((e) => e.toPlainText(embedBuilders, unknownEmbedBuilder))
-        .join();
-    return cachedPlainText!;
-  }
+  ]) =>
+      cachedPlainText ??= _root.children
+          .map((e) => e.toPlainText(embedBuilders, unknownEmbedBuilder))
+          .join();
 
   @visibleForTesting
   @internal

--- a/lib/src/document/document.dart
+++ b/lib/src/document/document.dart
@@ -172,7 +172,7 @@ class Document {
     final formatDelta = _rules.apply(RuleType.format, this, index,
         len: len, attribute: attribute);
     if (formatDelta.isNotEmpty) {
-      compose(formatDelta, ChangeSource.local);
+      compose(formatDelta, ChangeSource.local, false);
       delta = delta.compose(formatDelta);
     }
 
@@ -436,7 +436,7 @@ class Document {
   /// of this document.
   ///
   /// In case the [change] is invalid, behavior of this method is unspecified.
-  void compose(Delta delta, ChangeSource changeSource) {
+  void compose(Delta delta, ChangeSource changeSource, [bool reloadCacheText = true]) {
     assert(!documentChangeObserver.isClosed);
     delta.trim();
     assert(delta.isNotEmpty);
@@ -468,7 +468,9 @@ class Document {
       throw StateError('_delta compose failed');
     }
     assert(_delta == _root.toDelta(), 'Compose failed');
-    _cachedPlainText = null;
+    if(reloadCacheText) {
+      _cachedPlainText = null;
+    }
     final change = DocChange(originalDelta, delta, changeSource);
     documentChangeObserver.add(change);
     history.handleDocChange(change);

--- a/lib/src/document/document.dart
+++ b/lib/src/document/document.dart
@@ -472,19 +472,19 @@ class Document {
       throw StateError('_delta compose failed');
     }
     assert(_delta == _root.toDelta(), 'Compose failed');
-    cachedPlainText = null;
+    // cachedPlainText = null;
     final change = DocChange(originalDelta, delta, changeSource);
     documentChangeObserver.add(change);
     history.handleDocChange(change);
   }
 
   HistoryChanged undo() {
-    cachedPlainText = null;
+    // cachedPlainText = null;
     return history.undo(this);
   }
 
   HistoryChanged redo() {
-    cachedPlainText = null;
+    // cachedPlainText = null;
     return history.redo(this);
   }
 
@@ -582,7 +582,7 @@ class Document {
         _root.childCount > 1) {
       _root.remove(node);
     }
-    cachedPlainText = null;
+    // cachedPlainText = null;
   }
 
   bool isEmpty() {

--- a/lib/src/document/document.dart
+++ b/lib/src/document/document.dart
@@ -38,6 +38,9 @@ class Document {
     _loadDocument(delta);
   }
 
+  /// a var that contains the plain text of the entire document
+  String? _cachedPlainText;
+
   /// The root node of the document tree
   final Root _root = Root();
 
@@ -465,16 +468,19 @@ class Document {
       throw StateError('_delta compose failed');
     }
     assert(_delta == _root.toDelta(), 'Compose failed');
+    _cachedPlainText = null;
     final change = DocChange(originalDelta, delta, changeSource);
     documentChangeObserver.add(change);
     history.handleDocChange(change);
   }
 
   HistoryChanged undo() {
+    _cachedPlainText = null;
     return history.undo(this);
   }
 
   HistoryChanged redo() {
+    _cachedPlainText = null;
     return history.redo(this);
   }
 
@@ -539,6 +545,7 @@ class Document {
     Iterable<EmbedBuilder>? embedBuilders,
     EmbedBuilder? unknownEmbedBuilder,
   ]) =>
+    _cachedPlainText ??=
       _root.children
           .map((e) => e.toPlainText(embedBuilders, unknownEmbedBuilder))
           .join();

--- a/lib/src/document/document.dart
+++ b/lib/src/document/document.dart
@@ -472,19 +472,19 @@ class Document {
       throw StateError('_delta compose failed');
     }
     assert(_delta == _root.toDelta(), 'Compose failed');
-    // cachedPlainText = null;
+    cachedPlainText = null;
     final change = DocChange(originalDelta, delta, changeSource);
     documentChangeObserver.add(change);
     history.handleDocChange(change);
   }
 
   HistoryChanged undo() {
-    // cachedPlainText = null;
+    cachedPlainText = null;
     return history.undo(this);
   }
 
   HistoryChanged redo() {
-    // cachedPlainText = null;
+    cachedPlainText = null;
     return history.redo(this);
   }
 
@@ -582,7 +582,7 @@ class Document {
         _root.childCount > 1) {
       _root.remove(node);
     }
-    // cachedPlainText = null;
+    cachedPlainText = null;
   }
 
   bool isEmpty() {

--- a/lib/src/document/document.dart
+++ b/lib/src/document/document.dart
@@ -546,11 +546,13 @@ class Document {
   String toPlainText([
     Iterable<EmbedBuilder>? embedBuilders,
     EmbedBuilder? unknownEmbedBuilder,
-  ]) =>
+  ]) {
     _cachedPlainText ??=
       _root.children
           .map((e) => e.toPlainText(embedBuilders, unknownEmbedBuilder))
           .join();
+    return _cachedPlainText!;
+  }
 
   void _loadDocument(Delta doc) {
     if (doc.isEmpty) {

--- a/lib/src/document/document.dart
+++ b/lib/src/document/document.dart
@@ -38,7 +38,9 @@ class Document {
     _loadDocument(delta);
   }
 
-  /// a var that contains the plain text of the entire document
+  /// Stores the plain text content of the entire document in memory for quick access.
+  ///
+  /// It acts as a cache to avoid repeatedly extracting or generating the plain text.
   String? _cachedPlainText;
 
   /// The root node of the document tree

--- a/test/document/document_test.dart
+++ b/test/document/document_test.dart
@@ -182,4 +182,79 @@ void main() {
           reason: 'start of blank line');
     });
   });
+  group('cachedPlainText', () {
+    late Document document;
+
+    setUp(() {
+      document = Document();
+    });
+
+    test('is null initially', () {
+      expect(document.cachedPlainText, isNull);
+    });
+
+    test('updates to null when undo is called', () {
+      document.cachedPlainText = 'Non-null cached plain text';
+      expect(document.cachedPlainText, isNotNull);
+
+      document.undo();
+      expect(document.cachedPlainText, isNull);
+    });
+
+    test('updates to null when redo is called', () {
+      final document = Document()
+        ..cachedPlainText = 'Non-null cached plain text';
+      expect(document.cachedPlainText, isNotNull);
+
+      document.redo();
+      expect(document.cachedPlainText, isNull);
+    });
+
+    test('returns cachedPlainText if not null', () {
+      const example = 'Hello, World!';
+      document.cachedPlainText = example;
+
+      expect(document.cachedPlainText, example);
+    });
+
+    test('sets cachedPlainText if null when toPlainText is called', () {
+      document.toPlainText();
+      expect(document.cachedPlainText, isNotNull);
+    });
+
+    test('sets cachedPlainText correctly when toPlainText is called', () {
+      const example = 'Hello\n';
+      document = Document.fromDelta(Delta()..insert(example))..toPlainText();
+
+      expect(document.cachedPlainText, isNotNull);
+      expect(document.cachedPlainText, example);
+    });
+
+    test('sets cachedPlainText to null when loadDocument is called', () {
+      document.cachedPlainText = 'Not null';
+      expect(document.cachedPlainText, isNotNull);
+
+      document.loadDocument(Delta()..insert('Hello\n'));
+
+      expect(document.cachedPlainText, isNull);
+    });
+
+    test('sets cachedPlainText to null when compose is called', () {
+      document.cachedPlainText = 'Not null';
+      expect(document.cachedPlainText, isNotNull);
+
+      document.compose(Delta()..insert('Hello\n'), ChangeSource.local);
+
+      expect(document.cachedPlainText, isNull);
+    });
+
+    test('sets cachedPlainText correctly', () {
+      // This test is useful in case this property has a getter and setter.
+      document.cachedPlainText = 'Not null';
+      expect(document.cachedPlainText, isNotNull);
+
+      document.cachedPlainText = null;
+      expect(document.cachedPlainText, isNull);
+    });
+  });
 }


### PR DESCRIPTION
## Description

I added a variable that allows caching all the text in the document when needed. In this case, when `compose()` is called, this text will be reloaded, which will prevent important changes from NOT being added.

### Why we need this change?

If you look a bit at `raw_editor_state` and `raw_editor_state_selection_delegate_mixin,` you can notice that both in [`_getGlyphHeights`](https://github.com/singerdmx/flutter-quill/blob/2c54d43f8b5cfe4a352b128f3891fc6c82f5ab58/lib/src/editor/raw_editor/raw_editor_state.dart#L267-L294) and in [`textEditingValue`](https://github.com/singerdmx/flutter-quill/blob/2c54d43f8b5cfe4a352b128f3891fc6c82f5ab58/lib/src/editor/raw_editor/raw_editor_state_selection_delegate_mixin.dart#L17-L30) the `toPlainText` method is called. However, this does not happen once time, literally every frame the `toPlainText` method is called (the same thing happens if we also change the position of the caret) rebuilding the entire `Document` text (i suppose this behavior is related with the `CursorCont`).

> [!NOTE]
> We set the cached value to `null` because, in certain scenarios like performing an undo/redo operation, the cached content becomes invalid and needs to be refreshed. 
>
> When does this update happen? When the `toPlainText` method is called, which, by the way, is invoked very frequently. This ensures that the cached value always reflects the most up-to-date content of the editor.
> 
> Additionally, to prevent the cache from falling out of sync with the changes made to the editor, we reset its value to `null` within the `compose()` method whenever a modification operation occurs (such as deleting, inserting, or replacing text). This ensures that, instead of holding onto a potentially outdated value, the cache is regenerated only when needed, maintaining consistency with the editor's current state.


**This is basically the change:**

```diff
/// Returns plain text representation of this document.
String toPlainText([
  Iterable<EmbedBuilder>? embedBuilders,
  EmbedBuilder? unknownEmbedBuilder,
]) {
- return 
-   _root.children
-      .map((e) => e.toPlainText(embedBuilders, unknownEmbedBuilder))
-       .join();
+  _cachedPlainText ??=
+   _root.children
+       .map((e) => e.toPlainText(embedBuilders, unknownEmbedBuilder))
+        .join();
+    return _cachedPlainText!;
}
```

## Related issues

- *Related #997*

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [x] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
