### PR TITLE
Avoid focus ping pong between editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `copyWith` methods to `HorizontalSpacing`, `VerticalSpacing`, `DefaultTextBlockStyle`, and `DefaultListBlockStyle` for immutable updates of properties [#2550](https://github.com/singerdmx/flutter-quill/pull/2550).
 - Finnish (fi) language translation [#2564](https://github.com/singerdmx/flutter-quill/pull/2564).
 
+=======
+### Fixed
+
+ - Move focus request out of requestKeyboard to avoid focus ping pong between editors.
+
 ## [11.4.0] - 2025-04-23
 
 ### Added

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -403,7 +403,11 @@ class QuillEditorState extends State<QuillEditor>
   }
 
   void _requestKeyboard() {
-    _requireEditorCurrentState.requestKeyboard();
+    if (widget.focusNode.hasFocus) {
+      _requireEditorCurrentState.requestKeyboard();
+    } else {
+      widget.focusNode.requestFocus();
+    }
   }
 }
 

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -1201,8 +1201,6 @@ class QuillRawEditorState extends EditorState
       } else {
         _showCaretOnScreen();
       }
-    } else {
-      widget.config.focusNode.requestFocus();
     }
   }
 


### PR DESCRIPTION
In the current implementation, `requestKeyboard` will request focus if an editor is currently not focused.

In certain situations, there can be a delay between getting focus and executing the callback. If the editor has lost focus in that time, it will try to steal it back. This is in itself not great, but what's worse is that if you have more than one editor and switch between them rapidly, you can end up in a state where one editor is constantly trying to steal the focus back from the other, ending up in a ping pong situation that freezes the entire app.

## Description

This PR moves the call to `requestFocus` out of `requestKeyboard`, so that it can instead be requested separately in the places where it's needed.

## Related Issues

* Related: *#2324*

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
