### PR TITLE
fix: viewId when no View in context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `View.of(context)` calls throwing when used with the `screenshot` package.
+
 ## [11.4.2] - 2025-07-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed `View.of(context)` calls throwing when used with the `screenshot` package.
+- Fixed `View.of(context)` calls throwing when used with the `screenshot` package [#2662](https://github.com/singerdmx/flutter-quill/pull/2662).
 
 ## [11.4.2] - 2025-07-22
 

--- a/lib/src/common/extensions/view_id_ext.dart
+++ b/lib/src/common/extensions/view_id_ext.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/widgets.dart';
+
+extension ViewIdExt on BuildContext {
+  int? getViewId() {
+    late final platformDispatcher = WidgetsBinding.instance.platformDispatcher;
+    return View.maybeOf(this)?.viewId ??
+        // If context has no View, check platformDispatcher
+        platformDispatcher.views.firstOrNull?.viewId ??
+        platformDispatcher.implicitView?.viewId;
+  }
+}

--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -7,6 +7,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 
+import '../../common/extensions/view_id_ext.dart';
 import '../../delta/delta_diff.dart';
 import '../../document/document.dart';
 import '../editor.dart';
@@ -89,7 +90,7 @@ mixin RawEditorStateTextInputClientMixin on EditorState
           allowedMimeTypes: widget.config.contentInsertionConfiguration == null
               ? const <String>[]
               : widget.config.contentInsertionConfiguration!.allowedMimeTypes,
-          viewId: View.of(context).viewId,
+          viewId: context.getViewId(),
         ),
       );
 

--- a/lib/src/editor/raw_editor/scribble_focusable.dart
+++ b/lib/src/editor/raw_editor/scribble_focusable.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 
+import '../../common/extensions/view_id_ext.dart';
+
 class ScribbleFocusable extends StatefulWidget {
   const ScribbleFocusable({
     required this.child,
@@ -87,10 +89,16 @@ class _ScribbleFocusableState extends State<ScribbleFocusable>
     if (!calculatedBounds.overlaps(rect)) {
       return false;
     }
+
+    final viewId = context.getViewId();
+    if (viewId == null) {
+      // Can't perform hit testing without a viewId
+      return false;
+    }
+
     final intersection = calculatedBounds.intersect(rect);
     final result = HitTestResult();
-    WidgetsBinding.instance
-        .hitTestInView(result, intersection.center, View.of(context).viewId);
+    WidgetsBinding.instance.hitTestInView(result, intersection.center, viewId);
     return result.path.any((entry) =>
         entry.target == _renderBoxForEditor ||
         entry.target == _renderBoxForBounds);


### PR DESCRIPTION
<!-- 
Briefly describe your changes and summarize in the title.
Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md
Package versioning is automated.
Add updates to `Unreleased` in `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
-->

## Description

When using the quill editor in the `screenshot` package, there is no `View` associated with the context, leading `View.of(context)` calls to throw.

Note that this PR fixes the `View.of(context)` error, but the following `QuillRawEditorState.renderEditor` null error is not fixed yet:
```
════════ Exception caught by foundation library ════════════════════════════════
The following _TypeError was thrown while dispatching notifications for FocusNode:
Null check operator used on a null value

When the exception was thrown, this was the stack:
#0      QuillRawEditorState.renderEditor (package:flutter_quill/src/editor/raw_editor/raw_editor_state.dart:1177:32)
raw_editor_state.dart:1177
#1      RawEditorStateTextInputClientMixin._updateSizeAndTransform (package:flutter_quill/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart:390:20)
raw_editor_state_text_input_client_mixin.dart:390
#2      RawEditorStateTextInputClientMixin.openConnectionIfNeeded (package:flutter_quill/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart:97:7)
raw_editor_state_text_input_client_mixin.dart:97
#3      QuillRawEditorState.requestKeyboard (package:flutter_quill/src/editor/raw_editor/raw_editor_state.dart:1194:7)
raw_editor_state.dart:1194

```

## Related issues

We had a similar problem before with:
- https://github.com/singerdmx/flutter-quill/issues/1314
- https://github.com/singerdmx/flutter-quill/pull/1315

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [X] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
