### PR TITLE
Issue 2715 - Add length to custom Embeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added localization support for `mn` (Mongolian, Mongolia)
+- Added `length` property to `EmbedBuilder` and internal offset mapping so custom inline embeds (mentions, hashtags, etc.) can declare their character length for the platform keyboard, fixing `TextCapitalization.sentences` and word/sentence boundary detection around embeds [#2715](https://github.com/singerdmx/flutter-quill/issues/2715)
 
 ## [11.5.0] - 2025-10-18
 

--- a/lib/src/controller/quill_controller.dart
+++ b/lib/src/controller/quill_controller.dart
@@ -16,6 +16,7 @@ import '../document/nodes/leaf.dart';
 import '../document/structs/doc_change.dart';
 import '../document/style.dart';
 import '../editor/config/editor_config.dart';
+import '../editor/raw_editor/offset_mapping.dart';
 import '../editor/raw_editor/raw_editor_state.dart';
 import '../editor_toolbar_controller_shared/clipboard/clipboard_service_provider.dart';
 import 'clipboard/quill_controller_paste.dart';
@@ -81,6 +82,7 @@ class QuillController extends ChangeNotifier {
   set document(Document doc) {
     _document = doc;
     _setDocumentSearchProperties();
+    _cachedOffsetMapping = null;
 
     // Prevent the selection from
     _selection = const TextSelection(baseOffset: 0, extentOffset: 0);
@@ -136,6 +138,36 @@ class QuillController extends ChangeNotifier {
         text: document.toPlainText(),
         selection: selection,
       );
+
+  /// Cached offset mapping between document offsets and expanded-text offsets.
+  OffsetMapping? _cachedOffsetMapping;
+
+  /// Returns the [OffsetMapping] for the current document state.
+  ///
+  /// The mapping is lazily built and cached; it is invalidated automatically
+  /// whenever the controller notifies listeners (i.e. on every document or
+  /// selection change).
+  OffsetMapping get offsetMapping {
+    return _cachedOffsetMapping ??= buildOffsetMapping(
+      document.toDelta(),
+      _editorConfig?.embedBuilders,
+      _editorConfig?.unknownEmbedBuilder,
+    );
+  }
+
+  /// A [TextEditingValue] with embeds expanded to their [EmbedBuilder.toPlainText]
+  /// representation and the selection mapped to expanded-text offsets.
+  ///
+  /// This is sent to the platform so the OS keyboard can detect word and
+  /// sentence boundaries around inline embeds (e.g. for
+  /// [TextCapitalization.sentences]).
+  TextEditingValue get expandedTextEditingValue {
+    final mapping = offsetMapping;
+    return TextEditingValue(
+      text: mapping.expandedText,
+      selection: mapping.docToExpandedSelection(selection),
+    );
+  }
 
   /// Only attributes applied to all characters within this range are
   /// included in the result.
@@ -431,6 +463,12 @@ class QuillController extends ChangeNotifier {
     }
 
     notifyListeners();
+  }
+
+  @override
+  void notifyListeners() {
+    _cachedOffsetMapping = null;
+    super.notifyListeners();
   }
 
   @override

--- a/lib/src/editor/embed/embed_editor_builder.dart
+++ b/lib/src/editor/embed/embed_editor_builder.dart
@@ -11,6 +11,15 @@ abstract class EmbedBuilder {
   String get key;
   bool get expanded => true;
 
+  /// The character length this embed occupies in the text sent to the platform.
+  ///
+  /// Defaults to `1` (the single object-replacement character `\uFFFC`).
+  /// Override this together with [toPlainText] to return a value matching
+  /// the length of the plain-text representation so that the OS keyboard
+  /// can correctly detect word and sentence boundaries around the embed
+  /// (e.g. for [TextCapitalization.sentences]).
+  int get length => 1;
+
   WidgetSpan buildWidgetSpan(Widget widget) {
     return WidgetSpan(child: widget);
   }

--- a/lib/src/editor/raw_editor/offset_mapping.dart
+++ b/lib/src/editor/raw_editor/offset_mapping.dart
@@ -1,0 +1,237 @@
+import 'package:flutter/services.dart' show TextSelection, TextRange;
+
+import '../../../quill_delta.dart';
+import '../../document/nodes/embeddable.dart';
+import '../../document/nodes/leaf.dart';
+import '../embed/embed_editor_builder.dart';
+
+/// Records the position and expanded length of a single embed
+/// whose `toPlainText()` returns a string longer than 1 character.
+class EmbedSpan {
+  const EmbedSpan({
+    required this.docOffset,
+    required this.expandedOffset,
+    required this.expandedLength,
+  });
+
+  /// Offset of this embed in the document model (where it is length 1).
+  final int docOffset;
+
+  /// Offset of this embed in the expanded text.
+  final int expandedOffset;
+
+  /// Length of the embed's text in expanded form.
+  final int expandedLength;
+}
+
+/// Bidirectional mapping between document offsets (where embeds are length 1)
+/// and expanded-text offsets (where embeds use their `toPlainText()` length).
+///
+/// Used exclusively at the platform text-input boundary so that the OS
+/// keyboard sees real text for sentence/word boundary detection.
+class OffsetMapping {
+  OffsetMapping._({
+    required this.expandedText,
+    required List<EmbedSpan> embeds,
+  }) : _embeds = embeds;
+
+  /// The plain text with embeds expanded to their `toPlainText()` value.
+  final String expandedText;
+
+  /// Embed spans sorted by [EmbedSpan.docOffset].
+  final List<EmbedSpan> _embeds;
+
+  /// Convert a document offset to the corresponding expanded-text offset.
+  int docToExpanded(int docOffset) {
+    var shift = 0;
+    for (final embed in _embeds) {
+      if (embed.docOffset < docOffset) {
+        shift += embed.expandedLength - 1;
+      } else {
+        break;
+      }
+    }
+    return docOffset + shift;
+  }
+
+  /// Convert an expanded-text offset to a document offset.
+  ///
+  /// If the offset falls inside an embed's expanded text, snaps to the
+  /// nearest boundary (start or end of the embed in document space).
+  int expandedToDoc(int expandedOffset) {
+    var shift = 0;
+    for (final embed in _embeds) {
+      final embedStart = embed.expandedOffset;
+      final embedEnd = embed.expandedOffset + embed.expandedLength;
+
+      if (expandedOffset <= embedStart) {
+        break;
+      } else if (expandedOffset < embedEnd) {
+        // Inside the embed — snap to nearest boundary.
+        final distToStart = expandedOffset - embedStart;
+        final distToEnd = embedEnd - expandedOffset;
+        if (distToStart <= distToEnd) {
+          return embed.docOffset; // before embed
+        } else {
+          return embed.docOffset + 1; // after embed
+        }
+      } else {
+        shift += embed.expandedLength - 1;
+      }
+    }
+    return expandedOffset - shift;
+  }
+
+  /// Convert an expanded-text offset to a document offset.
+  ///
+  /// If the offset falls inside an embed's expanded text, snaps to the
+  /// **start** of the embed in document space.
+  /// Use this for the start of a deletion range.
+  int expandedToDocFloor(int expandedOffset) {
+    var shift = 0;
+    for (final embed in _embeds) {
+      final embedStart = embed.expandedOffset;
+      final embedEnd = embed.expandedOffset + embed.expandedLength;
+
+      if (expandedOffset <= embedStart) {
+        break;
+      } else if (expandedOffset < embedEnd) {
+        return embed.docOffset;
+      } else {
+        shift += embed.expandedLength - 1;
+      }
+    }
+    return expandedOffset - shift;
+  }
+
+  /// Convert an expanded-text offset to a document offset.
+  ///
+  /// If the offset falls inside an embed's expanded text, snaps to the
+  /// **end** (one past) the embed in document space.
+  /// Use this for the end of a deletion range.
+  int expandedToDocCeil(int expandedOffset) {
+    var shift = 0;
+    for (final embed in _embeds) {
+      final embedStart = embed.expandedOffset;
+      final embedEnd = embed.expandedOffset + embed.expandedLength;
+
+      if (expandedOffset <= embedStart) {
+        break;
+      } else if (expandedOffset <= embedEnd) {
+        // At or inside the embed — snap to after the embed.
+        return embed.docOffset + 1;
+      } else {
+        shift += embed.expandedLength - 1;
+      }
+    }
+    return expandedOffset - shift;
+  }
+
+  /// Convert a document-space [TextSelection] to expanded-text space.
+  TextSelection docToExpandedSelection(TextSelection selection) {
+    return selection.copyWith(
+      baseOffset: docToExpanded(selection.baseOffset),
+      extentOffset: docToExpanded(selection.extentOffset),
+    );
+  }
+
+  /// Convert an expanded-text-space [TextSelection] to document space.
+  TextSelection expandedToDocSelection(TextSelection selection) {
+    return selection.copyWith(
+      baseOffset: expandedToDoc(selection.baseOffset),
+      extentOffset: expandedToDoc(selection.extentOffset),
+    );
+  }
+
+  /// Convert an expanded-text-space [TextRange] to document space.
+  TextRange expandedToDocRange(TextRange range) {
+    return TextRange(
+      start: expandedToDoc(range.start),
+      end: expandedToDoc(range.end),
+    );
+  }
+}
+
+/// Build an [OffsetMapping] by walking the document [delta].
+///
+/// For each embed operation, looks up the matching [EmbedBuilder] from
+/// [embedBuilders] (or [unknownEmbedBuilder]) and calls `toPlainText()`.
+/// If the expanded text differs from the single-character default, an
+/// [EmbedSpan] is recorded.
+OffsetMapping buildOffsetMapping(
+  Delta delta,
+  Iterable<EmbedBuilder>? embedBuilders,
+  EmbedBuilder? unknownEmbedBuilder,
+) {
+  final buffer = StringBuffer();
+  final embeds = <EmbedSpan>[];
+  var docOffset = 0;
+  var expandedOffset = 0;
+
+  for (final op in delta.toList()) {
+    if (!op.isInsert) continue;
+
+    if (op.data is Map) {
+      // Embed operation.
+      final embeddable =
+          Embeddable.fromJson(Map<String, dynamic>.from(op.data as Map));
+      final embedText = _getEmbedPlainText(
+        embeddable,
+        embedBuilders,
+        unknownEmbedBuilder,
+      );
+
+      buffer.write(embedText);
+
+      if (embedText.length != 1 ||
+          embedText != Embed.kObjectReplacementCharacter) {
+        embeds.add(EmbedSpan(
+          docOffset: docOffset,
+          expandedOffset: expandedOffset,
+          expandedLength: embedText.length,
+        ));
+      }
+
+      docOffset += 1; // always 1 in document/delta
+      expandedOffset += embedText.length;
+    } else {
+      // Text operation.
+      final text = op.data as String;
+      buffer.write(text);
+      docOffset += text.length;
+      expandedOffset += text.length;
+    }
+  }
+
+  return OffsetMapping._(
+    expandedText: buffer.toString(),
+    embeds: embeds,
+  );
+}
+
+/// Look up the matching [EmbedBuilder] for [embeddable] and call
+/// `toPlainText()`. Falls back to [unknownEmbedBuilder] or `\uFFFC`.
+String _getEmbedPlainText(
+  Embeddable embeddable,
+  Iterable<EmbedBuilder>? embedBuilders,
+  EmbedBuilder? unknownEmbedBuilder,
+) {
+  final embedNode = Embed(embeddable);
+
+  if (embedBuilders != null) {
+    for (final builder in embedBuilders) {
+      if (builder.key == embeddable.type) {
+        final text = builder.toPlainText(embedNode);
+        // Enforce non-empty — fall back to replacement character.
+        return text.isEmpty ? Embed.kObjectReplacementCharacter : text;
+      }
+    }
+  }
+
+  if (unknownEmbedBuilder != null) {
+    final text = unknownEmbedBuilder.toPlainText(embedNode);
+    return text.isEmpty ? Embed.kObjectReplacementCharacter : text;
+  }
+
+  return Embed.kObjectReplacementCharacter;
+}

--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -19,8 +19,15 @@ mixin RawEditorStateTextInputClientMixin on EditorState
 
   set _lastKnownRemoteTextEditingValue(TextEditingValue? value) {
     __lastKnownRemoteTextEditingValue = value;
-    if (composingRange.value != value?.composing) {
-      composingRange.value = value?.composing ?? TextRange.empty;
+    // The composing range from the platform is in expanded-text space.
+    // Convert it to document space for rendering (TextLine uses doc offsets).
+    var composing = value?.composing ?? TextRange.empty;
+    if (composing.isValid && !composing.isCollapsed) {
+      final mapping = widget.controller.offsetMapping;
+      composing = mapping.expandedToDocRange(composing);
+    }
+    if (composingRange.value != composing) {
+      composingRange.value = composing;
     }
   }
 
@@ -76,7 +83,8 @@ mixin RawEditorStateTextInputClientMixin on EditorState
     }
 
     if (!hasConnection) {
-      _lastKnownRemoteTextEditingValue = textEditingValue;
+      _lastKnownRemoteTextEditingValue =
+          widget.controller.expandedTextEditingValue;
       _textInputConnection = TextInput.attach(
         this,
         TextInputConfiguration(
@@ -122,9 +130,12 @@ mixin RawEditorStateTextInputClientMixin on EditorState
     if (hasConnection) {
       assert(mounted);
       if (composingRange.isValid) {
-        final offset = composingRange.start;
+        // The composing range is in expanded-text space; convert to document
+        // space before querying the caret rect from the render editor.
+        final mapping = widget.controller.offsetMapping;
+        final docOffset = mapping.expandedToDoc(composingRange.start);
         final composingRect =
-            renderEditor.getLocalRectForCaret(TextPosition(offset: offset));
+            renderEditor.getLocalRectForCaret(TextPosition(offset: docOffset));
         _textInputConnection!.setComposingRect(composingRect);
       }
       SchedulerBinding.instance
@@ -168,7 +179,9 @@ mixin RawEditorStateTextInputClientMixin on EditorState
       return;
     }
 
-    final value = textEditingValue;
+    // Use the expanded text (with embeds expanded via toPlainText()) so the
+    // platform keyboard can detect word/sentence boundaries around embeds.
+    final value = widget.controller.expandedTextEditingValue;
 
     // Since we don't keep track of the composing range in value provided
     // by the Controller we need to add it here manually before comparing
@@ -225,6 +238,11 @@ mixin RawEditorStateTextInputClientMixin on EditorState
       return;
     }
 
+    // The last known remote value and the incoming value are both in
+    // expanded-text space (embeds use their toPlainText() representation).
+    // We diff in that space and then map positions back to document space.
+    final mapping = widget.controller.offsetMapping;
+
     final effectiveLastKnownValue = _lastKnownRemoteTextEditingValue!;
     _lastKnownRemoteTextEditingValue = value;
     final oldText = effectiveLastKnownValue.text;
@@ -232,13 +250,20 @@ mixin RawEditorStateTextInputClientMixin on EditorState
     final cursorPosition = value.selection.extentOffset;
     final diff = getDiff(oldText, text, cursorPosition);
     if (diff.deleted.isEmpty && diff.inserted.isEmpty) {
-      widget.controller.updateSelection(value.selection, ChangeSource.local);
+      // Selection-only change — convert from expanded to document offsets.
+      final docSelection = mapping.expandedToDocSelection(value.selection);
+      widget.controller.updateSelection(docSelection, ChangeSource.local);
     } else {
+      // Text change — convert diff positions from expanded to document space.
+      final docStart = mapping.expandedToDocFloor(diff.start);
+      final docDeleteEnd =
+          mapping.expandedToDocCeil(diff.start + diff.deleted.length);
+      final docSelection = mapping.expandedToDocSelection(value.selection);
       widget.controller.replaceText(
-        diff.start,
-        diff.deleted.length,
+        docStart,
+        docDeleteEnd - docStart,
         diff.inserted,
-        value.selection,
+        docSelection,
       );
     }
   }

--- a/test/editor/offset_mapping_test.dart
+++ b/test/editor/offset_mapping_test.dart
@@ -1,0 +1,221 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_quill/quill_delta.dart';
+import 'package:flutter_quill/src/document/nodes/leaf.dart' as leaf;
+import 'package:flutter_quill/src/editor/raw_editor/offset_mapping.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A trivial embed builder whose [toPlainText] returns multi-char text.
+class _MentionBuilder extends EmbedBuilder {
+  @override
+  String get key => 'mention';
+
+  @override
+  bool get expanded => false;
+
+  @override
+  String toPlainText(leaf.Embed node) => '@${node.value.data}';
+
+  @override
+  Widget build(BuildContext context, EmbedContext embedContext) =>
+      const SizedBox.shrink();
+}
+
+/// A builder that returns default \uFFFC (length 1).
+class _ImageBuilder extends EmbedBuilder {
+  @override
+  String get key => 'image';
+
+  @override
+  Widget build(BuildContext context, EmbedContext embedContext) =>
+      const SizedBox.shrink();
+}
+
+void main() {
+  group('OffsetMapping', () {
+    test('no embeds produces identity mapping', () {
+      final delta = Delta()..insert('Hello world\n');
+      final mapping = buildOffsetMapping(delta, null, null);
+
+      expect(mapping.expandedText, 'Hello world\n');
+      expect(mapping.docToExpanded(0), 0);
+      expect(mapping.docToExpanded(5), 5);
+      expect(mapping.docToExpanded(12), 12);
+      expect(mapping.expandedToDoc(0), 0);
+      expect(mapping.expandedToDoc(5), 5);
+      expect(mapping.expandedToDoc(12), 12);
+    });
+
+    test('embed with default toPlainText (\\uFFFC) produces identity mapping',
+        () {
+      final delta = Delta()
+        ..insert('Hi ')
+        ..insert({'image': 'url.png'})
+        ..insert('\n');
+      final mapping = buildOffsetMapping(delta, [_ImageBuilder()], null);
+
+      // The image uses the default \uFFFC, so no shift
+      expect(mapping.expandedText, 'Hi ${leaf.Embed.kObjectReplacementCharacter}\n');
+      expect(mapping.docToExpanded(0), 0);
+      expect(mapping.docToExpanded(3), 3); // at embed
+      expect(mapping.docToExpanded(4), 4); // after embed
+      expect(mapping.expandedToDoc(3), 3);
+      expect(mapping.expandedToDoc(4), 4);
+    });
+
+    group('single multi-char embed', () {
+      late OffsetMapping mapping;
+
+      setUp(() {
+        // Document: "Hello " + {mention: JohnDoe} + ". world\n"
+        // Doc offsets: H(0) e(1) l(2) l(3) o(4) (5) [embed](6) .(7) (8) w(9) ...
+        // Expanded: "Hello @JohnDoe. world\n"
+        final delta = Delta()
+          ..insert('Hello ')
+          ..insert({'mention': 'JohnDoe'})
+          ..insert('. world\n');
+        mapping = buildOffsetMapping(delta, [_MentionBuilder()], null);
+      });
+
+      test('expanded text is correct', () {
+        expect(mapping.expandedText, 'Hello @JohnDoe. world\n');
+      });
+
+      test('docToExpanded before embed', () {
+        expect(mapping.docToExpanded(0), 0);
+        expect(mapping.docToExpanded(5), 5);
+        expect(mapping.docToExpanded(6), 6); // start of embed
+      });
+
+      test('docToExpanded after embed', () {
+        // Doc offset 7 = "." which in expanded is at 14
+        expect(mapping.docToExpanded(7), 14);
+        expect(mapping.docToExpanded(8), 15);
+      });
+
+      test('expandedToDoc before embed', () {
+        expect(mapping.expandedToDoc(0), 0);
+        expect(mapping.expandedToDoc(5), 5);
+        expect(mapping.expandedToDoc(6), 6); // at embed start
+      });
+
+      test('expandedToDoc inside embed snaps to nearest boundary', () {
+        // "@JohnDoe" is at expanded offsets 6-13 (length 8)
+        // Midpoint at 10: dist to start = 4, dist to end = 4 → ties go to start
+        expect(mapping.expandedToDoc(7), 6); // closer to start
+        expect(mapping.expandedToDoc(9), 6); // closer to start
+        expect(mapping.expandedToDoc(10), 6); // tie → start
+        expect(mapping.expandedToDoc(11), 7); // closer to end
+        expect(mapping.expandedToDoc(13), 7); // closer to end
+      });
+
+      test('expandedToDoc after embed', () {
+        expect(mapping.expandedToDoc(14), 7); // "."
+        expect(mapping.expandedToDoc(15), 8);
+        expect(mapping.expandedToDoc(21), 14);
+      });
+
+      test('expandedToDocFloor inside embed snaps to embed start', () {
+        expect(mapping.expandedToDocFloor(6), 6);
+        expect(mapping.expandedToDocFloor(7), 6);
+        expect(mapping.expandedToDocFloor(13), 6);
+        expect(mapping.expandedToDocFloor(14), 7); // past embed
+      });
+
+      test('expandedToDocCeil inside embed snaps to embed end', () {
+        expect(mapping.expandedToDocCeil(6), 6); // at embed start → before
+        expect(mapping.expandedToDocCeil(7), 7); // inside → after embed
+        expect(mapping.expandedToDocCeil(13), 7);
+        expect(mapping.expandedToDocCeil(14), 7); // at embed end → after
+      });
+
+      test('docToExpandedSelection round trip', () {
+        final docSel = const TextSelection(baseOffset: 5, extentOffset: 8);
+        final expandedSel = mapping.docToExpandedSelection(docSel);
+        expect(expandedSel.baseOffset, 5);
+        expect(expandedSel.extentOffset, 15); // 8 + 7 shift
+
+        final backToDoc = mapping.expandedToDocSelection(expandedSel);
+        expect(backToDoc.baseOffset, 5);
+        expect(backToDoc.extentOffset, 8);
+      });
+    });
+
+    group('multiple embeds', () {
+      late OffsetMapping mapping;
+
+      setUp(() {
+        // "Hi " + {mention: A} + " and " + {mention: BC} + "!\n"
+        // Doc: H(0)i(1) (2)[embed1](3) (4)a(5)n(6)d(7) (8)[embed2](9)!(10)\n(11)
+        // Expanded: "Hi @A and @BC!\n"
+        final delta = Delta()
+          ..insert('Hi ')
+          ..insert({'mention': 'A'})
+          ..insert(' and ')
+          ..insert({'mention': 'BC'})
+          ..insert('!\n');
+        mapping = buildOffsetMapping(delta, [_MentionBuilder()], null);
+      });
+
+      test('expanded text is correct', () {
+        expect(mapping.expandedText, 'Hi @A and @BC!\n');
+      });
+
+      test('docToExpanded with cumulative shifts', () {
+        expect(mapping.docToExpanded(0), 0); // H
+        expect(mapping.docToExpanded(3), 3); // embed1 start
+        expect(mapping.docToExpanded(4), 5); // space after embed1 (shift +1)
+        expect(mapping.docToExpanded(9), 10); // embed2 start (shift +1)
+        expect(mapping.docToExpanded(10), 13); // "!" (shift +1+2=3)
+        expect(mapping.docToExpanded(11), 14); // \n
+      });
+
+      test('expandedToDoc with cumulative shifts', () {
+        expect(mapping.expandedToDoc(0), 0);
+        expect(mapping.expandedToDoc(5), 4); // space after embed1
+        expect(mapping.expandedToDoc(10), 9); // embed2 start
+        expect(mapping.expandedToDoc(13), 10); // "!"
+      });
+    });
+
+    test('embed at offset 0', () {
+      final delta = Delta()
+        ..insert({'mention': 'X'})
+        ..insert(' hi\n');
+      final mapping = buildOffsetMapping(delta, [_MentionBuilder()], null);
+
+      expect(mapping.expandedText, '@X hi\n');
+      expect(mapping.docToExpanded(0), 0);
+      expect(mapping.docToExpanded(1), 2); // after embed
+      expect(mapping.expandedToDoc(0), 0);
+      expect(mapping.expandedToDoc(1), 0); // inside embed → snap to start
+      expect(mapping.expandedToDoc(2), 1);
+    });
+
+    test('adjacent embeds', () {
+      final delta = Delta()
+        ..insert({'mention': 'A'})
+        ..insert({'mention': 'B'})
+        ..insert('\n');
+      final mapping = buildOffsetMapping(delta, [_MentionBuilder()], null);
+
+      expect(mapping.expandedText, '@A@B\n');
+      expect(mapping.docToExpanded(0), 0); // embed1
+      expect(mapping.docToExpanded(1), 2); // embed2
+      expect(mapping.docToExpanded(2), 4); // \n
+    });
+
+    test('no embed builders provided falls back to \\uFFFC', () {
+      final delta = Delta()
+        ..insert('a')
+        ..insert({'mention': 'X'})
+        ..insert('\n');
+      final mapping = buildOffsetMapping(delta, null, null);
+
+      expect(mapping.expandedText, 'a${leaf.Embed.kObjectReplacementCharacter}\n');
+      // No shift because \uFFFC is length 1
+      expect(mapping.docToExpanded(1), 1);
+      expect(mapping.docToExpanded(2), 2);
+    });
+  });
+}


### PR DESCRIPTION
## Description

  Adds support for custom inline embeds (mentions, hashtags, etc.) to declare their character length for the platform keyboard, fixing `TextCapitalization.sentences` and word/sentence boundary detection
  around embeds.

  **Problem:** All embeds are sent to the platform as a single `\uFFFC` character. The OS keyboard cannot detect sentence endings (e.g. `@JohnDoe. Next sentence`) because it only sees `\uFFFC.` --> not
  enough context for capitalization or word boundaries.

  **Solution:**
  - Added `int get length` property to `EmbedBuilder` (defaults to `1`, fully backward compatible)
  - Added internal `OffsetMapping` layer at the platform text-input boundary that translates between document offsets (embeds = length 1) and expanded-text offsets (embeds = `toPlainText().length`)
  - The Delta/OT layer is **unchanged** --> embeds remain length 1 internally

  **Usage:** Override `toPlainText()` and `length` on your `EmbedBuilder`:

  ```dart
  class MentionBuilder extends EmbedBuilder {
    @override
    String get key => 'mention';

    @override
    bool get expanded => false;

    @override
    String toPlainText(Embed node) => '@${node.value.data}';

    @override
    int get length => toPlainText(...).length;
  }

  Files changed:
  - lib/src/editor/embed/embed_editor_builder.dart --> added int get length => 1;
  - lib/src/editor/raw_editor/offset_mapping.dart --> new internal OffsetMapping utility
  - lib/src/controller/quill_controller.dart --> cached offsetMapping + expandedTextEditingValue
  - lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart --> use expanded text for platform I/O
  - test/editor/offset_mapping_test.dart --> 17 unit tests
  - CHANGELOG.md --> added entry under [Unreleased]


## Related Issues
Fixes #2715 
Closes #2715 

## Type of Change

<!---
Check the boxes that apply with x and leave the others empty. For example:
- [x] ✨ **New feature:** Adds new functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without changing current behavior.
-->

- [x] ✨ **Feature:** New functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [x] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
