### PR TITLE
Fix caret not auto scroll to visible when page has multiple editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
 - Fix caret not auto scroll to visible when page has multiple editors [#2570](https://github.com/singerdmx/flutter-quill/pull/2570).
-  **BREAKING**: QuillEditorConfig is now accept `EdgeInsets padding` instead of `EdgeInsetsGeometry`.
+
+### Changed
+- **BREAKING**: QuillEditorConfig is now accept `EdgeInsets padding` instead of `EdgeInsetsGeometry`.
 
 ## [11.4.1] - 2025-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix caret not auto scroll to visible when page has multiple editors [#2570](https://github.com/singerdmx/flutter-quill/pull/2570).
+  **BREAKING**: QuillEditorConfig is now accept `EdgeInsets padding` instead of `EdgeInsetsGeometry`.
+
 ## [11.4.1] - 2025-05-15
 
 ### Added

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -365,18 +365,18 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -738,10 +738,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   web:
     dependency: transitive
     description:
@@ -754,10 +754,10 @@ packages:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.4"
+    version: "3.1.0"
   win32:
     dependency: transitive
     description:

--- a/lib/src/editor/config/editor_config.dart
+++ b/lib/src/editor/config/editor_config.dart
@@ -1,4 +1,4 @@
-/// @docImport '../../rules/insert.dart' show AutoFormatMultipleLinksRule;
+/// @docImport '../../rules/insert.dart';
 library;
 
 import 'dart:ui' as ui;

--- a/lib/src/editor/config/editor_config.dart
+++ b/lib/src/editor/config/editor_config.dart
@@ -214,7 +214,7 @@ class QuillEditorConfig {
 
   /// Additional space around the content of this editor.
   /// by default will be [EdgeInsets.zero]
-  final EdgeInsetsGeometry padding;
+  final EdgeInsets padding;
 
   /// Whether this editor should focus itself if nothing else is already
   /// focused.
@@ -484,7 +484,7 @@ class QuillEditorConfig {
     bool? scrollable,
     double? scrollBottomInset,
     bool? enableAlwaysIndentOnTab,
-    EdgeInsetsGeometry? padding,
+    EdgeInsets? padding,
     bool? autoFocus,
     bool? onTapOutsideEnabled,
     Function(PointerDownEvent event, FocusNode focusNode)? onTapOutside,

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -1222,71 +1222,6 @@ class RenderEditor extends RenderEditableContainerBox
     );
   }
 
-  /// Returns the y-offset of the editor at which [selection] is visible.
-  ///
-  /// The offset is the distance from the top of the editor and is the minimum
-  /// from the current scroll position until [selection] becomes visible.
-  /// Returns null if [selection] is already visible.
-  ///
-  /// Finds the closest scroll offset that fully reveals the editing cursor.
-  ///
-  /// The `scrollOffset` parameter represents current scroll offset in the
-  /// parent viewport.
-  ///
-  /// The `offsetInViewport` parameter represents the editor's vertical offset
-  /// in the parent viewport. This value should normally be 0.0 if this editor
-  /// is the only child of the viewport or if it's the topmost child. Otherwise
-  /// it should be a positive value equal to total height of all siblings of
-  /// this editor from above it.
-  ///
-  /// Returns `null` if the cursor is currently visible.
-  double? getOffsetToRevealCursor(
-      double viewportHeight, double scrollOffset, double offsetInViewport) {
-    // Endpoints coordinates represents lower left or lower right corner of
-    // the selection. If we want to scroll up to reveal the caret we need to
-    // adjust the dy value by the height of the line. We also add a small margin
-    // so that the caret is not too close to the edge of the viewport.
-    final endpoints = getEndpointsForSelection(selection);
-
-    // when we drag the right handle, we should get the last point
-    TextSelectionPoint endpoint;
-    if (selection.isCollapsed) {
-      endpoint = endpoints.first;
-    } else {
-      if (selection is DragTextSelection) {
-        endpoint = (selection as DragTextSelection).first
-            ? endpoints.first
-            : endpoints.last;
-      } else {
-        endpoint = endpoints.first;
-      }
-    }
-
-    // Collapsed selection => caret
-    final child = childAtPosition(selection.extent);
-    const kMargin = 8.0;
-
-    final caretTop = endpoint.point.dy -
-        child.preferredLineHeight(TextPosition(
-            offset: selection.extentOffset - child.container.documentOffset)) -
-        kMargin +
-        offsetInViewport +
-        scrollBottomInset;
-    final caretBottom =
-        endpoint.point.dy + kMargin + offsetInViewport + scrollBottomInset;
-    double? dy;
-    if (caretTop < scrollOffset) {
-      dy = caretTop;
-    } else if (caretBottom > scrollOffset + viewportHeight) {
-      dy = caretBottom - viewportHeight;
-    }
-    if (dy == null) {
-      return null;
-    }
-    // Clamping to 0.0 so that the content does not jump unnecessarily.
-    return math.max(dy, 0);
-  }
-
   @override
   Rect getLocalRectForCaret(TextPosition position) {
     final targetChild = childAtPosition(position);
@@ -1297,6 +1232,10 @@ class RenderEditor extends RenderEditableContainerBox
     final boxParentData = targetChild.parentData as BoxParentData;
     return childLocalRect.shift(Offset(0, boxParentData.offset.dy));
   }
+
+  TextPosition get caretTextPosition => _floatingCursorRect == null
+      ? selection.extent
+      : _floatingCursorTextPosition;
 
   // Start floating cursor
 

--- a/lib/src/editor/raw_editor/config/raw_editor_config.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_config.dart
@@ -159,7 +159,7 @@ class QuillRawEditorConfig {
   final KeyEventResult? Function(KeyEvent event, Node? node)? onKeyPressed;
 
   /// Additional space around the editor contents.
-  final EdgeInsetsGeometry padding;
+  final EdgeInsets padding;
 
   /// Enables always indenting when the TAB key is pressed.
   ///

--- a/lib/src/toolbar/config/buttons/link_style_options.dart
+++ b/lib/src/toolbar/config/buttons/link_style_options.dart
@@ -1,4 +1,4 @@
-/// @docImport '../../../rules/insert.dart' show AutoFormatMultipleLinksRule;
+/// @docImport '../../../rules/insert.dart';
 library;
 
 import '../../../common/utils/link_validator.dart';


### PR DESCRIPTION
<!-- 
Briefly describe your changes and summarize in the title.
Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md
Package versioning is automated.
Add updates to `Unreleased` in `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
-->

## Description

For this fix, I copied all code based on flutter `editable_text.dart` to have the same behavior. I have pushed multiple commits to track the changes:
- The first commit is just copied original code from Flutter (no change): [editable_text.dart#L4228](https://github.com/flutter/flutter/blob/3.29.0/packages/flutter/lib/src/widgets/editable_text.dart#L4228)
- The second commit is refactoring to fit flutter_quill


## Related Issues
- https://github.com/singerdmx/flutter-quill/issues/2569

## Fixed Demo

https://github.com/user-attachments/assets/ae027618-21c6-499f-a3e8-4bc338f79a18

## Type of Change

<!---
Check the boxes that apply with x and leave the others empty. For example:
- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without changing current behavior.
-->

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
