### PR TITLE
fix Inserting Chinese text after an image converts the image to 'obj'

### DIFF
--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -222,8 +222,13 @@ mixin RawEditorStateTextInputClientMixin on EditorState
     _lastKnownRemoteTextEditingValue = value;
     final oldText = effectiveLastKnownValue.text;
     final text = value.text;
-    final cursorPosition = value.selection.extentOffset;
-    final diff = getDiff(oldText, text, cursorPosition);
+
+    // Dynamically calculate cursor position to resolve misalignment issues when inputting Chinese with Sogou Pinyin.
+    // 动态计算光标位置, 解决使用搜狗拼音输入中文时光标位置偏移问题
+    final effectiveCursorPosition = value.isComposingRangeValid
+        ? value.composing.end
+        : value.selection.extentOffset;
+    final diff = getDiff(oldText, text, effectiveCursorPosition);
     if (diff.deleted.isEmpty && diff.inserted.isEmpty) {
       widget.controller.updateSelection(value.selection, ChangeSource.local);
     } else {


### PR DESCRIPTION
## Description

*Fix cursor misalignment when inputting Chinese with Sogou Pinyin.  Prevent images from being converted to `obj` after inserting Chinese text. *

## Related Issues

- *Fix #2503* Inserting Chinese text after an image converts the image to 'obj' 


## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
