### PR TITLE
fix unpredicatble endless loop of '_handleFocusChanged' in the hase of page route changingwhen editor is set to readonly

### DIFF
--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -788,8 +788,6 @@ class QuillRawEditorState extends EditorState
       _clipboardStatus!.addListener(_onChangedClipboardStatus);
     }
 
-    controller.addListener(_didChangeTextEditingValueListener);
-
     _scrollController = widget.config.scrollController;
     _scrollController.addListener(_updateSelectionOverlayForScroll);
 
@@ -802,9 +800,6 @@ class QuillRawEditorState extends EditorState
     // Floating cursor
     _floatingCursorResetController = AnimationController(vsync: this);
     _floatingCursorResetController.addListener(onFloatingCursorResetTick);
-
-    // listen to composing range changes
-    composingRange.addListener(_onComposingRangeChanged);
 
     if (isKeyboardOS) {
       _keyboardVisible = true;
@@ -832,8 +827,13 @@ class QuillRawEditorState extends EditorState
       });
     }
 
-    // Focus
-    widget.config.focusNode.addListener(_handleFocusChanged);
+    if (!widget.config.readOnly) {
+      controller.addListener(_didChangeTextEditingValueListener);
+      // listen to composing range changes
+      composingRange.addListener(_onComposingRangeChanged);
+      // Focus
+      widget.config.focusNode.addListener(_handleFocusChanged);
+    }
   }
 
   // KeyboardVisibilityController only checks for keyboards that
@@ -939,10 +939,12 @@ class QuillRawEditorState extends EditorState
     assert(!hasConnection);
     _selectionOverlay?.dispose();
     _selectionOverlay = null;
-    controller.removeListener(_didChangeTextEditingValueListener);
-    widget.config.focusNode.removeListener(_handleFocusChanged);
+    if (!widget.config.readOnly) {
+      controller.removeListener(_didChangeTextEditingValueListener);
+      widget.config.focusNode.removeListener(_handleFocusChanged);
+      composingRange.removeListener(_onComposingRangeChanged);
+    }
     _cursorCont.dispose();
-    composingRange.removeListener(_onComposingRangeChanged);
     if (_clipboardStatus != null) {
       _clipboardStatus!
         ..removeListener(_onChangedClipboardStatus)


### PR DESCRIPTION
## Description
If the property `readOnly` is set to true, typically in the read mode of contents, the UI tread may be stuck by endless loop when the route push back to the page with quill.  The direct cause comes from the `_handleFocusChanged` listener, the `focusNode` will keep losing focus and requesting focus again instantly. 
The root cause hasn't been digged out,  removing the unnesessary listeners in `readOnly` mode can resolve the issue at the moment.

## Type of Change
- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
