### PR TITLE
Fix: show toolbar on double tap in QuillEditor

### DIFF
--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -1135,7 +1135,11 @@ class QuillRawEditorState extends EditorState
 
   void _updateOrDisposeSelectionOverlayIfNeeded() {
     if (_selectionOverlay != null) {
-      if (!_hasFocus || textEditingValue.selection.isCollapsed) {
+      if (!_hasFocus) {
+        _selectionOverlay!.dispose();
+        _selectionOverlay = null;
+      } else if (textEditingValue.selection.isCollapsed && _selectionOverlay!.toolbar == null) {
+        // Only dispose the selection overlay when selection is collapsed and no toolbar is shown
         _selectionOverlay!.dispose();
         _selectionOverlay = null;
       } else {

--- a/test/double_tap_toolbar_test.dart
+++ b/test/double_tap_toolbar_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_quill/quill_delta.dart';
+import 'package:flutter/material.dart' show MaterialTextSelectionToolbar;
+import 'package:flutter/cupertino.dart' show CupertinoTextSelectionToolbar;
+
+void main() {
+  group('Double Tap Toolbar Test', () {
+    late QuillController controller;
+
+    setUp(() {
+      controller = QuillController.basic();
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    testWidgets('should show toolbar on double tap', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: QuillEditor.basic(
+              controller: controller,
+              config: const QuillEditorConfig(),
+            ),
+          ),
+        ),
+      );
+
+      // Add some text to the editor
+      controller.document = Document.fromDelta(
+        Delta()..insert('Hello World\n'),
+      );
+      await tester.pumpAndSettle();
+
+      // Double tap on the text
+      await tester.tap(find.byType(QuillEditor));
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tap(find.byType(QuillEditor));
+      await tester.pumpAndSettle();
+
+      // Check for any known toolbar widget by type name
+      final toolbarTypeNames = [
+        'AdaptiveTextSelectionToolbar',
+        'MaterialTextSelectionToolbar',
+        'CupertinoTextSelectionToolbar',
+      ];
+      final foundToolbar = tester.allWidgets.any(
+        (widget) => toolbarTypeNames.contains(widget.runtimeType.toString()),
+      );
+      expect(foundToolbar, isTrue, reason: 'Toolbar should be shown on double tap');
+    });
+  });
+} 


### PR DESCRIPTION
## 🐛 Bug Fix

**Issue**: Double tap on text in QuillEditor doesn't show the paste field/context menu, unlike Flutter's native TextField.

**Related Issue**: [Issue #2594](https://github.com/singerdmx/flutter-quill/issues/2594)

## �� Problem Analysis

When users double-tap on text in QuillEditor:
- ✅ First tap: Field focuses correctly
- ❌ Second tap: Paste field/context menu doesn't appear
- ✅ Expected: Paste field should appear (like in Flutter's TextField)

The issue occurs because the selection overlay is disposed immediately when the selection becomes collapsed after word selection, preventing the toolbar from being displayed.

## 🛠️ Solution

Modified the `_updateOrDisposeSelectionOverlayIfNeeded()` method in `lib/src/editor/raw_editor/raw_editor_state.dart` to:

- **Delay disposal** of selection overlay when selection is collapsed
- **Allow toolbar display** even when selection is collapsed
- **Maintain existing functionality** for all other scenarios

### Key Changes

```dart
// Before: Selection overlay disposed immediately when collapsed
if (!_hasFocus || textEditingValue.selection.isCollapsed) {
  _selectionOverlay!.dispose();
  _selectionOverlay = null;
}

// After: Only dispose when no toolbar is shown
if (!_hasFocus) {
  _selectionOverlay!.dispose();
  _selectionOverlay = null;
} else if (textEditingValue.selection.isCollapsed && _selectionOverlay!.toolbar == null) {
  // Only dispose when selection is collapsed and no toolbar is shown
  _selectionOverlay!.dispose();
  _selectionOverlay = null;
}
```

## ✅ Testing

- **Added test**: `test/double_tap_toolbar_test.dart` verifies toolbar appears on double tap
- **Existing tests pass**: Clipboard, context menu, and other functionality unaffected
- **Manual testing**: Confirmed behavior matches Flutter's native TextField

## 🎯 Impact

- **Fixes**: Double tap now shows paste field/context menu
- **Maintains**: All existing functionality (long press, selection, etc.)
- **Improves**: User experience consistency with native Flutter widgets
- **No breaking changes**: Backward compatible

## 📋 Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New test added (or existing test updated)
- [x] All existing tests pass
- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Documentation updated (if applicable)

## 🔗 Related

- Closes #[Issue Number]
- Addresses user feedback about inconsistent behavior with native TextField