### PR TITLE
Fixed no underline displayed for characters being converted with IME

### DIFF
--- a/lib/src/document/nodes/node.dart
+++ b/lib/src/document/nodes/node.dart
@@ -51,6 +51,8 @@ abstract base class Node extends LinkedListEntry<Node> {
 
   Node clone() => newInstance()..applyStyle(style);
 
+  Node cloneWithOffset() => clone()..parent = parent.._offset = offset;
+
   int? _offset;
 
   /// Offset in characters of this node relative to [parent] node.

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -251,7 +251,7 @@ class _TextLineState extends State<TextLine> {
       }
 
       // here child is Text node and its value is cloned
-      textNodes.add(child.clone());
+      textNodes.add(child.cloneWithOffset());
     }
 
     if (textNodes.isNotEmpty) {


### PR DESCRIPTION

## Description

* This PR Fixed no underline displayed for characters being converted with IME within a hasEmbed line on iOS

## Related Issues

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
