### PR TITLE
Feature/selection with physical mouse and keyboard

### DIFF
--- a/lib/src/editor/config/editor_config.dart
+++ b/lib/src/editor/config/editor_config.dart
@@ -81,6 +81,7 @@ class QuillEditorConfig {
     this.requestKeyboardFocusOnCheckListChanged = false,
     this.textInputAction = TextInputAction.newline,
     this.enableScribble = false,
+    this.autocorrect = true,
     this.onScribbleActivated,
     this.scribbleAreaInsets,
     this.readOnlyMouseCursor = SystemMouseCursors.text,
@@ -462,6 +463,9 @@ class QuillEditorConfig {
   /// Enable Scribble? Currently Apple Pencil only, defaults to false.
   final bool enableScribble;
 
+  /// Whether to enable autocorrection. Defaults to true.
+  final bool autocorrect;
+
   /// Called when Scribble is activated.
   final void Function()? onScribbleActivated;
 
@@ -528,6 +532,7 @@ class QuillEditorConfig {
     bool? requestKeyboardFocusOnCheckListChanged,
     TextInputAction? textInputAction,
     bool? enableScribble,
+    bool? autocorrect,
     void Function()? onScribbleActivated,
     EdgeInsets? scribbleAreaInsets,
     void Function(TextInputAction action)? onPerformAction,
@@ -596,6 +601,7 @@ class QuillEditorConfig {
           requestKeyboardFocusOnCheckListChanged ??
               this.requestKeyboardFocusOnCheckListChanged,
       textInputAction: textInputAction ?? this.textInputAction,
+      autocorrect: autocorrect ?? this.autocorrect,
       enableScribble: enableScribble ?? this.enableScribble,
       onScribbleActivated: onScribbleActivated ?? this.onScribbleActivated,
       scribbleAreaInsets: scribbleAreaInsets ?? this.scribbleAreaInsets,

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -321,6 +321,7 @@ class QuillEditorState extends State<QuillEditor>
         onTapOutside: config.onTapOutside,
         dialogTheme: config.dialogTheme,
         contentInsertionConfiguration: config.contentInsertionConfiguration,
+        autocorrect: config.autocorrect,
         enableScribble: config.enableScribble,
         onScribbleActivated: config.onScribbleActivated,
         scribbleAreaInsets: config.scribbleAreaInsets,

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -31,6 +31,8 @@ abstract class RenderAbstractEditor implements TextLayoutMetrics {
 
   TextSelection selectLineAtPosition(TextPosition position);
 
+  TextSelection selectParagraphAtPosition(TextPosition position);
+
   /// Returns preferred line height at specified `position` in text.
   double preferredLineHeight(TextPosition position);
 
@@ -103,6 +105,11 @@ abstract class RenderAbstractEditor implements TextLayoutMetrics {
   ///
   /// {@macro flutter.rendering.editable.select}
   void selectWord(SelectionChangedCause cause);
+
+  /// Select a paragraph around the location of the last tap down.
+  ///
+  /// {@macro flutter.rendering.editable.select}
+  void selectParagraph(SelectionChangedCause cause);
 
   /// Move selection to the location of the last tap down.
   ///
@@ -1072,6 +1079,16 @@ class RenderEditor extends RenderEditableContainerBox
   }
 
   @override
+  void selectParagraph(SelectionChangedCause cause) {
+    if (_lastTapDownPosition == null) {
+      return;
+    }
+    final TextPosition position = getPositionForOffset(_lastTapDownPosition!);
+    final TextSelection newSelection = selectParagraphAtPosition(position);
+    _handleSelectionChange(newSelection, cause);
+  }
+
+  @override
   void selectPosition({required SelectionChangedCause cause}) {
     selectPositionAt(from: _lastTapDownPosition!, cause: cause);
   }
@@ -1095,6 +1112,23 @@ class RenderEditor extends RenderEditableContainerBox
       return TextSelection.fromPosition(position);
     }
     return TextSelection(baseOffset: line.start, extentOffset: line.end);
+  }
+
+  @override
+  TextSelection selectParagraphAtPosition(TextPosition position) {
+    final child = childAtPosition(position);
+    final nodeOffset = child.container.offset;
+    final text = child.container.toPlainText();
+    final trailingNewlineLength = text.endsWith('\n') ? 1 : 0;
+    final paragraphEnd =
+        nodeOffset + child.container.length - trailingNewlineLength;
+
+    // When tapping past the end of the text, we want a collapsed cursor.
+    if (position.offset >= paragraphEnd) {
+      return TextSelection.fromPosition(position);
+    }
+
+    return TextSelection(baseOffset: nodeOffset, extentOffset: paragraphEnd);
   }
 
   @override

--- a/lib/src/editor/raw_editor/config/raw_editor_config.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_config.dart
@@ -65,6 +65,7 @@ class QuillRawEditorConfig {
     this.contentInsertionConfiguration,
     this.textInputAction = TextInputAction.newline,
     this.requestKeyboardFocusOnCheckListChanged = false,
+    this.autocorrect = true,
     this.enableScribble = false,
     this.onScribbleActivated,
     this.scribbleAreaInsets,
@@ -398,6 +399,9 @@ class QuillRawEditorConfig {
   final bool requestKeyboardFocusOnCheckListChanged;
 
   final TextInputAction textInputAction;
+
+  /// Whether to enable auto-correction.
+  final bool autocorrect;
 
   /// Enable Scribble? Currently Apple Pencil only, defaults to false.
   final bool enableScribble;

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -510,6 +510,12 @@ class QuillRawEditorState extends EditorState
 
     _selectionOverlay?.handlesVisible = _shouldShowSelectionHandles();
 
+    // Always sync the new selection to the TextInputConnection so that
+    // a physical keyboard types at the correct (tapped) position.
+    // Without this, the platform-side selection stays stale and keystrokes
+    // are inserted at the old cursor position.
+    updateRemoteValueIfNeeded();
+
     if (!_keyboardVisible) {
       // This will show the keyboard for all selection changes on the
       // editor, not just changes triggered by user gestures.
@@ -847,10 +853,16 @@ class QuillRawEditorState extends EditorState
               _onChangeTextEditingValue(!_hasFocus);
             }
           });
-
-          HardwareKeyboard.instance.addHandler(_hardwareKeyboardEvent);
         }
       });
