### PR TITLE
Expose Rule type so that Document.setCustomRules can be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed unicode from `QuillText` element that causes weird caret behavior on empty lines [#2453](https://github.com/singerdmx/flutter-quill/pull/2453).
 * Update QuillController `length` extension method deprecation message [#2483](https://github.com/singerdmx/flutter-quill/pull/2483).
 
+### Added
+
+* `Rule` is now part of the public API, so that `Document.setCustomRules` can be used.
+
 ## [11.0.0] - 2025-02-16
 
 > [!IMPORTANT]

--- a/lib/flutter_quill.dart
+++ b/lib/flutter_quill.dart
@@ -33,6 +33,7 @@ export 'src/editor_toolbar_controller_shared/copy_cut_service/copy_cut_service_p
 export 'src/editor_toolbar_controller_shared/copy_cut_service/default_copy_cut_service.dart';
 export 'src/editor_toolbar_controller_shared/quill_config.dart';
 export 'src/l10n/generated/quill_localizations.dart';
+export 'src/rules/rule.dart' show Rule;
 export 'src/toolbar/embed/embed_button_builder.dart';
 export 'src/toolbar/simple_toolbar.dart';
 export 'src/toolbar/structs/link_dialog_action.dart';


### PR DESCRIPTION
## Description

Exposes the `Rule` type through the public API. It's been around for a while and not seen a ton of changes. `Document` exposes the `setCustomRules`-method, but it is not strictly speaking callable through the public API since `Rule` and all its subtypes are only exposed through the internal API.

In our specific use case, we have a custom inline style that we would like to preserve the style of when typing in the middle of it. One option would be to expose the `PreserveInlineStylesRule` and make it more configurable. That would actually be more preferable for us but it seemed a lot more invasive, so I opted to try this route instead.

## Type of Change
- [x] ✨ **Feature:** New functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
