### PR TITLE
feat: Swallow Tab key events and prevent propagation

### DIFF
--- a/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
@@ -78,6 +78,15 @@ class EditorKeyboardShortcuts extends StatelessWidget {
   }
 
   KeyEventResult _onKeyEvent(node, KeyEvent event) {
+    final isTab = event.logicalKey == LogicalKeyboardKey.tab;
+    // Swallow Tab before Quill ever sees it
+    if (event is KeyDownEvent && isTab) {
+      // move focus onward
+      FocusManager.instance.primaryFocus?.nextFocus();
+      // stop propagation so it does not insert a tab character
+      return KeyEventResult.handled;
+    }
+
     final onKey = onKeyPressed;
     if (onKey != null) {
       // Find the current node the user is on.
@@ -93,7 +102,6 @@ class EditorKeyboardShortcuts extends StatelessWidget {
       return KeyEventResult.ignored;
     }
 
-    final isTab = event.logicalKey == LogicalKeyboardKey.tab;
     final isSpace = event.logicalKey == LogicalKeyboardKey.space;
     final containsSelection =
         controller.selection.baseOffset != controller.selection.extentOffset;


### PR DESCRIPTION
## Description

When using the QuillEditor with a hardware keyboard, pressing the Tab key always inserts a tab/space character into the document. 

This breaks standard keyboard focus and traps users inside the editor, making keyboard navigation and accessibility impossible.

Known issue with Flutter Quill:
https://github.com/singerdmx/flutter-quill/issues/1871#event-13249190906

## Related Issues
https://github.com/singerdmx/flutter-quill/issues/1871#event-13249190906

## Type of Change

- [x] ✨ **Feature:** New functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
