### PR TITLE
Explicitly schedule frame on secondary click.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
- - Explicitly schedule frame on secondary click to ensure context menu is shown on Windows [#2507](https://github.com/singerdmx/flutter-quill/pull/2507)
+ - Explicitly schedule frame on secondary click to ensure context menu is shown on Windows [#2507](https://github.com/singerdmx/flutter-quill/pull/2507).
 
 ## [11.1.0] - 2025-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+ - Explicitly schedule frame on secondary click to ensure context menu is shown on Windows [#2507](https://github.com/singerdmx/flutter-quill/pull/2507)
+
 ## [11.1.0] - 2025-03-11
 
 ### Fixed

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -575,6 +575,7 @@ class _QuillEditorSelectionGestureDetectorBuilder
       SchedulerBinding.instance.addPostFrameCallback((_) {
         super.onSecondarySingleTapUp(details);
       });
+      SchedulerBinding.instance.scheduleFrame();
     } else {
       super.onSecondarySingleTapUp(details);
     }

--- a/lib/src/editor/widgets/delegate.dart
+++ b/lib/src/editor/widgets/delegate.dart
@@ -205,6 +205,7 @@ class EditorTextSelectionGestureDetectorBuilder {
         editor!.showToolbar();
       }
     });
+    SchedulerBinding.instance.scheduleFrame();
   }
 
   /// Handler for [EditorTextSelectionGestureDetector.onSingleTapCancel].


### PR DESCRIPTION
## Description

On Windows, there does not appear to be a new frame scheduled on right click, which means the post frame callbacks that actually show the context menu are not executed until the user does something else (when it's way too late).

## Related Issues

* Related: *#2477*

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
