### PR TITLE
feat: add mergeImeCompositionHistory config to group IME intermediate states in undo stack

### DIFF
--- a/lib/src/document/history.dart
+++ b/lib/src/document/history.dart
@@ -32,6 +32,21 @@ class History {
   ///record delay
   final int interval;
 
+  bool _forceMergeNext = false;
+
+  bool get forceMergeNext => _forceMergeNext;
+
+  /// Forces the next change to merge into the last undo step.
+  /// Automatically resets to false after the current synchronous operations finish.
+  set forceMergeNext(bool value) {
+    _forceMergeNext = value;
+    if (value) {
+      Future.microtask(() {
+        _forceMergeNext = false;
+      });
+    }
+  }
+
   void handleDocChange(DocChange docChange) {
     if (ignoreChange) return;
     if (!userOnly || docChange.source == ChangeSource.local) {
@@ -51,7 +66,8 @@ class History {
     var undoDelta = change.invert(before);
     final timeStamp = DateTime.now().millisecondsSinceEpoch;
 
-    if (lastRecorded + interval > timeStamp && stack.undo.isNotEmpty) {
+    if ((forceMergeNext || lastRecorded + interval > timeStamp) &&
+        stack.undo.isNotEmpty) {
       final lastDelta = stack.undo.removeLast();
       undoDelta = undoDelta.compose(lastDelta);
     } else {

--- a/lib/src/editor/config/editor_config.dart
+++ b/lib/src/editor/config/editor_config.dart
@@ -37,6 +37,7 @@ class QuillEditorConfig {
     this.placeholder,
     this.checkBoxReadOnly,
     this.disableClipboard = false,
+    this.mergeImeCompositionHistory = false,
     this.textSelectionThemeData,
     this.showCursor,
     this.paintCursorAboveText,
@@ -189,6 +190,14 @@ class QuillEditorConfig {
   ///
   /// Defaults to `false`.
   final bool disableClipboard;
+
+  /// Whether to merge the IME composing text (uncommitted text) into a single
+  /// undo/redo history step.
+  ///
+  /// When set to `true`, typing Pinyin or other IME candidates will be grouped
+  /// together, preventing the undo stack from recording every single keystroke.
+  /// Defaults to `false`.
+  final bool mergeImeCompositionHistory;
 
   /// Whether this editor should create a scrollable container for its content.
   ///
@@ -481,6 +490,7 @@ class QuillEditorConfig {
     List<SpaceShortcutEvent>? spaceShortcutEvents,
     bool? checkBoxReadOnly,
     bool? disableClipboard,
+    bool? mergeImeCompositionHistory,
     bool? scrollable,
     double? scrollBottomInset,
     bool? enableAlwaysIndentOnTab,
@@ -541,6 +551,8 @@ class QuillEditorConfig {
       spaceShortcutEvents: spaceShortcutEvents ?? this.spaceShortcutEvents,
       checkBoxReadOnly: checkBoxReadOnly ?? this.checkBoxReadOnly,
       disableClipboard: disableClipboard ?? this.disableClipboard,
+      mergeImeCompositionHistory:
+          mergeImeCompositionHistory ?? this.mergeImeCompositionHistory,
       scrollable: scrollable ?? this.scrollable,
       onKeyPressed: onKeyPressed ?? this.onKeyPressed,
       scrollBottomInset: scrollBottomInset ?? this.scrollBottomInset,

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -278,6 +278,7 @@ class QuillEditorState extends State<QuillEditor>
         readOnly: controller.readOnly,
         checkBoxReadOnly: config.checkBoxReadOnly,
         disableClipboard: config.disableClipboard,
+        mergeImeCompositionHistory: config.mergeImeCompositionHistory,
         placeholder: config.placeholder,
         onLaunchUrl: config.onLaunchUrl,
         contextMenuBuilder: showSelectionToolbar

--- a/lib/src/editor/raw_editor/config/raw_editor_config.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_config.dart
@@ -38,6 +38,7 @@ class QuillRawEditorConfig {
     this.readOnly = false,
     this.checkBoxReadOnly,
     this.disableClipboard = false,
+    this.mergeImeCompositionHistory = false,
     this.placeholder,
     this.onLaunchUrl,
     this.contextMenuBuilder = defaultContextMenuBuilder,
@@ -196,6 +197,14 @@ class QuillRawEditorConfig {
   ///
   /// Defaults to `false`.
   final bool disableClipboard;
+
+  /// Whether to merge the IME composing text (uncommitted text) into a single
+  /// undo/redo history step.
+  ///
+  /// When set to `true`, typing Pinyin or other IME candidates will be grouped
+  /// together, preventing the undo stack from recording every single keystroke.
+  /// Defaults to `false`.
+  final bool mergeImeCompositionHistory;
 
   final String? placeholder;
 

--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -51,6 +51,11 @@ mixin RawEditorStateTextInputClientMixin on EditorState
   bool get hasConnection =>
       _textInputConnection != null && _textInputConnection!.attached;
 
+  /// Indicates if the IME was composing in the previous update.
+  /// Used by [QuillEditorConfig.mergeImeCompositionHistory] to merge
+  /// intermediate keystrokes (e.g., Pinyin) into a single undo step.
+  bool _wasComposing = false;
+
   /// Opens or closes input connection based on the current state of
   /// [focusNode] and [value].
   void openOrCloseConnection() {
@@ -211,6 +216,14 @@ mixin RawEditorStateTextInputClientMixin on EditorState
     if (_lastKnownRemoteTextEditingValue == value) {
       // There is no difference between this value and the last known value.
       return;
+    }
+
+    if (widget.config.mergeImeCompositionHistory) {
+      // Handle IME composition history.
+      // If the user was composing (e.g., typing Pinyin) in the previous step,
+      // force the upcoming document change to merge into the same undo step.
+      widget.controller.document.history.forceMergeNext = _wasComposing;
+      _wasComposing = value.composing.isValid;
     }
 
     // Check if only composing range changed.


### PR DESCRIPTION

<!-- 
Briefly describe your changes and summarize in the title.
Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md
Package versioning is automated.
Add updates to `Unreleased` in `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
-->

## Description

Currently, when users type using an Input Method Editor (IME) like Chinese Pinyin or Japanese, every intermediate keystroke (composing state) is recorded as a separate step in the `History` undo stack. This leads to a broken undo/redo experience where pressing `Cmd+Z` or `Ctrl+Z` undoes individual pinyin letters instead of the final committed word.

This PR introduces a new configurable feature to group these IME composition states into a single, clean undo step.

## Changes Made
* **Added `mergeImeCompositionHistory` in `QuillEditorConfig`:** A new boolean flag (defaulting to `true`) allowing developers to control this IME history merging behavior.
* **Added `forceMergeNext` in `History`:** A new setter in the bottom-layer `History` class. It utilizes Dart's `Future.microtask` to automatically and safely reset its state after the current synchronous event loop, ensuring no state leakage to subsequent regular key presses.
* **Intercepted `updateEditingValue` in `RawEditorState`:** Reads the `isComposing` state from `TextEditingValue` and flags the history stack to merge the upcoming delta if the previous state was composing.

## Visual Proof (Before & After)
* **Before:** Pressing Undo removes intermediate pinyin characters one by one.

https://github.com/user-attachments/assets/593fcbca-d935-43b0-a8bc-d43c495a5070

* **After:** Pressing Undo cleanly removes the entire committed phrase as a single logical step.

https://github.com/user-attachments/assets/b1a0b2d9-a7ca-4299-950c-eb3f200c6620

## Type of Change

<!---
Check the boxes that apply with x and leave the others empty. For example:
- [ ] ✨ **New feature:** Adds new functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without changing current behavior.
-->

- [x] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.

