### PR TITLE
fix: correct selection while scrolling

### DIFF
--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -984,19 +984,21 @@ class RenderEditor extends RenderEditableContainerBox
 
     if (position.offset < _extendSelectionOrigin!.baseOffset) {
       _handleSelectionChange(
-        TextSelection(
+        DragTextSelection(
           baseOffset: position.offset,
           extentOffset: _extendSelectionOrigin!.extentOffset,
           affinity: selection.affinity,
+          first: true,
         ),
         cause,
       );
     } else if (position.offset > _extendSelectionOrigin!.extentOffset) {
       _handleSelectionChange(
-        TextSelection(
+        DragTextSelection(
           baseOffset: _extendSelectionOrigin!.baseOffset,
           extentOffset: position.offset,
           affinity: selection.affinity,
+          first: false,
         ),
         cause,
       );
@@ -1055,10 +1057,11 @@ class RenderEditor extends RenderEditableContainerBox
       extentOffset = math.max(fromPosition.offset, toPosition.offset);
     }
 
-    final newSelection = TextSelection(
+    final newSelection = DragTextSelection(
       baseOffset: baseOffset,
       extentOffset: extentOffset,
       affinity: fromPosition.affinity,
+      first: toPosition == null || fromPosition.offset <= toPosition.offset,
     );
 
     // Call [onSelectionChanged] only when the selection actually changed.

--- a/lib/src/editor/widgets/text/text_selection.dart
+++ b/lib/src/editor/widgets/text/text_selection.dart
@@ -498,22 +498,24 @@ class _TextSelectionHandleOverlayState
 
     final isNormalized =
         widget.selection.extentOffset >= widget.selection.baseOffset;
-    TextSelection newSelection;
+    DragTextSelection newSelection;
     switch (widget.position) {
       case _TextSelectionHandlePosition.start:
-        newSelection = TextSelection(
+        newSelection = DragTextSelection(
           baseOffset:
               isNormalized ? position.offset : widget.selection.baseOffset,
           extentOffset:
               isNormalized ? widget.selection.extentOffset : position.offset,
+          first: true,
         );
         break;
       case _TextSelectionHandlePosition.end:
-        newSelection = TextSelection(
+        newSelection = DragTextSelection(
           baseOffset:
               isNormalized ? widget.selection.baseOffset : position.offset,
           extentOffset:
               isNormalized ? position.offset : widget.selection.extentOffset,
+          first: false,
         );
         break;
     }


### PR DESCRIPTION
<!-- 
Briefly describe your changes and summarize in the title.
Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md
Package versioning is automated.
Add updates to `Unreleased` in `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
-->

## Description

Fixed a bug on desktop/web that occurred when extending the current selection by holding down the left mouse button and scrolling up or down with the mouse wheel.

By default, scrolling snaps back to the starting offset of the selection. This PR uses the existing DragTextSelection class to indicate whether the selection is moving up or down, allowing the scroll to move to the start or end accordingly.

Bug example:

https://github.com/user-attachments/assets/50b92767-2c7b-47c4-bfec-44cc4a2fc25f



## Related Issues

<!--
Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/singerdmx/flutter-quill/issues). Indicate, which of these issues are resolved or fixed by this PR.
*e.g.*
- *Fix #123*
- *Related #456*
-->
Fix #2590


## Type of Change

<!---
Check the boxes that apply with x and leave the others empty. For example:
- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without changing current behavior.
-->

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
