### PR TITLE
fix: show paste menu on double tap in QuillEditor

### DIFF
--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -257,6 +257,9 @@ class QuillEditorState extends State<QuillEditor>
           theme.colorScheme.primary.withValues(alpha: 0.40);
     }
 
+    final isMobile = Theme.of(context).platform == TargetPlatform.iOS ||
+        Theme.of(context).platform == TargetPlatform.android;
+
     final showSelectionToolbar =
         config.enableInteractiveSelection && config.enableSelectionToolbar;
 

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -525,6 +525,13 @@ class QuillRawEditorState extends EditorState
         bringIntoView(selection.extent);
       }
     }
+
+    // Show toolbar on selection change if it's not from drag
+    if (cause != SelectionChangedCause.drag && 
+        cause != SelectionChangedCause.toolbar &&
+        widget.config.contextMenuBuilder != null) {
+      showToolbar();
+    }
   }
 
   void _handleSelectionCompleted() {

--- a/lib/src/editor/widgets/delegate.dart
+++ b/lib/src/editor/widgets/delegate.dart
@@ -286,19 +286,11 @@ class EditorTextSelectionGestureDetectorBuilder {
   ///  which triggers this callback.
   @protected
   void onDoubleTapDown(TapDownDetails details) {
-    if (delegate.selectionEnabled) {
-      renderEditor!.selectWord(SelectionChangedCause.tap);
-      // allow the selection to get updated before trying to bring up
-      // toolbars.
-      //
-      // if double tap happens on an editor that doesn't
-      // have focus, selection hasn't been set when the toolbars
-      // get added
-      SchedulerBinding.instance.addPostFrameCallback((_) {
-        if (checkSelectionToolbarShouldShow(isAdditionalAction: false)) {
-          editor!.showToolbar();
-        }
-      });
+    renderEditor!.handleTapDown(details);
+    final selection = renderEditor!.getSelectionForPosition(details.globalPosition);
+    if (selection != null) {
+      renderEditor!.handleSelectionChanged(selection, SelectionChangedCause.tap);
+      editor!.showToolbar();
     }
   }
 
@@ -357,6 +349,7 @@ class EditorTextSelectionGestureDetectorBuilder {
   /// the handlers provided by this builder.
   ///
   /// The [child] or its subtree should contain [EditableText].
+  @override
   Widget build({
     required HitTestBehavior behavior,
     required Widget child,


### PR DESCRIPTION
Fix: Show Paste Menu on Double Tap in QuillEditor

Problem
Currently, the QuillEditor does not show the context menu (paste/copy/cut/select) when a user double taps on a word, which is the default behavior in Flutter’s built-in TextField. This makes it less intuitive for users who expect the paste menu to appear on a double tap, especially when comparing with standard Flutter text input widgets.

Steps to Reproduce
Tap a word in the QuillEditor (field focuses).
Tap the word again (double tap) to try to summon the paste menu.
Actual: The paste menu does not appear.
Expected: The paste menu should appear, just like in Flutter’s TextField.

Solution
Improved gesture handling in the editor to show the context menu (paste menu) on double tap.
Modified the selection change logic to ensure the toolbar appears on selection changes that are not caused by drag or toolbar actions.
Now, tapping a word focuses the field, and double tapping shows the paste menu, matching the behavior of Flutter’s TextField.
