### PR TITLE
Clarify platform support of QuillEditorConfig.onKeyPressed

### DIFF
--- a/lib/src/editor/config/editor_config.dart
+++ b/lib/src/editor/config/editor_config.dart
@@ -140,7 +140,7 @@ class QuillEditorConfig {
   /// A handler for keys that are pressed when the editor is focused.
   ///
   /// This feature is supported on **desktop devices** and **mobile devices with a
-  /// hardware keyboard connected.*** It is not supported by virtual on-screen
+  /// hardware keyboard connected.** It is not supported by virtual on-screen
   /// keyboards of touch devices.
   ///
   /// # Example:

--- a/lib/src/editor/config/editor_config.dart
+++ b/lib/src/editor/config/editor_config.dart
@@ -139,7 +139,9 @@ class QuillEditorConfig {
 
   /// A handler for keys that are pressed when the editor is focused.
   ///
-  /// This feature is supported on **desktop devices only**.
+  /// This feature is supported on **desktop devices** and **mobile devices with a
+  /// hardware keyboard connected.*** It is not supported by virtual on-screen
+  /// keyboards of touch devices.
   ///
   /// # Example:
   /// To prevent the user from removing any **Embed Object**, try:


### PR DESCRIPTION
## Description

The documentation stated that `QuillEditorConfig.onKeyPressed` is only supported by desktop devices. I found that it is also supported by mobile devices when they have a hardware keyboard connected, which is great, because I needed to customize some Quill editor behavior for exactly this scenario.

I modified the documentation of `QuillEditorConfig.onKeyPressed` to reflect this.

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [x] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.