### PR TITLE
Wrap bottom sheet content in SafeAreas

### DIFF
--- a/flutter_quill_extensions/lib/src/toolbar/camera/select_camera_action.dart
+++ b/flutter_quill_extensions/lib/src/toolbar/camera/select_camera_action.dart
@@ -11,28 +11,33 @@ class SelectCameraActionDialog extends StatelessWidget {
     return SizedBox(
       height: 150,
       width: double.infinity,
-      child: SingleChildScrollView(
-        child: Column(
-          children: [
-            ListTile(
-              title: Text(context.loc.photo),
-              subtitle: Text(
-                context.loc.takeAPhotoUsingYourCamera,
+      child: SafeArea(
+        top: false,
+        left: false,
+        right: false,
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              ListTile(
+                title: Text(context.loc.photo),
+                subtitle: Text(
+                  context.loc.takeAPhotoUsingYourCamera,
+                ),
+                leading: const Icon(Icons.photo_sharp),
+                enabled: !isDesktopApp,
+                onTap: () => Navigator.of(context).pop(CameraAction.image),
               ),
-              leading: const Icon(Icons.photo_sharp),
-              enabled: !isDesktopApp,
-              onTap: () => Navigator.of(context).pop(CameraAction.image),
-            ),
-            ListTile(
-              title: Text(context.loc.video),
-              subtitle: Text(
-                context.loc.recordAVideoUsingYourCamera,
+              ListTile(
+                title: Text(context.loc.video),
+                subtitle: Text(
+                  context.loc.recordAVideoUsingYourCamera,
+                ),
+                leading: const Icon(Icons.camera),
+                enabled: !isDesktopApp,
+                onTap: () => Navigator.of(context).pop(CameraAction.video),
               ),
-              leading: const Icon(Icons.camera),
-              enabled: !isDesktopApp,
-              onTap: () => Navigator.of(context).pop(CameraAction.video),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/flutter_quill_extensions/lib/src/toolbar/image/select_image_source.dart
+++ b/flutter_quill_extensions/lib/src/toolbar/image/select_image_source.dart
@@ -11,35 +11,40 @@ class SelectImageSourceDialog extends StatelessWidget {
     return Container(
       constraints: const BoxConstraints(minHeight: 200),
       width: double.infinity,
-      child: SingleChildScrollView(
-        child: Column(
-          children: [
-            ListTile(
-              title: Text(context.loc.gallery),
-              subtitle: Text(
-                context.loc.pickAPhotoFromYourGallery,
+      child: SafeArea(
+        top: false,
+        left: false,
+        right: false,
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              ListTile(
+                title: Text(context.loc.gallery),
+                subtitle: Text(
+                  context.loc.pickAPhotoFromYourGallery,
+                ),
+                leading: const Icon(Icons.photo_sharp),
+                onTap: () => Navigator.of(context).pop(InsertImageSource.gallery),
               ),
-              leading: const Icon(Icons.photo_sharp),
-              onTap: () => Navigator.of(context).pop(InsertImageSource.gallery),
-            ),
-            ListTile(
-              title: Text(context.loc.camera),
-              subtitle: Text(
-                context.loc.takeAPhotoUsingYourCamera,
+              ListTile(
+                title: Text(context.loc.camera),
+                subtitle: Text(
+                  context.loc.takeAPhotoUsingYourCamera,
+                ),
+                leading: const Icon(Icons.camera),
+                enabled: !isDesktopApp,
+                onTap: () => Navigator.of(context).pop(InsertImageSource.camera),
               ),
-              leading: const Icon(Icons.camera),
-              enabled: !isDesktopApp,
-              onTap: () => Navigator.of(context).pop(InsertImageSource.camera),
-            ),
-            ListTile(
-              title: Text(context.loc.link),
-              subtitle: Text(
-                context.loc.pasteAPhotoUsingALink,
+              ListTile(
+                title: Text(context.loc.link),
+                subtitle: Text(
+                  context.loc.pasteAPhotoUsingALink,
+                ),
+                leading: const Icon(Icons.link),
+                onTap: () => Navigator.of(context).pop(InsertImageSource.link),
               ),
-              leading: const Icon(Icons.link),
-              onTap: () => Navigator.of(context).pop(InsertImageSource.link),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/flutter_quill_extensions/lib/src/toolbar/video/select_video_source.dart
+++ b/flutter_quill_extensions/lib/src/toolbar/video/select_video_source.dart
@@ -11,33 +11,38 @@ class SelectVideoSourceDialog extends StatelessWidget {
     return Container(
       constraints: const BoxConstraints(minHeight: 200),
       width: double.infinity,
-      child: SingleChildScrollView(
-        child: Column(
-          children: [
-            ListTile(
-              title: Text(context.loc.gallery),
-              subtitle: Text(
-                context.loc.pickAVideoFromYourGallery,
+      child: SafeArea(
+        top: false,
+        left: false,
+        right: false,
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              ListTile(
+                title: Text(context.loc.gallery),
+                subtitle: Text(
+                  context.loc.pickAVideoFromYourGallery,
+                ),
+                leading: const Icon(Icons.photo_sharp),
+                onTap: () => Navigator.of(context).pop(InsertVideoSource.gallery),
               ),
-              leading: const Icon(Icons.photo_sharp),
-              onTap: () => Navigator.of(context).pop(InsertVideoSource.gallery),
-            ),
-            ListTile(
-              title: Text(context.loc.camera),
-              subtitle: Text(context.loc.recordAVideoUsingYourCamera),
-              leading: const Icon(Icons.camera),
-              enabled: !isDesktopApp,
-              onTap: () => Navigator.of(context).pop(InsertVideoSource.camera),
-            ),
-            ListTile(
-              title: Text(context.loc.link),
-              subtitle: Text(
-                context.loc.pasteAVideoUsingALink,
+              ListTile(
+                title: Text(context.loc.camera),
+                subtitle: Text(context.loc.recordAVideoUsingYourCamera),
+                leading: const Icon(Icons.camera),
+                enabled: !isDesktopApp,
+                onTap: () => Navigator.of(context).pop(InsertVideoSource.camera),
               ),
-              leading: const Icon(Icons.link),
-              onTap: () => Navigator.of(context).pop(InsertVideoSource.link),
-            ),
-          ],
+              ListTile(
+                title: Text(context.loc.link),
+                subtitle: Text(
+                  context.loc.pasteAVideoUsingALink,
+                ),
+                leading: const Icon(Icons.link),
+                onTap: () => Navigator.of(context).pop(InsertVideoSource.link),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -1286,6 +1286,9 @@ class QuillRawEditorState extends EditorState
   }
 
   @override
+  bool onFocusReceived() => false;
+
+  @override
   bool get liveTextInputEnabled => false;
 
   @override

--- a/lib/src/editor/widgets/link.dart
+++ b/lib/src/editor/widgets/link.dart
@@ -228,25 +228,33 @@ Future<LinkMenuAction> _showMaterialMenu(
   final result = await showModalBottomSheet<LinkMenuAction>(
     context: context,
     builder: (ctx) {
-      return Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          _MaterialAction(
-            title: context.loc.open,
-            icon: Icons.language_sharp,
-            onPressed: () => Navigator.of(context).pop(LinkMenuAction.launch),
-          ),
-          _MaterialAction(
-            title: context.loc.copy,
-            icon: Icons.copy_sharp,
-            onPressed: () => Navigator.of(context).pop(LinkMenuAction.copy),
-          ),
-          _MaterialAction(
-            title: context.loc.remove,
-            icon: Icons.link_off_sharp,
-            onPressed: () => Navigator.of(context).pop(LinkMenuAction.remove),
-          ),
-        ],
+      return SafeArea(
+        top: false,
+        left: false,
+        right: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _MaterialAction(
+              title: context.loc.open,
+              icon: Icons.language_sharp,
+              onPressed: () =>
+                  Navigator.of(context).pop(LinkMenuAction.launch),
+            ),
+            _MaterialAction(
+              title: context.loc.copy,
+              icon: Icons.copy_sharp,
+              onPressed: () =>
+                  Navigator.of(context).pop(LinkMenuAction.copy),
+            ),
+            _MaterialAction(
+              title: context.loc.remove,
+              icon: Icons.link_off_sharp,
+              onPressed: () =>
+                  Navigator.of(context).pop(LinkMenuAction.remove),
+            ),
+          ],
+        ),
       );
     },
   );


### PR DESCRIPTION
## Description

Currently, when the (old) three-button navigation mode is in use on Android, and the app uses fullscreen mode, the bottommost option on all bottom sheets opened by flutter-quill effectively get blocked by Android's system buttons, being shown behind the button bar:

<img width="491" height="332" alt="image" src="https://github.com/user-attachments/assets/0a0ba37e-8ba3-464a-a66f-52bcc66ac833" />

This PR wraps the bottom sheets in a proper `SafeArea` widget, which adds the necessary padding so that all options are reachable.

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
