### PR TITLE
feat(android): native text process actions (WIP)

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -166,6 +166,7 @@ class _HomePageState extends State<HomePage> {
                     ),
                     TimeStampEmbedBuilder(),
                   ],
+                  displayNativeContextMenuItems: true,
                 ),
               ),
             ),

--- a/lib/src/editor/config/editor_config.dart
+++ b/lib/src/editor/config/editor_config.dart
@@ -81,6 +81,7 @@ class QuillEditorConfig {
     this.readOnlyMouseCursor = SystemMouseCursors.text,
     this.onPerformAction,
     @experimental this.customLeadingBlockBuilder,
+    this.displayNativeContextMenuItems = false,
   });
 
   @experimental
@@ -452,6 +453,32 @@ class QuillEditorConfig {
   /// Called when a text input action is performed.
   final void Function(TextInputAction action)? onPerformAction;
 
+  /// The native context menu items like `Translate` and `Search` on Android.
+  ///
+  /// This feature is platform-specific and will
+  /// be silently ignored on platforms other than Android.
+  ///
+  /// To use this feature, ensure the following is added in your `AndroidManifest.xml`:
+  ///
+  /// ```xml
+  /// <queries>
+  ///  <intent>
+  ///      <action android:name="android.intent.action.PROCESS_TEXT"/>
+  ///      <data android:mimeType="text/plain"/>
+  ///  </intent>
+  /// </queries>
+  /// ```
+  ///
+  /// This is the case for newly created Flutter projects.
+  ///
+  /// If the 'queries' element is not found, this config will be ignored.
+  /// For more details, refer to [DefaultProcessTextService](https://api.flutter.dev/flutter/services/DefaultProcessTextService-class.html).
+  ///
+  /// This is always ignored when [contextMenuBuilder] is not null.
+  ///
+  /// Defaults to `false`.
+  final bool displayNativeContextMenuItems;
+
   // IMPORTANT For project authors: The copyWith()
   // should be manually updated each time we add or remove a property
 
@@ -512,6 +539,7 @@ class QuillEditorConfig {
     void Function()? onScribbleActivated,
     EdgeInsets? scribbleAreaInsets,
     void Function(TextInputAction action)? onPerformAction,
+    bool? displayNativeContextMenuItems,
   }) {
     return QuillEditorConfig(
       customLeadingBlockBuilder:
@@ -581,6 +609,8 @@ class QuillEditorConfig {
       onScribbleActivated: onScribbleActivated ?? this.onScribbleActivated,
       scribbleAreaInsets: scribbleAreaInsets ?? this.scribbleAreaInsets,
       onPerformAction: onPerformAction ?? this.onPerformAction,
+      displayNativeContextMenuItems:
+          displayNativeContextMenuItems ?? this.displayNativeContextMenuItems,
     );
   }
 }


### PR DESCRIPTION
## Description

*Add support for querying the native processing action button items on Android.*

Thanks to @theachoem for the amazing issue report; however, this PR will not be merged soon. Pressing the back button doesn't hide the context menu/toolbar, and we need to check if this is a regression or an already existing issue. I will add the tests as soon as we're in the final stage of this PR.

## Related Issues

- *Fix #2515*

## Type of Change

- [x] ✨ **Feature:** New functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [x] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