+    }
+
+    // Register hardware keyboard handler for all non-web platforms so that
+    // _keyboardVisible is set to true when a physical keyboard is used
+    // (e.g. Android/iPadOS tablets with external keyboards). This must be
+    // outside the isIOSSimulator async block so it runs unconditionally.
+    if (!kIsWeb && !isKeyboardOS && !isFlutterTest) {
+      HardwareKeyboard.instance.addHandler(_hardwareKeyboardEvent);
     }
 
     controller.addListener(_didChangeTextEditingValueListener);

--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -82,6 +82,7 @@ mixin RawEditorStateTextInputClientMixin on EditorState
         TextInputConfiguration(
           inputType: TextInputType.multiline,
           readOnly: widget.config.readOnly,
+          autocorrect: widget.config.autocorrect,
           inputAction: widget.config.textInputAction,
           enableSuggestions: !widget.config.readOnly,
           keyboardAppearance: createKeyboardAppearance(),

--- a/lib/src/editor/widgets/delegate.dart
+++ b/lib/src/editor/widgets/delegate.dart
@@ -302,6 +302,29 @@ class EditorTextSelectionGestureDetectorBuilder {
     }
   }
 
+  /// Handler for [EditorTextSelectionGestureDetector.onTripleTapDown].
+  ///
+  /// By default, it selects a line (paragraph) through [RenderEditor.selectParagraph]
+  /// if selectionEnabled and shows toolbar if necessary.
+  ///
+  /// See also:
+  ///
+  ///  * [EditorTextSelectionGestureDetector.onTripleTapDown],
+  ///  which triggers this callback.
+  @protected
+  void onTripleTapDown(TapDownDetails details) {
+    if (delegate.selectionEnabled) {
+      renderEditor!.selectParagraph(SelectionChangedCause.tap);
+      // allow the selection to get updated before trying to bring up
+      // toolbars.
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (checkSelectionToolbarShouldShow(isAdditionalAction: false)) {
+          editor!.showToolbar();
+        }
+      });
+    }
+  }
+
   /// Handler for [EditorTextSelectionGestureDetector.onDragSelectionStart].
   ///
   /// By default, it selects a text position specified in [details].
