### PR TITLE
Proposed fix for issue where closeConnectionIfNeeded() was initiating a _markNeedsBuild() during dispose, causing exception

### DIFF
--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -960,6 +960,10 @@ class QuillRawEditorState extends EditorState
 
   @override
   void dispose() {
+    if (!widget.config.readOnly) {
+      widget.config.focusNode.removeListener(_handleFocusChanged);
+      composingRange.removeListener(_onComposingRangeChanged);
+    }
     closeConnectionIfNeeded();
     _keyboardVisibilitySubscription?.cancel();
     HardwareKeyboard.instance.removeHandler(_hardwareKeyboardEvent);
@@ -967,10 +971,6 @@ class QuillRawEditorState extends EditorState
     _selectionOverlay?.dispose();
     _selectionOverlay = null;
     controller.removeListener(_didChangeTextEditingValueListener);
-    if (!widget.config.readOnly) {
-      widget.config.focusNode.removeListener(_handleFocusChanged);
-      composingRange.removeListener(_onComposingRangeChanged);
-    }
     _cursorCont.dispose();
     if (_clipboardStatus != null) {
       _clipboardStatus!


### PR DESCRIPTION
### Proposed fix for issue where closeConnectionIfNeeded() was initiating a _markNeedsBuild() during dispose, causing exception

Using flutter_quill `11.4.1` I was hitting this error in my flutter app, where by:

1. Load a widget with Quill (whole screen editor, with back button)
2. User hits back button.
3. App copies text out of Quill.
4. App changes page (setPageIndex), which disposes the Quill widget.
5. Quill's `dispose()` fires `closeConnectionIfNeeded()'
6. Which changes `RawEditorStateTextInputClientMixin._lastKnownRemoteTextEditingValue`
7. Which notifies `QuillRawEditorState._onComposingRangeChanged()`
8. Which fires `_markNeedsBuild()` because `mounted = true` still

I'm an experienced engineer outside of dart, but I've been dabbling here for a few months. This may be the way my own app is setup, bungling the process, but I dug through this for a few hours and this PR was my best attempt at a fix today.

Here's the error stack:

![Screenshot 2025-06-13 at 13 11 28](https://github.com/user-attachments/assets/3f39f8e2-39d0-4cd2-87ff-f6b8978f0e00)


## PR Description

Reorders `dispose()` actions, making sure `composingRange.removeListener(_onComposingRangeChanged);` fires before `closeConnectionIfNeeded()` to avoid the latter firing the former and leading to an exception.

## Type of Change

- [x] 🛠️ **Bug fix:** Resolves an issue without changing current behavior.