### PR TITLE
fix(web): Remove KeyboardListener causing extra Tab stop in focus traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **[Web]** Remove unnecessary `KeyboardListener` that was causing an extra Tab stop in focus traversal, improving keyboard navigation efficiency.
+
 ### Added
 
 - Added localization support for `mn` (Mongolian, Mongolia)

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -330,7 +330,7 @@ class QuillEditorState extends State<QuillEditor>
       ),
     );
 
-    final editor = selectionEnabled
+    return selectionEnabled
         ? _selectionGestureDetectorBuilder.build(
             behavior: HitTestBehavior.translucent,
             detectWordBoundary: config.detectWordBoundary,
@@ -339,8 +339,6 @@ class QuillEditorState extends State<QuillEditor>
             quillMagnifierBuilder: config.quillMagnifierBuilder,
           )
         : child;
-
-    return editor;
   }
 
   EmbedBuilder _getEmbedBuilder(Embed node) {

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -340,20 +340,6 @@ class QuillEditorState extends State<QuillEditor>
           )
         : child;
 
-    if (kIsWeb) {
-      // Intercept RawKeyEvent on Web to prevent it from propagating to parents
-      // that might interfere with the editor key behavior, such as
-      // SingleChildScrollView. Thanks to @wliumelb for the workaround.
-      // See issue https://github.com/singerdmx/flutter-quill/issues/304
-      return KeyboardListener(
-        onKeyEvent: (_) {},
-        focusNode: FocusNode(
-          onKeyEvent: (node, event) => KeyEventResult.skipRemainingHandlers,
-        ),
-        child: editor,
-      );
-    }
-
     return editor;
   }
 


### PR DESCRIPTION
## Description

This PR removes the web-specific `KeyboardListener` that was causing inefficient Tab navigation focus on Flutter Web.

**Current behavior:** On Flutter Web, users need an extra Tab press to reach the Quill editor because a `KeyboardListener` with a `FocusNode` creates an additional focus stop in the tab order, making keyboard navigation inefficient.

**New behavior:** Tab navigation works efficiently across all platforms, allowing users to focus the editor directly without unnecessary extra tab stops.

**Motivation:** The original `KeyboardListener` was added as a workaround for issue #304 to prevent key event interference with parent widgets like `SingleChildScrollView`. However, the original issue could not be reproduced in current Flutter/Quill versions, while the workaround was creating an unnecessary focus traversal step. This change prioritizes efficient keyboard navigation and code simplification.

**Alternative solution:** If the original issue #304 resurfaces, an alternative approach would be to add `skipTraversal: true` to the `FocusNode` instead of removing the entire `KeyboardListener`.

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.