### PR TITLE
refactor: update localization handling to fall back to English and im…

### DIFF
--- a/flutter_quill_extensions/pubspec.yaml
+++ b/flutter_quill_extensions/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   web: ">=0.5.0 <2.0.0"
   path: ^1.8.0
 
-  flutter_quill: ^11.0.0
+  flutter_quill:
   photo_view: ^0.15.0
 
   # Plugins

--- a/flutter_quill_extensions/pubspec.yaml
+++ b/flutter_quill_extensions/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   web: ">=0.5.0 <2.0.0"
   path: ^1.8.0
 
-  flutter_quill:
+  flutter_quill: ^11.0.0
   photo_view: ^0.15.0
 
   # Plugins

--- a/lib/src/l10n/extensions/localizations_ext.dart
+++ b/lib/src/l10n/extensions/localizations_ext.dart
@@ -1,7 +1,12 @@
 import 'package:flutter/widgets.dart' show BuildContext;
 
 import '../generated/quill_localizations.dart';
+import '../generated/quill_localizations_en.dart';
 
+@Deprecated(
+  'FlutterQuill now falls back to English strings when the localization '
+  'delegate is missing. This exception will be removed in a future release.',
+)
 class MissingFlutterQuillLocalizationException extends UnimplementedError {
   MissingFlutterQuillLocalizationException();
   @override
@@ -13,11 +18,14 @@ class MissingFlutterQuillLocalizationException extends UnimplementedError {
 }
 
 extension LocalizationsExt on BuildContext {
-  /// Require the [FlutterQuillLocalizations] instance.
+  static final FlutterQuillLocalizations _fallbackLocalization =
+      FlutterQuillLocalizationsEn();
+
+  /// Retrieve the [FlutterQuillLocalizations] instance, falling back to the
+  /// default English messages if no delegate is registered.
   ///
-  /// `loc` is short for `localizations`
+  /// `loc` is short for `localizations`.
   FlutterQuillLocalizations get loc {
-    return FlutterQuillLocalizations.of(this) ??
-        (throw MissingFlutterQuillLocalizationException());
+    return FlutterQuillLocalizations.of(this) ?? _fallbackLocalization;
   }
 }


### PR DESCRIPTION
<!-- 
Briefly describe your changes and summarize in the title.
Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md
Package versioning is automated.
Add updates to `Unreleased` in `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
-->

## Description

**Localization fallback improvements:**

* The `loc` getter in the `LocalizationsExt` extension now falls back to the default English localization (`FlutterQuillLocalizationsEn`) if no delegate is registered, instead of throwing a `MissingFlutterQuillLocalizationException`.
* The `MissingFlutterQuillLocalizationException` class is now marked as deprecated, as it will be removed in a future release.

**Test updates:**

* Tests in `editor_test.dart` were updated to verify that no exception is thrown when the localization delegate is missing, and that English fallback messages are used. [[1]](diffhunk://#diff-58af8da82a007aef54a274e59147a4c58b10da296ba9b6b8179dd4d3f79c390bL161-R166) [[2]](diffhunk://#diff-58af8da82a007aef54a274e59147a4c58b10da296ba9b6b8179dd4d3f79c390bR176-R191)
* Tests now check that the provided localization delegate is used when available (e.g., Spanish), and that fallback localization provides correct interpolated messages when the delegate is missing.
## Related Issues

- *Related #2609 https://github.com/singerdmx/flutter-quill/issues/2609*

## Type of Change

<!---
Check the boxes that apply with x and leave the others empty. For example:
- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without changing current behavior.
-->

- [X] ✨ **Feature:** New functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [X] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