@@ -376,6 +399,7 @@ class EditorTextSelectionGestureDetectorBuilder {
       onSingleLongTapMoveUpdate: onSingleLongTapMoveUpdate,
       onSingleLongTapEnd: onSingleLongTapEnd,
       onDoubleTapDown: onDoubleTapDown,
+      onTripleTapDown: onTripleTapDown,
       onSecondarySingleTapUp: onSecondarySingleTapUp,
       onDragSelectionStart: onDragSelectionStart,
       onDragSelectionUpdate: onDragSelectionUpdate,

--- a/lib/src/editor/widgets/text/text_selection.dart
+++ b/lib/src/editor/widgets/text/text_selection.dart
@@ -11,6 +11,9 @@ import '../../../document/nodes/node.dart';
 import '../../editor.dart';
 import 'magnifier.dart';
 
+// Longer timeout after double-tap to make triple-tap easier to trigger
+const Duration _kTripleTapTimeout = Duration(milliseconds: 500);
+
 TextSelection localSelection(Node node, TextSelection selection, fromParent) {
   final base = fromParent ? node.offset : node.documentOffset;
   assert(base <= selection.end && selection.start <= base + node.length - 1);
@@ -673,6 +676,7 @@ class EditorTextSelectionGestureDetector extends StatefulWidget {
     this.onSingleLongTapMoveUpdate,
     this.onSingleLongTapEnd,
     this.onDoubleTapDown,
+    this.onTripleTapDown,
     this.onDragSelectionStart,
     this.onDragSelectionUpdate,
     this.onDragSelectionEnd,
@@ -734,6 +738,10 @@ class EditorTextSelectionGestureDetector extends StatefulWidget {
   /// time (within [kDoubleTapTimeout]) to a previous short tap.
   final GestureTapDownCallback? onDoubleTapDown;
 
+  /// Called after three quick taps that are close in space and time
+  /// (within [kDoubleTapTimeout]) to each other.
+  final GestureTapDownCallback? onTripleTapDown;
+
   /// Called when a mouse starts dragging to select text.
   final GestureDragStartCallback? onDragSelectionStart;
 
@@ -769,12 +777,20 @@ class EditorTextSelectionGestureDetector extends StatefulWidget {
 class _EditorTextSelectionGestureDetectorState
     extends State<EditorTextSelectionGestureDetector> {
   // Counts down for a short duration after a previous tap. Null otherwise.
-  Timer? _doubleTapTimer;
+  Timer? _consecutiveTapTimer;
   Offset? _lastTapOffset;
+
+  // Tracks the number of consecutive taps (0 = first tap, 1 = double tap,
+  // 2 = triple tap)
+  int _consecutiveTapCount = 0;
 
   // True if a second tap down of a double tap is detected. Used to discard
   // subsequent tap up / tap hold of the same tap.
   bool _isDoubleTap = false;
+
+  // True if a third tap down of a triple tap is detected. Used to discard
+  // subsequent tap up / tap hold of the same tap.
+  bool _isTripleTap = false;
 
   // _isDoubleTap for mouse right click
   bool _isSecondaryDoubleTap = false;
@@ -791,7 +807,7 @@ class _EditorTextSelectionGestureDetectorState
 
   @override
   void dispose() {
-    _doubleTapTimer?.cancel();
+    _consecutiveTapTimer?.cancel();
     _dragUpdateThrottleTimer?.cancel();
     widget.dragOffsetNotifier?.removeListener(_dragOffsetListener);
     super.dispose();
@@ -823,30 +839,42 @@ class _EditorTextSelectionGestureDetectorState
   void _handleTapDown(TapDownDetails details) {
     widget.onTapDown?.call(details);
 
-    // This isn't detected as a double tap gesture in the gesture recognizer
-    // because it's 2 single taps, each of which may do different things
+    // This isn't detected as a multi-tap gesture in the gesture recognizer
+    // because it's multiple single taps, each of which may do different things
     // depending on whether it's a single tap, the first tap of a double tap,
-    // the second tap held down, a clean double tap etc.
-    if (_doubleTapTimer != null &&
+    // the second tap held down, a clean double tap, triple tap, etc.
+    if (_consecutiveTapTimer != null &&
         _isWithinDoubleTapTolerance(details.globalPosition)) {
-      // If there was already a previous tap, the second down hold/tap is a
-      // double tap down.
+      // If there was already a previous tap, increment the count
+      _consecutiveTapCount++;
 
-      widget.onDoubleTapDown?.call(details);
-
-      _doubleTapTimer!.cancel();
-      _doubleTapTimeout();
-      _isDoubleTap = true;
+      if (_consecutiveTapCount == 1) {
+        // Second tap = double tap
+        widget.onDoubleTapDown?.call(details);
+        _consecutiveTapTimer!.cancel();
+        _isDoubleTap = true;
+      } else if (_consecutiveTapCount == 2) {
+        // Third tap = triple tap
+        widget.onTripleTapDown?.call(details);
+        _consecutiveTapTimer!.cancel();
+        _consecutiveTapTimeout();
+        _isTripleTap = true;
+        return;
+      }
     }
   }
 
   void _handleTapUp(TapUpDetails details) {
-    if (!_isDoubleTap) {
+    if (!_isDoubleTap && !_isTripleTap) {
       widget.onSingleTapUp?.call(details);
       _lastTapOffset = details.globalPosition;
-      _doubleTapTimer = Timer(kDoubleTapTimeout, _doubleTapTimeout);
+      _consecutiveTapTimer = Timer(kDoubleTapTimeout, _consecutiveTapTimeout);
+    } else if (_isDoubleTap) {
+      _lastTapOffset = details.globalPosition;
+      _consecutiveTapTimer = Timer(_kTripleTapTimeout, _consecutiveTapTimeout);
     }
     _isDoubleTap = false;
+    _isTripleTap = false;
   }
 
   void _handleTapCancel() {
@@ -858,12 +886,12 @@ class _EditorTextSelectionGestureDetectorState
     if (widget.onSecondaryTapDown != null) {
       widget.onSecondaryTapDown?.call(details);
     }
-    if (_doubleTapTimer != null &&
+    if (_consecutiveTapTimer != null &&
         _isWithinDoubleTapTolerance(details.globalPosition)) {
       widget.onSecondaryDoubleTapDown?.call(details);
 
-      _doubleTapTimer!.cancel();
-      _doubleTapTimeout();
+      _consecutiveTapTimer!.cancel();
+      _consecutiveTapTimeout();
       _isDoubleTap = true;
     }
   }
@@ -872,7 +900,7 @@ class _EditorTextSelectionGestureDetectorState
     if (!_isSecondaryDoubleTap) {
       widget.onSecondarySingleTapUp?.call(details);
       _lastTapOffset = details.globalPosition;
-      _doubleTapTimer = Timer(kDoubleTapTimeout, _doubleTapTimeout);
+      _consecutiveTapTimer = Timer(kDoubleTapTimeout, _consecutiveTapTimeout);
     }
     _isSecondaryDoubleTap = false;
   }
@@ -936,8 +964,8 @@ class _EditorTextSelectionGestureDetectorState
   }
 
   void _forcePressStarted(ForcePressDetails details) {
-    _doubleTapTimer?.cancel();
-    _doubleTapTimer = null;
+    _consecutiveTapTimer?.cancel();
+    _consecutiveTapTimer = null;
     widget.onForcePressStart?.call(details);
   }
 
@@ -962,18 +990,20 @@ class _EditorTextSelectionGestureDetectorState
   }
 
   void _handleLongPressEnd(LongPressEndDetails details) {
-    if (!_isDoubleTap) {
+    if (!_isDoubleTap && !_isTripleTap) {
       widget.onSingleLongTapEnd?.call(details);
     }
     // after a long press (from double tap or drag) make sure
     // magnifier is removed
     widget.dragOffsetNotifier?.value = null;
     _isDoubleTap = false;
+    _isTripleTap = false;
   }
 
-  void _doubleTapTimeout() {
-    _doubleTapTimer = null;
+  void _consecutiveTapTimeout() {
+    _consecutiveTapTimer = null;
     _lastTapOffset = null;
+    _consecutiveTapCount = 0;
   }
 
   bool _isWithinDoubleTapTolerance(Offset secondTapOffset) {

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+flutter = "3.35.7-stable"


### PR DESCRIPTION
add mise
fix physical mouse and keyboard 

## Description
There was a bug that using a physical keyboard doesn't work to select which part of the text to write in.
This PR fixes that.

## Related Issues
https://github.com/singerdmx/flutter-quill/issues/2534

## Type of Change
- [x] 🛠️ **Bug fix:** Resolves an issue without changing current behavior.

