### PR TITLE
Add copyWith methods to DefaultStyles, HorizontalSpacing, and VerticalSpacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Added `copyWith` methods to `HorizontalSpacing`, `VerticalSpacing`, `DefaultTextBlockStyle`, and `DefaultListBlockStyle` for immutable updates of properties.
+
+- `copyWith` methods to `HorizontalSpacing`, `VerticalSpacing`, `DefaultTextBlockStyle`, and `DefaultListBlockStyle` for immutable updates of properties [#2550](https://github.com/singerdmx/flutter-quill/pull/2550).
 
 ## [11.4.0] - 2025-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `copyWith` methods to `HorizontalSpacing`, `VerticalSpacing`, `DefaultTextBlockStyle`, and `DefaultListBlockStyle` for immutable updates of properties.
+
 ## [11.4.0] - 2025-04-23
 
 ### Added

--- a/lib/src/common/structs/horizontal_spacing.dart
+++ b/lib/src/common/structs/horizontal_spacing.dart
@@ -26,7 +26,6 @@ class HorizontalSpacing {
   bool operator ==(Object other) =>
       identical(this, other) ||
           other is HorizontalSpacing &&
-              runtimeType == other.runtimeType &&
               left == other.left &&
               right == other.right;
 

--- a/lib/src/common/structs/horizontal_spacing.dart
+++ b/lib/src/common/structs/horizontal_spacing.dart
@@ -11,4 +11,25 @@ class HorizontalSpacing {
   final double right;
 
   static const zero = HorizontalSpacing(0, 0);
+
+  HorizontalSpacing copyWith({
+    double? left,
+    double? right,
+  }) {
+    return HorizontalSpacing(
+      left ?? this.left,
+      right ?? this.right,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+          other is HorizontalSpacing &&
+              runtimeType == other.runtimeType &&
+              left == other.left &&
+              right == other.right;
+
+  @override
+  int get hashCode => Object.hash(left, right);
 }

--- a/lib/src/common/structs/vertical_spacing.dart
+++ b/lib/src/common/structs/vertical_spacing.dart
@@ -11,4 +11,25 @@ class VerticalSpacing {
   final double bottom;
 
   static const zero = VerticalSpacing(0, 0);
+
+  VerticalSpacing copyWith({
+    double? top,
+    double? bottom,
+  }) {
+    return VerticalSpacing(
+      top ?? this.top,
+      bottom ?? this.bottom,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+          other is VerticalSpacing &&
+              runtimeType == other.runtimeType &&
+              top == other.top &&
+              bottom == other.bottom;
+
+  @override
+  int get hashCode => Object.hash(top, bottom);
 }

--- a/lib/src/common/structs/vertical_spacing.dart
+++ b/lib/src/common/structs/vertical_spacing.dart
@@ -26,7 +26,6 @@ class VerticalSpacing {
   bool operator ==(Object other) =>
       identical(this, other) ||
           other is VerticalSpacing &&
-              runtimeType == other.runtimeType &&
               top == other.top &&
               bottom == other.bottom;
 

--- a/lib/src/editor/widgets/default_styles.dart
+++ b/lib/src/editor/widgets/default_styles.dart
@@ -62,6 +62,22 @@ class DefaultTextBlockStyle {
   /// Decoration, if present, is painted in the content area, excluding
   /// any [spacing].
   final BoxDecoration? decoration;
+
+  DefaultTextBlockStyle copyWith({
+    TextStyle? style,
+    HorizontalSpacing? horizontalSpacing,
+    VerticalSpacing? verticalSpacing,
+    VerticalSpacing? lineSpacing,
+    BoxDecoration? decoration,
+  }) {
+    return DefaultTextBlockStyle(
+      style ?? this.style,
+      horizontalSpacing ?? this.horizontalSpacing,
+      verticalSpacing ?? this.verticalSpacing,
+      lineSpacing ?? this.lineSpacing,
+      decoration ?? this.decoration,
+    );
+  }
 }
 
 /// Theme data for inline code.
@@ -170,6 +186,30 @@ class DefaultListBlockStyle extends DefaultTextBlockStyle {
   final QuillCheckboxBuilder? checkboxUIBuilder;
   final LeadingBlockIndentWidth indentWidthBuilder;
   final LeadingBlockNumberPointWidth numberPointWidthBuilder;
+
+  @override
+  DefaultListBlockStyle copyWith({
+    TextStyle? style,
+    HorizontalSpacing? horizontalSpacing,
+    VerticalSpacing? verticalSpacing,
+    VerticalSpacing? lineSpacing,
+    BoxDecoration? decoration,
+    QuillCheckboxBuilder? checkboxUIBuilder,
+    LeadingBlockIndentWidth? indentWidthBuilder,
+    LeadingBlockNumberPointWidth? numberPointWidthBuilder,
+  }) {
+    return DefaultListBlockStyle(
+      style ?? this.style,
+      horizontalSpacing ?? this.horizontalSpacing,
+      verticalSpacing ?? this.verticalSpacing,
+      lineSpacing ?? this.lineSpacing,
+      decoration ?? this.decoration,
+      checkboxUIBuilder ?? this.checkboxUIBuilder,
+      indentWidthBuilder: indentWidthBuilder ?? this.indentWidthBuilder,
+      numberPointWidthBuilder:
+      numberPointWidthBuilder ?? this.numberPointWidthBuilder,
+    );
+  }
 }
 
 @immutable

--- a/lib/src/l10n/generated/quill_localizations.dart
+++ b/lib/src/l10n/generated/quill_localizations.dart
@@ -105,13 +105,15 @@ import 'quill_localizations_zh.dart';
 /// property.
 abstract class FlutterQuillLocalizations {
   FlutterQuillLocalizations(String locale)
-      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
   static FlutterQuillLocalizations? of(BuildContext context) {
     return Localizations.of<FlutterQuillLocalizations>(
-        context, FlutterQuillLocalizations);
+      context,
+      FlutterQuillLocalizations,
+    );
   }
 
   static const LocalizationsDelegate<FlutterQuillLocalizations> delegate =
@@ -129,11 +131,11 @@ abstract class FlutterQuillLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
@@ -186,7 +188,7 @@ abstract class FlutterQuillLocalizations {
     Locale('vi'),
     Locale('zh'),
     Locale('zh', 'CN'),
-    Locale('zh', 'HK')
+    Locale('zh', 'HK'),
   ];
 
   /// No description provided for @pasteLink.
@@ -833,56 +835,57 @@ class _FlutterQuillLocalizationsDelegate
   @override
   Future<FlutterQuillLocalizations> load(Locale locale) {
     return SynchronousFuture<FlutterQuillLocalizations>(
-        lookupFlutterQuillLocalizations(locale));
+      lookupFlutterQuillLocalizations(locale),
+    );
   }
 
   @override
   bool isSupported(Locale locale) => <String>[
-        'ar',
-        'bg',
-        'bn',
-        'bs',
-        'ca',
-        'cs',
-        'da',
-        'de',
-        'el',
-        'en',
-        'es',
-        'fa',
-        'fr',
-        'gu',
-        'he',
-        'hi',
-        'hr',
-        'hu',
-        'id',
-        'it',
-        'ja',
-        'km',
-        'ko',
-        'ku',
-        'mk',
-        'ms',
-        'ne',
-        'nl',
-        'no',
-        'pl',
-        'pt',
-        'ro',
-        'ru',
-        'sk',
-        'sr',
-        'sv',
-        'sw',
-        'th',
-        'tk',
-        'tr',
-        'uk',
-        'ur',
-        'vi',
-        'zh'
-      ].contains(locale.languageCode);
+    'ar',
+    'bg',
+    'bn',
+    'bs',
+    'ca',
+    'cs',
+    'da',
+    'de',
+    'el',
+    'en',
+    'es',
+    'fa',
+    'fr',
+    'gu',
+    'he',
+    'hi',
+    'hr',
+    'hu',
+    'id',
+    'it',
+    'ja',
+    'km',
+    'ko',
+    'ku',
+    'mk',
+    'ms',
+    'ne',
+    'nl',
+    'no',
+    'pl',
+    'pt',
+    'ro',
+    'ru',
+    'sk',
+    'sr',
+    'sv',
+    'sw',
+    'th',
+    'tk',
+    'tr',
+    'uk',
+    'ur',
+    'vi',
+    'zh',
+  ].contains(locale.languageCode);
 
   @override
   bool shouldReload(_FlutterQuillLocalizationsDelegate old) => false;
@@ -1028,8 +1031,9 @@ FlutterQuillLocalizations lookupFlutterQuillLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-      'FlutterQuillLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+    'FlutterQuillLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
 }


### PR DESCRIPTION
- [x] ✨ **Feature:** New functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.


Easily override style:
```
DefaultStyles _buildDefaults(BuildContext context) {
    // flutter quill
    final base = DefaultStyles.getInstance(context);
    final h1 = base.h1;

    return base.merge(
      DefaultStyles(
        // Before (Copied from default_styles.dart file)
        // h1: DefaultTextBlockStyle(
        //   TextStyle(
        //     fontSize: 34,
        //     color: Colors.white,
        //     letterSpacing: -0.5,
        //     height: 1.083,
        //     fontWeight: FontWeight.bold,
        //     decoration: TextDecoration.none,
        //   ),
        //   HorizontalSpacing(0, 0),
        //   const VerticalSpacing(16, 0),
        //   VerticalSpacing.zero,
        //   null,
        // ),

        // after (Modified)
        // h1: h1?.copyWith(
        //   style: h1.style.copyWith(color: Colors.blue),
        //   verticalSpacing: h1.verticalSpacing.copyWith(bottom: 20),
        // ),


      ),
    );
  }
```