### PR TITLE
fix: QuillToolbarSelectLineHeightStyleDropdownButton ignores defaultDisplayText

### DIFF
--- a/lib/src/toolbar/buttons/select_line_height_dropdown_button.dart
+++ b/lib/src/toolbar/buttons/select_line_height_dropdown_button.dart
@@ -48,6 +48,7 @@ class _QuillToolbarSelectLineHeightStyleDropdownButtonState
   Attribute<dynamic> _selectedItem = Attribute.lineHeight;
 
   final _menuController = MenuController();
+
   @override
   void initState() {
     super.initState();
@@ -97,9 +98,17 @@ class _QuillToolbarSelectLineHeightStyleDropdownButtonState
 
   String _label(Attribute<dynamic> attribute) {
     var label = LineHeightAttribute.lineHeightNormal.value.toString();
+
     if (attribute.value != null) {
       label = attribute.value.toString();
+    } else {
+      final defaultDisplayText = widget.options.defaultDisplayText;
+
+      if (defaultDisplayText != null && defaultDisplayText.isNotEmpty) {
+        label = defaultDisplayText;
+      }
     }
+
     return label;
   }
 


### PR DESCRIPTION
<!-- 
Briefly describe your changes and summarize in the title.
Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md
Package versioning is automated.
Add updates to `Unreleased` in `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
-->

## Description

Use defaultDisplayText in QuillToolbarSelectLineHeightStyleDropdownButton when no line-height attribute. Previously the label defaulted to “1”.

## Related Issues

Fixes #2680

## Type of Change

<!---
Check the boxes that apply with x and leave the others empty. For example:
- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without changing current behavior.
-->

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
