### PR TITLE
Fix selection in readOnly mode, Add magnifier via RawMagnifier widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Allow selection in read only mode
+- Display magnifier when dragging on iOS/Android
+- Fixes [#2518](https://github.com/singerdmx/flutter-quill/pull/2518)
+
 ## [11.2.0] - 2025-03-26
 
 ### Added 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Allow selection in read only mode
-- Display magnifier when dragging on iOS/Android
-- Fixes [#2518](https://github.com/singerdmx/flutter-quill/pull/2518)
+### Fixed
+
+- Can't select text when `readOnly` is true [#2529](https://github.com/singerdmx/flutter-quill/pull/2529).
+
+### Added
+
+- Display magnifier using `RawMagnifier` widget when dragging on iOS/Android [#2529](https://github.com/singerdmx/flutter-quill/pull/2529).
 
 ## [11.2.0] - 2025-03-26
 

--- a/lib/flutter_quill.dart
+++ b/lib/flutter_quill.dart
@@ -27,6 +27,7 @@ export 'src/editor/style_widgets/style_widgets.dart';
 export 'src/editor/widgets/cursor.dart';
 export 'src/editor/widgets/default_styles.dart';
 export 'src/editor/widgets/link.dart';
+export 'src/editor/widgets/text/magnifier.dart';
 export 'src/editor/widgets/text/utils/text_block_utils.dart';
 export 'src/editor_toolbar_controller_shared/copy_cut_service/copy_cut_service.dart';
 export 'src/editor_toolbar_controller_shared/copy_cut_service/copy_cut_service_provider.dart';

--- a/lib/src/editor/config/editor_config.dart
+++ b/lib/src/editor/config/editor_config.dart
@@ -15,6 +15,7 @@ import '../widgets/default_styles.dart';
 import '../widgets/delegate.dart';
 import '../widgets/link.dart';
 import '../widgets/text/utils/text_block_utils.dart';
+import '../widgets/text/magnifier.dart';
 import 'search_config.dart';
 
 // IMPORTANT For project authors: The QuillEditorConfig.copyWith()
@@ -56,6 +57,7 @@ class QuillEditorConfig {
     this.enableAlwaysIndentOnTab = false,
     this.embedBuilders,
     this.textSpanBuilder = defaultSpanBuilder,
+    this.quillMagnifierBuilder,
     this.unknownEmbedBuilder,
     @experimental this.searchConfig = const QuillSearchConfig(),
     this.linkActionPickerDelegate = defaultLinkActionPickerDelegate,
@@ -364,6 +366,14 @@ class QuillEditorConfig {
   final CustomRecognizerBuilder? customRecognizerBuilder;
 
   final TextSpanBuilder textSpanBuilder;
+
+  /// To add a magnifier when selecting, specify a builder that returns the magnfier widget
+  ///
+  /// The default is no magnifier
+  ///
+  /// There is a provided magnifier [QuillMagnifier] that is available via the function
+  /// defaultQuillMagnifierBuilder
+  final QuillMagnifierBuilder? quillMagnifierBuilder;
 
   /// See [search](https://github.com/singerdmx/flutter-quill/blob/master/doc/configurations/search.md)
   /// page for docs.

--- a/lib/src/editor/config/editor_config.dart
+++ b/lib/src/editor/config/editor_config.dart
@@ -14,8 +14,8 @@ import '../raw_editor/raw_editor.dart';
 import '../widgets/default_styles.dart';
 import '../widgets/delegate.dart';
 import '../widgets/link.dart';
-import '../widgets/text/utils/text_block_utils.dart';
 import '../widgets/text/magnifier.dart';
+import '../widgets/text/utils/text_block_utils.dart';
 import 'search_config.dart';
 
 // IMPORTANT For project authors: The QuillEditorConfig.copyWith()

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -309,6 +309,7 @@ class QuillEditorState extends State<QuillEditor>
         scrollPhysics: config.scrollPhysics,
         embedBuilder: _getEmbedBuilder,
         textSpanBuilder: config.textSpanBuilder,
+        quillMagnifierBuilder: config.quillMagnifierBuilder,
         linkActionPickerDelegate: config.linkActionPickerDelegate,
         customStyleBuilder: config.customStyleBuilder,
         customRecognizerBuilder: config.customRecognizerBuilder,
@@ -335,6 +336,7 @@ class QuillEditorState extends State<QuillEditor>
             detectWordBoundary: config.detectWordBoundary,
             child: child,
             dragOffsetNotifier: dragOffsetNotifier,
+            quillMagnifierBuilder: config.quillMagnifierBuilder,
           )
         : child;
 

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -196,7 +196,7 @@ class QuillEditorState extends State<QuillEditor>
   QuillEditorConfig get configurations => widget.config;
   QuillEditorConfig get config => widget.config;
 
-  // The offset of the drag gesture - where to display the magnifier
+  /// {@macro drag_offset_notifier}
   final dragOffsetNotifier = isMobileApp ? ValueNotifier<Offset?>(null) : null;
 
   @override

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -196,6 +196,9 @@ class QuillEditorState extends State<QuillEditor>
   QuillEditorConfig get configurations => widget.config;
   QuillEditorConfig get config => widget.config;
 
+  // The offset of the drag gesture - where to display the magnifier
+  final dragOffsetNotifier = isMobileApp ? ValueNotifier<Offset?>(null) : null;
+
   @override
   void initState() {
     super.initState();
@@ -260,6 +263,7 @@ class QuillEditorState extends State<QuillEditor>
     final child = QuillRawEditor(
       key: _editorKey,
       controller: controller,
+      dragOffsetNotifier: dragOffsetNotifier,
       config: QuillRawEditorConfig(
         characterShortcutEvents: widget.config.characterShortcutEvents,
         spaceShortcutEvents: widget.config.spaceShortcutEvents,
@@ -330,6 +334,7 @@ class QuillEditorState extends State<QuillEditor>
             behavior: HitTestBehavior.translucent,
             detectWordBoundary: config.detectWordBoundary,
             child: child,
+            dragOffsetNotifier: dragOffsetNotifier,
           )
         : child;
 

--- a/lib/src/editor/raw_editor/config/raw_editor_config.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_config.dart
@@ -12,6 +12,7 @@ import '../../../editor/widgets/default_styles.dart';
 import '../../../editor/widgets/delegate.dart';
 import '../../../editor/widgets/link.dart';
 import '../../../toolbar/theme/quill_dialog_theme.dart';
+import '../../widgets/text/magnifier.dart';
 import '../../widgets/text/utils/text_block_utils.dart';
 import '../builders/leading_block_builder.dart';
 import 'events/events.dart';
@@ -70,6 +71,7 @@ class QuillRawEditorConfig {
     this.readOnlyMouseCursor = SystemMouseCursors.text,
     this.onPerformAction,
     @experimental this.customLeadingBuilder,
+    this.quillMagnifierBuilder,
   });
 
   /// Controls whether this editor has keyboard focus.
@@ -408,4 +410,7 @@ class QuillRawEditorConfig {
 
   /// Called when a text input action is performed.
   final void Function(TextInputAction action)? onPerformAction;
+
+  /// Used to build the [QuillMagnifier] when long-pressing/dragging selection
+  final QuillMagnifierBuilder? quillMagnifierBuilder;
 }

--- a/lib/src/editor/raw_editor/raw_editor.dart
+++ b/lib/src/editor/raw_editor/raw_editor.dart
@@ -26,6 +26,7 @@ class QuillRawEditor extends StatefulWidget {
   final QuillController controller;
   final QuillRawEditorConfig config;
 
+  /// {@template drag_offset_notifier}
   /// dragOffsetNotifier - Only used on iOS and Android
   ///
   /// [QuillRawEditor] contains a gesture detector [EditorTextSelectionGestureDetector]
@@ -44,6 +45,7 @@ class QuillRawEditor extends StatefulWidget {
   /// the correct location (or hide the magnifier if null). [EditorTextSelectionOverlay] will
   /// use the value of the dragOffsetNotifier to hide the context menu when the magnifier is
   /// displayed and show the context menu when dragging is complete.
+  /// {@endtemplate}
   final ValueNotifier<Offset?>? dragOffsetNotifier;
 
   @override

--- a/lib/src/editor/raw_editor/raw_editor.dart
+++ b/lib/src/editor/raw_editor/raw_editor.dart
@@ -25,6 +25,25 @@ class QuillRawEditor extends StatefulWidget {
 
   final QuillController controller;
   final QuillRawEditorConfig config;
+
+  /// dragOffsetNotifier - Only used on iOS and Android
+  ///
+  /// [QuillRawEditor] contains a gesture detector [EditorTextSelectionGestureDetector]
+  /// within it's widget tree that includes a [RawMagnifier]. The RawMagnifier needs
+  /// the current position of selection drag events in order to display the magnifier
+  /// in the correct location. Setting the position to null will hide the magnifier.
+  ///
+  /// Initial selection events are posted by [EditorTextSelectionGestureDetector]. Once
+  /// a selection has been created, dragging the selection handles happens in
+  /// [EditorTextSelectionOverlay].
+  ///
+  /// Both [EditorTextSelectionGestureDetector] and [EditorTextSelectionOverlay] will update
+  /// the value of the dragOffsetNotifier.
+  ///
+  /// The [EditorTextSelectionGestureDetector] will use the value to display the magnifier in
+  /// the correct location (or hide the magnifier if null). [EditorTextSelectionOverlay] will
+  /// use the value of the dragOffsetNotifier to hide the context menu when the magnifier is
+  /// displayed and show the context menu when dragging is complete.
   final ValueNotifier<Offset?>? dragOffsetNotifier;
 
   @override

--- a/lib/src/editor/raw_editor/raw_editor.dart
+++ b/lib/src/editor/raw_editor/raw_editor.dart
@@ -11,6 +11,7 @@ class QuillRawEditor extends StatefulWidget {
   QuillRawEditor({
     required this.config,
     required this.controller,
+    this.dragOffsetNotifier,
     super.key,
   })  : assert(config.maxHeight == null || config.maxHeight! > 0,
             'maxHeight cannot be null'),
@@ -24,6 +25,7 @@ class QuillRawEditor extends StatefulWidget {
 
   final QuillController controller;
   final QuillRawEditorConfig config;
+  ValueNotifier<Offset?>? dragOffsetNotifier;
 
   @override
   State<StatefulWidget> createState() => QuillRawEditorState();

--- a/lib/src/editor/raw_editor/raw_editor.dart
+++ b/lib/src/editor/raw_editor/raw_editor.dart
@@ -25,7 +25,7 @@ class QuillRawEditor extends StatefulWidget {
 
   final QuillController controller;
   final QuillRawEditorConfig config;
-  ValueNotifier<Offset?>? dragOffsetNotifier;
+  final ValueNotifier<Offset?>? dragOffsetNotifier;
 
   @override
   State<StatefulWidget> createState() => QuillRawEditorState();

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -853,8 +853,9 @@ class QuillRawEditorState extends EditorState
       });
     }
 
+    controller.addListener(_didChangeTextEditingValueListener);
+
     if (!widget.config.readOnly) {
-      controller.addListener(_didChangeTextEditingValueListener);
       // listen to composing range changes
       composingRange.addListener(_onComposingRangeChanged);
       // Focus
@@ -965,8 +966,8 @@ class QuillRawEditorState extends EditorState
     assert(!hasConnection);
     _selectionOverlay?.dispose();
     _selectionOverlay = null;
+    controller.removeListener(_didChangeTextEditingValueListener);
     if (!widget.config.readOnly) {
-      controller.removeListener(_didChangeTextEditingValueListener);
       widget.config.focusNode.removeListener(_handleFocusChanged);
       composingRange.removeListener(_onComposingRangeChanged);
     }
@@ -1081,6 +1082,7 @@ class QuillRawEditorState extends EditorState
         contextMenuBuilder: widget.config.contextMenuBuilder == null
             ? null
             : (context) => widget.config.contextMenuBuilder!(context, this),
+        dragOffsetNotifier: widget.dragOffsetNotifier,
       );
       _selectionOverlay!.handlesVisible = _shouldShowSelectionHandles();
       _selectionOverlay!.showHandles();

--- a/lib/src/editor/widgets/delegate.dart
+++ b/lib/src/editor/widgets/delegate.dart
@@ -380,8 +380,8 @@ class EditorTextSelectionGestureDetectorBuilder {
       onDragSelectionEnd: onDragSelectionEnd,
       behavior: behavior,
       detectWordBoundary: detectWordBoundary,
-      child: child,
       dragOffsetNotifier: dragOffsetNotifier,
+      child: child,
     );
   }
 }

--- a/lib/src/editor/widgets/delegate.dart
+++ b/lib/src/editor/widgets/delegate.dart
@@ -8,6 +8,7 @@ import '../../document/attribute.dart';
 import '../../document/nodes/leaf.dart';
 import '../editor.dart';
 import '../raw_editor/raw_editor.dart';
+import 'text/magnifier.dart';
 import 'text/text_selection.dart';
 
 typedef CustomStyleBuilder = TextStyle Function(Attribute attribute);
@@ -362,6 +363,7 @@ class EditorTextSelectionGestureDetectorBuilder {
     Key? key,
     bool detectWordBoundary = true,
     ValueNotifier<Offset?>? dragOffsetNotifier,
+    QuillMagnifierBuilder? quillMagnifierBuilder,
   }) {
     return EditorTextSelectionGestureDetector(
       key: key,
@@ -381,6 +383,7 @@ class EditorTextSelectionGestureDetectorBuilder {
       behavior: behavior,
       detectWordBoundary: detectWordBoundary,
       dragOffsetNotifier: dragOffsetNotifier,
+      quillMagnifierBuilder: quillMagnifierBuilder,
       child: child,
     );
   }

--- a/lib/src/editor/widgets/delegate.dart
+++ b/lib/src/editor/widgets/delegate.dart
@@ -361,6 +361,7 @@ class EditorTextSelectionGestureDetectorBuilder {
     required Widget child,
     Key? key,
     bool detectWordBoundary = true,
+    ValueNotifier<Offset?>? dragOffsetNotifier,
   }) {
     return EditorTextSelectionGestureDetector(
       key: key,
@@ -380,6 +381,7 @@ class EditorTextSelectionGestureDetectorBuilder {
       behavior: behavior,
       detectWordBoundary: detectWordBoundary,
       child: child,
+      dragOffsetNotifier: dragOffsetNotifier,
     );
   }
 }

--- a/lib/src/editor/widgets/text/magnifier.dart
+++ b/lib/src/editor/widgets/text/magnifier.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+typedef QuillMagnifierBuilder = Widget Function(Offset dragPosition);
+
+Widget defaultQuillMagnifierBuilder(Offset dragPosition) =>
+    QuillMagnifier(dragPosition: dragPosition);
+
+class QuillMagnifier extends StatelessWidget {
+  const QuillMagnifier({required this.dragPosition,  super.key});
+
+  final Offset dragPosition;
+
+  @override
+  Widget build(BuildContext context) {
+    final position = dragPosition.translate(-60, -80);
+    return Positioned(
+      top: position.dy,
+      left: position.dx,
+      child: Container(
+        decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(20),
+        ),
+        child: RawMagnifier(
+          clipBehavior: Clip.hardEdge,
+          decoration: MagnifierDecoration(
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+            shadows: const [
+              BoxShadow(
+                color: Colors.black26,
+                spreadRadius: 2,
+                blurRadius: 5,
+                offset: Offset(3, 3), // changes position of shadow
+              ),
+            ],
+          ),
+          size: const Size(100, 45),
+          focalPointOffset: const Offset(5, 55),
+          magnificationScale: 1.3,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/editor/widgets/text/text_selection.dart
+++ b/lib/src/editor/widgets/text/text_selection.dart
@@ -959,9 +959,11 @@ class _EditorTextSelectionGestureDetectorState
 
   void _handleLongPressEnd(LongPressEndDetails details) {
     if (!_isDoubleTap) {
-      widget.dragOffsetNotifier?.value = null;
       widget.onSingleLongTapEnd?.call(details);
     }
+    // after a long press (from double tap or drag) make sure
+    // magnifier is removed
+    widget.dragOffsetNotifier?.value = null;
     _isDoubleTap = false;
   }
 

--- a/lib/src/editor/widgets/text/text_selection.dart
+++ b/lib/src/editor/widgets/text/text_selection.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 
 import '../../../document/nodes/node.dart';
 import '../../editor.dart';
+import 'magnifier.dart';
 
 TextSelection localSelection(Node node, TextSelection selection, fromParent) {
   final base = fromParent ? node.offset : node.documentOffset;
@@ -678,6 +679,7 @@ class EditorTextSelectionGestureDetector extends StatefulWidget {
     this.behavior,
     this.detectWordBoundary = true,
     this.dragOffsetNotifier,
+    this.quillMagnifierBuilder,
     super.key,
   });
 
@@ -756,6 +758,8 @@ class EditorTextSelectionGestureDetector extends StatefulWidget {
   final bool detectWordBoundary;
 
   final ValueNotifier<Offset?>? dragOffsetNotifier;
+
+  final QuillMagnifierBuilder? quillMagnifierBuilder;
 
   @override
   State<StatefulWidget> createState() =>
@@ -1055,42 +1059,15 @@ class _EditorTextSelectionGestureDetectorState
       gestures: gestures,
       excludeFromSemantics: true,
       behavior: widget.behavior,
-      child: Stack(
-        children: [
-          widget.child,
-          if (_magnifierPosition != null)
-            Builder(builder: (context) {
-              final position = _magnifierPosition!.translate(-60, -80);
-              return Positioned(
-                top: position.dy,
-                left: position.dx,
-                child: Container(
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(20),
-                    color: Theme.of(context).scaffoldBackgroundColor,
-                  ),
-                  child: RawMagnifier(
-                    clipBehavior: Clip.hardEdge,
-                    decoration: MagnifierDecoration(
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-                      shadows: const [
-                        BoxShadow(
-                          color: Colors.black26,
-                          spreadRadius: 2,
-                          blurRadius: 5,
-                          offset: Offset(3, 3), // changes position of shadow
-                        ),
-                      ],
-                    ),
-                    size: const Size(100, 45),
-                    focalPointOffset: const Offset(5, 55),
-                    magnificationScale: 1.3,
-                  ),
-                ),
-              );
-            }),
-        ],
-      ),
+      child: (widget.quillMagnifierBuilder == null)
+          ? widget.child
+          : Stack(
+              children: [
+                widget.child,
+                if (_magnifierPosition != null)
+                  widget.quillMagnifierBuilder!(_magnifierPosition!)
+              ],
+            ),
     );
   }
 }

--- a/lib/src/editor/widgets/text/text_selection.dart
+++ b/lib/src/editor/widgets/text/text_selection.dart
@@ -779,7 +779,6 @@ class _EditorTextSelectionGestureDetectorState
   Offset? _magnifierPosition;
 
   @override
-  @override
   void initState() {
     // when the drag offset changes (from handle drag or 1st selection update the magnifier)
     widget.dragOffsetNotifier?.addListener(_dragOffsetListener);

--- a/lib/src/editor/widgets/text/text_selection.dart
+++ b/lib/src/editor/widgets/text/text_selection.dart
@@ -218,6 +218,7 @@ class EditorTextSelectionOverlay {
   /// To hide the whole overlay, see [hide].
   void hideToolbar() {
     assert(toolbar != null);
+    dragOffsetNotifier?.removeListener(_dragOffsetListener);
     toolbar!.remove();
     toolbar = null;
   }
@@ -226,7 +227,13 @@ class EditorTextSelectionOverlay {
   void showToolbar() {
     assert(toolbar == null);
     if (contextMenuBuilder == null) return;
+    dragOffsetNotifier?.addListener(_dragOffsetListener);
     toolbar = OverlayEntry(builder: (context) {
+      // when the dragOffsetNotifier is not null and the value is not null
+      // the magnifier is being shown, so we don't want to show the context menu
+      if (dragOffsetNotifier?.value != null) {
+        return Container();
+      }
       return contextMenuBuilder!(context);
     });
     Overlay.of(context, rootOverlay: true, debugRequiredFor: debugRequiredFor)
@@ -235,6 +242,13 @@ class EditorTextSelectionOverlay {
     // make sure handles are visible as well
     if (_handles == null) {
       showHandles();
+    }
+  }
+
+  // after dragging and magnifier is removed, restore the context menu
+  void _dragOffsetListener() {
+    if (dragOffsetNotifier?.value == null) {
+      toolbar?.markNeedsBuild();
     }
   }
 

--- a/lib/src/editor/widgets/text/text_selection.dart
+++ b/lib/src/editor/widgets/text/text_selection.dart
@@ -367,10 +367,10 @@ class EditorTextSelectionOverlay {
     _handles = <OverlayEntry>[
       OverlayEntry(
           builder: (context) =>
-          _buildHandle(context, _TextSelectionHandlePosition.start)),
+              _buildHandle(context, _TextSelectionHandlePosition.start)),
       OverlayEntry(
           builder: (context) =>
-          _buildHandle(context, _TextSelectionHandlePosition.end)),
+              _buildHandle(context, _TextSelectionHandlePosition.end)),
     ];
 
     Overlay.of(context, rootOverlay: true, debugRequiredFor: debugRequiredFor)
@@ -489,7 +489,7 @@ class _TextSelectionHandleOverlayState
     widget.dragOffsetNotifier?.value = details.globalPosition;
     _dragPosition += details.delta;
     final position =
-    widget.renderObject.getPositionForOffset(details.globalPosition);
+        widget.renderObject.getPositionForOffset(details.globalPosition);
     if (widget.selection.isCollapsed) {
       widget.onSelectionHandleChanged(TextSelection.fromPosition(position));
       return;
@@ -502,17 +502,17 @@ class _TextSelectionHandleOverlayState
       case _TextSelectionHandlePosition.start:
         newSelection = TextSelection(
           baseOffset:
-          isNormalized ? position.offset : widget.selection.baseOffset,
+              isNormalized ? position.offset : widget.selection.baseOffset,
           extentOffset:
-          isNormalized ? widget.selection.extentOffset : position.offset,
+              isNormalized ? widget.selection.extentOffset : position.offset,
         );
         break;
       case _TextSelectionHandlePosition.end:
         newSelection = TextSelection(
           baseOffset:
-          isNormalized ? widget.selection.baseOffset : position.offset,
+              isNormalized ? widget.selection.baseOffset : position.offset,
           extentOffset:
-          isNormalized ? position.offset : widget.selection.extentOffset,
+              isNormalized ? position.offset : widget.selection.extentOffset,
         );
         break;
     }
@@ -565,7 +565,7 @@ class _TextSelectionHandleOverlayState
         : widget.selection.extent;
     final lineHeight = widget.renderObject.preferredLineHeight(textPosition);
     final handleAnchor =
-    widget.selectionControls.getHandleAnchor(type!, lineHeight);
+        widget.selectionControls.getHandleAnchor(type!, lineHeight);
     final handleSize = widget.selectionControls.getHandleSize(lineHeight);
 
     final handleRect = Rect.fromLTWH(
@@ -1045,7 +1045,7 @@ class _EditorTextSelectionGestureDetectorState
         (instance) {
           instance
             ..onStart =
-            widget.onForcePressStart != null ? _forcePressStarted : null
+                widget.onForcePressStart != null ? _forcePressStarted : null
             ..onEnd = widget.onForcePressEnd != null ? _forcePressEnded : null;
         },
       );


### PR DESCRIPTION
## Description

1) Allow selection in read only mode
2) Displays magnifier when dragging on iOS/Android

## Related Issues

- *Fix #2518*
- *Fix #1504*

## Type of Change

- [x] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
