### PR TITLE
doc: update controller length extension method deprecation message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Removed unicode from `QuillText` element that causes weird caret behavior on empty lines [#2453](https://github.com/singerdmx/flutter-quill/pull/2453).
+* Update QuillController `length` extension method deprecation message [#2483](https://github.com/singerdmx/flutter-quill/pull/2483).
 
 ## [11.0.0] - 2025-02-16
 

--- a/flutter_quill_extensions/lib/src/common/extensions/controller_ext.dart
+++ b/flutter_quill_extensions/lib/src/common/extensions/controller_ext.dart
@@ -6,7 +6,7 @@ extension QuillControllerExt on QuillController {
       'Invalid extension property and will be removed, use selection.baseOffset instead')
   int get index => selection.baseOffset;
   @Deprecated(
-      'Invalid extension property and will be removed, use selection.baseOffset instead')
+      'Invalid extension property and will be removed, use selection.extentOffset - selection.baseOffset instead')
   int get length => selection.extentOffset - index;
 
   @Deprecated('Invalid extension method and will be removed.')


### PR DESCRIPTION
<!-- 
Briefly describe your changes and summarize in the title.
Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md
Package versioning is automated.
Add updates to `Unreleased` in `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
-->

## Description

V11 deprecates the `length` extension method on controller and the deprecation message suggests to use `selection.baseOffset` instead.

However it will cause assertion failure for the following code

```dart
  void insertEmbeddable(Embeddable embed) {
    final position = selection.baseOffset;
    this
      ..replaceText(
        position, // In former versions, here is `index`.
        position, // In former versions, here is `length`.
        embed,
        null,
      )
      ..moveCursorToPosition(position + 1);
  }
```

Assertion failure:

```log
flutter: ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────
flutter: │ [error] | 3:28:44 815ms | 
flutter: │ 'package:flutter_quill/src/document/nodes/container.dart': Failed assertion: line 138 pos 12: 'index == 0 || (index > 0 && index < length)': is not true.
flutter: │ StackTrace: #0      _AssertionError._doThrowNew (dart:core-patch/errors_patch.dart:63:4)
flutter: │ #1      _AssertionError._throwNew (dart:core-patch/errors_patch.dart:45:5)
flutter: │ #2      QuillContainer.insert (package:flutter_quill/src/document/nodes/container.dart:138:12)
flutter: │ #3      Document.compose (package:flutter_quill/src/document/document.dart:451:15)
flutter: │ #4      Document.insert (package:flutter_quill/src/document/document.dart:88:5)
flutter: │ #5      Document.replace (package:flutter_quill/src/document/document.dart:144:17)
flutter: │ #6      QuillController.replaceText (package:flutter_quill/src/controller/quill_controller.dart:284:24)
flutter: │ #7      BBCodeExt.insertEmbeddable (package:flutter_bbcode_editor/src/editor_controller.dart:120:9)
flutter: │ #8      BBCodeEditorToolbarImageButton.build.<anonymous closure> (package:flutter_bbcode_editor/src/tags/image/image_button.dart:205:20)
flutter: │ <asynchronous suspension>
flutter: │ }
```

I think it should be a typo as the getter actually now is `selection.extentOffset - selection.baseOffset`.

This PR updates the deprecation message on `length` method to match its implementation.

## Related Issues

<!--
Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/singerdmx/flutter-quill/issues). Indicate, which of these issues are resolved or fixed by this PR.
*e.g.*
- *Fix #123*
- *Related #456*
-->

## Type of Change

<!---
Check the boxes that apply with x and leave the others empty. For example:
- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without changing current behavior.
-->

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [x] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
