### PR TITLE
Add Fields to Control Uniform Line Height for Span in flutter-quill

### DIFF
--- a/lib/src/editor/widgets/default_styles.dart
+++ b/lib/src/editor/widgets/default_styles.dart
@@ -248,6 +248,7 @@ class DefaultStyles {
     this.sizeHuge,
     this.palette,
     this.forceStrutHeight,
+    this.leadingOffset,
   });
 
   final DefaultTextBlockStyle? h1;
@@ -287,7 +288,10 @@ class DefaultStyles {
   /// Custom palette of colors
   final Map<String, Color>? palette;
 
+  // 强制设置同高
   final bool? forceStrutHeight;
+  // 基线位置
+  final double? leadingOffset;
 
   static DefaultStyles getInstance(BuildContext context) {
     final themeData = Theme.of(context);
@@ -568,6 +572,7 @@ class DefaultStyles {
       sizeHuge: other.sizeHuge ?? sizeHuge,
       palette: other.palette ?? palette,
       forceStrutHeight: other.forceStrutHeight ?? forceStrutHeight,
+      leadingOffset: other.leadingOffset ?? leadingOffset,
     );
   }
 }

--- a/lib/src/editor/widgets/default_styles.dart
+++ b/lib/src/editor/widgets/default_styles.dart
@@ -247,6 +247,7 @@ class DefaultStyles {
     this.sizeLarge,
     this.sizeHuge,
     this.palette,
+    this.forceStrutHeight,
   });
 
   final DefaultTextBlockStyle? h1;
@@ -285,6 +286,8 @@ class DefaultStyles {
 
   /// Custom palette of colors
   final Map<String, Color>? palette;
+
+  final bool? forceStrutHeight;
 
   static DefaultStyles getInstance(BuildContext context) {
     final themeData = Theme.of(context);
@@ -564,6 +567,7 @@ class DefaultStyles {
       sizeLarge: other.sizeLarge ?? sizeLarge,
       sizeHuge: other.sizeHuge ?? sizeHuge,
       palette: other.palette ?? palette,
+      forceStrutHeight: other.forceStrutHeight ?? forceStrutHeight,
     );
   }
 }

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -170,8 +170,11 @@ class _TextLineState extends State<TextLine> {
       }
     }
     final textSpan = _getTextSpanForWholeLine();
-    final strutStyle =
-        StrutStyle.fromTextStyle(textSpan.style ?? const TextStyle());
+    // 增加强制固定行高
+    final strutStyle = StrutStyle.fromTextStyle(
+      textSpan.style ?? const TextStyle(),
+      forceStrutHeight: widget.styles.forceStrutHeight ?? false,
+    );
     final textAlign = _getTextAlign();
     final child = RichText(
       key: _richTextKey,

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -173,7 +173,8 @@ class _TextLineState extends State<TextLine> {
     // 增加强制固定行高
     final strutStyle = StrutStyle.fromTextStyle(
       textSpan.style ?? const TextStyle(),
-      forceStrutHeight: widget.styles.forceStrutHeight ?? false,
+      forceStrutHeight: widget.styles.forceStrutHeight,
+      leading: widget.styles.leadingOffset,
     );
     final textAlign = _getTextAlign();
     final child = RichText(


### PR DESCRIPTION
This pull request introduces two additional fields to control the uniform line height for the RichText widget in the flutter-quill package. The goal is to enhance the text rendering by enabling a fixed line height using the StrutStyle properties, which can be controlled via forceStrutHeight and leadingOffset. This update ensures that the line height is consistent across multiple TextSpan widgets, providing better visual alignment when rendering text.

Modifications:
	1.	Added the strutStyle: A StrutStyle is created from the textSpan.style (or a default TextStyle) to apply a fixed line height.
	•	forceStrutHeight: Ensures the strut height is enforced, even if it would normally be overridden.
	•	leading: This controls the leading offset (the space between lines of text).
	2.	RichText Widget Update: The strutStyle is applied to the RichText widget to manage text rendering with the specified line height and spacing.

Code Changes:

in commit

Rationale:
	•	Control over Line Height: The primary reason for this change is to allow better control over the line height for text spans in flutter-quill. By adding these fields, we ensure that the line height is consistent and can be adjusted per use case.
	•	Improved Text Layout: This change makes it easier to handle cases where consistent vertical spacing is required between lines of text, especially for rich text editing use cases.

Potential Impact:

This modification is non-breaking, as it only introduces additional properties that can be customized. It ensures better control over text appearance without altering the core functionality of the RichText widget.


Suggested Reviewers:
	•	@flutter-quill team
	•	@maintainers



