### PR TITLE
fix: resolve drag-selection jumping issue on desktop

### DIFF
--- a/lib/src/document/history.dart
+++ b/lib/src/document/history.dart
@@ -32,6 +32,21 @@ class History {
   ///record delay
   final int interval;
 
+  bool _forceMergeNext = false;
+
+  bool get forceMergeNext => _forceMergeNext;
+
+  /// Forces the next change to merge into the last undo step.
+  /// Automatically resets to false after the current synchronous operations finish.
+  set forceMergeNext(bool value) {
+    _forceMergeNext = value;
+    if (value) {
+      Future.microtask(() {
+        _forceMergeNext = false;
+      });
+    }
+  }
+
   void handleDocChange(DocChange docChange) {
     if (ignoreChange) return;
     if (!userOnly || docChange.source == ChangeSource.local) {
@@ -51,7 +66,8 @@ class History {
     var undoDelta = change.invert(before);
     final timeStamp = DateTime.now().millisecondsSinceEpoch;
 
-    if (lastRecorded + interval > timeStamp && stack.undo.isNotEmpty) {
+    if ((forceMergeNext || lastRecorded + interval > timeStamp) &&
+        stack.undo.isNotEmpty) {
       final lastDelta = stack.undo.removeLast();
       undoDelta = undoDelta.compose(lastDelta);
     } else {

--- a/lib/src/editor/config/editor_config.dart
+++ b/lib/src/editor/config/editor_config.dart
@@ -37,6 +37,7 @@ class QuillEditorConfig {
     this.placeholder,
     this.checkBoxReadOnly,
     this.disableClipboard = false,
+    this.mergeImeCompositionHistory = false,
     this.textSelectionThemeData,
     this.showCursor,
     this.paintCursorAboveText,
@@ -189,6 +190,14 @@ class QuillEditorConfig {
   ///
   /// Defaults to `false`.
   final bool disableClipboard;
+
+  /// Whether to merge the IME composing text (uncommitted text) into a single
+  /// undo/redo history step.
+  ///
+  /// When set to `true`, typing Pinyin or other IME candidates will be grouped
+  /// together, preventing the undo stack from recording every single keystroke.
+  /// Defaults to `false`.
+  final bool mergeImeCompositionHistory;
 
   /// Whether this editor should create a scrollable container for its content.
   ///
@@ -481,6 +490,7 @@ class QuillEditorConfig {
     List<SpaceShortcutEvent>? spaceShortcutEvents,
     bool? checkBoxReadOnly,
     bool? disableClipboard,
+    bool? mergeImeCompositionHistory,
     bool? scrollable,
     double? scrollBottomInset,
     bool? enableAlwaysIndentOnTab,
@@ -541,6 +551,8 @@ class QuillEditorConfig {
       spaceShortcutEvents: spaceShortcutEvents ?? this.spaceShortcutEvents,
       checkBoxReadOnly: checkBoxReadOnly ?? this.checkBoxReadOnly,
       disableClipboard: disableClipboard ?? this.disableClipboard,
+      mergeImeCompositionHistory:
+          mergeImeCompositionHistory ?? this.mergeImeCompositionHistory,
       scrollable: scrollable ?? this.scrollable,
       onKeyPressed: onKeyPressed ?? this.onKeyPressed,
       scrollBottomInset: scrollBottomInset ?? this.scrollBottomInset,

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -278,6 +278,7 @@ class QuillEditorState extends State<QuillEditor>
         readOnly: controller.readOnly,
         checkBoxReadOnly: config.checkBoxReadOnly,
         disableClipboard: config.disableClipboard,
+        mergeImeCompositionHistory: config.mergeImeCompositionHistory,
         placeholder: config.placeholder,
         onLaunchUrl: config.onLaunchUrl,
         contextMenuBuilder: showSelectionToolbar

--- a/lib/src/editor/raw_editor/config/raw_editor_config.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_config.dart
@@ -38,6 +38,7 @@ class QuillRawEditorConfig {
     this.readOnly = false,
     this.checkBoxReadOnly,
     this.disableClipboard = false,
+    this.mergeImeCompositionHistory = false,
     this.placeholder,
     this.onLaunchUrl,
     this.contextMenuBuilder = defaultContextMenuBuilder,
@@ -196,6 +197,14 @@ class QuillRawEditorConfig {
   ///
   /// Defaults to `false`.
   final bool disableClipboard;
+
+  /// Whether to merge the IME composing text (uncommitted text) into a single
+  /// undo/redo history step.
+  ///
+  /// When set to `true`, typing Pinyin or other IME candidates will be grouped
+  /// together, preventing the undo stack from recording every single keystroke.
+  /// Defaults to `false`.
+  final bool mergeImeCompositionHistory;
 
   final String? placeholder;
 

--- a/lib/src/editor/raw_editor/raw_editor_state_selection_delegate_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_selection_delegate_mixin.dart
@@ -33,15 +33,17 @@ mixin RawEditorStateSelectionDelegateMixin on EditorState
   void bringIntoView(TextPosition position) {
     // Ignore errors if position is invalid (i.e. paste on iOS when editor
     // has no content and user pasted from toolbar)
-    try {
-      final localRect = renderEditor.getLocalRectForCaret(position);
-      final targetOffset = _getOffsetToRevealCaret(localRect, position);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      try {
+        final localRect = renderEditor.getLocalRectForCaret(position);
+        final targetOffset = _getOffsetToRevealCaret(localRect, position);
 
-      if (scrollController.hasClients) {
-        scrollController.jumpTo(targetOffset.offset);
-      }
-      renderEditor.showOnScreen(rect: targetOffset.rect);
-    } catch (_) {}
+        if (scrollController.hasClients) {
+          scrollController.jumpTo(targetOffset.offset);
+        }
+        renderEditor.showOnScreen(rect: targetOffset.rect);
+      } catch (_) {}
+    });
   }
 
   // Finds the closest scroll offset to the current scroll offset that fully

--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -51,6 +51,11 @@ mixin RawEditorStateTextInputClientMixin on EditorState
   bool get hasConnection =>
       _textInputConnection != null && _textInputConnection!.attached;
 
+  /// Indicates if the IME was composing in the previous update.
+  /// Used by [QuillEditorConfig.mergeImeCompositionHistory] to merge
+  /// intermediate keystrokes (e.g., Pinyin) into a single undo step.
+  bool _wasComposing = false;
+
   /// Opens or closes input connection based on the current state of
   /// [focusNode] and [value].
   void openOrCloseConnection() {
@@ -211,6 +216,14 @@ mixin RawEditorStateTextInputClientMixin on EditorState
     if (_lastKnownRemoteTextEditingValue == value) {
       // There is no difference between this value and the last known value.
       return;
+    }
+
+    if (widget.config.mergeImeCompositionHistory) {
+      // Handle IME composition history.
+      // If the user was composing (e.g., typing Pinyin) in the previous step,
+      // force the upcoming document change to merge into the same undo step.
+      widget.controller.document.history.forceMergeNext = _wasComposing;
+      _wasComposing = value.composing.isValid;
     }
 
     // Check if only composing range changed.


### PR DESCRIPTION

<!-- 
Briefly describe your changes and summarize in the title.
Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md
Package versioning is automated.
Add updates to `Unreleased` in `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
-->

## Description

The Problem：When there are multiple lines of text, dragging to select from top to bottom causes the editor to jump back to the first line of the selection.

The Solution：Wrapped the `bringIntoView` logic in `WidgetsBinding.instance.addPostFrameCallback`. This ensures the scroll position is calculated and updated only after the layout is stable and the new caret position is ready.

## Related Issues
Fixes #2697, Fixes #1642

<!--
Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/singerdmx/flutter-quill/issues). Indicate, which of these issues are resolved or fixed by this PR.
*e.g.*
- *Fix #123*
- *Related #456*
-->

## Type of Change

<!---
Check the boxes that apply with x and leave the others empty. For example:
- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without changing current behavior.
-->
- [x] 🛠️ **Bug fix:** Resolves an issue without changing current behavior.
