### PR TITLE
RichText Paste 이벤트 내부 에디터에서 못받는 원인 수정

### DIFF
--- a/lib/src/controller/clipboard/quill_controller_paste.dart
+++ b/lib/src/controller/clipboard/quill_controller_paste.dart
@@ -6,28 +6,28 @@ import 'package:meta/meta.dart';
 
 import '../../../flutter_quill.dart';
 import '../../../quill_delta.dart';
+import 'quill_controller_rich_paste.dart';
 
 extension QuillControllerPaste on QuillController {
   @internal
-  bool pastePlainTextOrDelta(
+  Future<bool> pastePlainTextOrDelta(
     String? clipboardText, {
     required String pastePlainText,
     required Delta pasteDelta,
-  }) {
+  }) async {
     if (clipboardText != null) {
       /// Internal copy-paste preserves styles and embeds
-      if (clipboardText == pastePlainText &&
-          pastePlainText.isNotEmpty &&
-          pasteDelta.isNotEmpty) {
-        replaceText(selection.start, selection.end - selection.start,
-            pasteDelta, TextSelection.collapsed(offset: selection.end));
-      } else {
+      if (clipboardText == pastePlainText && pastePlainText.isNotEmpty && pasteDelta.isNotEmpty) {
         replaceText(
             selection.start,
             selection.end - selection.start,
-            clipboardText,
-            TextSelection.collapsed(
-                offset: selection.end + clipboardText.length));
+            // [Fix] onRichTextPaste
+            // pasteDelta,
+            await getDeltaToPaste(pasteDelta, isExternal: false),
+            TextSelection.collapsed(offset: selection.end));
+      } else {
+        replaceText(selection.start, selection.end - selection.start, clipboardText,
+            TextSelection.collapsed(offset: selection.end + clipboardText.length));
       }
       return true;
     }

--- a/lib/src/controller/clipboard/quill_controller_rich_paste.dart
+++ b/lib/src/controller/clipboard/quill_controller_rich_paste.dart
@@ -74,11 +74,15 @@ extension QuillControllerRichPaste on QuillController {
     return false;
   }
 
+  // [Fix] onRichTextPaste
   @visibleForTesting
-  Future<Delta> getDeltaToPaste(Delta clipboardDelta) async {
+  Future<Delta> getDeltaToPaste(
+    Delta clipboardDelta, {
+    required bool isExternal,
+  }) async {
     final onRichTextPaste = config.clipboardConfig?.onRichTextPaste;
     if (onRichTextPaste != null) {
-      final delta = await onRichTextPaste(clipboardDelta, true);
+      final delta = await onRichTextPaste(clipboardDelta, isExternal);
       if (delta != null) {
         return delta;
       }
@@ -91,7 +95,7 @@ extension QuillControllerRichPaste on QuillController {
       selection.start,
       selection.end - selection.start,
       // Ensure to await to pass Delta instead of Future<Delta> since this accept Object
-      await getDeltaToPaste(clipboardDelta),
+      await getDeltaToPaste(clipboardDelta, isExternal: true),
       TextSelection.collapsed(offset: selection.end),
     );
   }

--- a/lib/src/controller/quill_controller.dart
+++ b/lib/src/controller/quill_controller.dart
@@ -981,7 +981,7 @@ class QuillController extends ChangeNotifier {
 
     if (plainText != null) {
       final plainTextToPaste = await getTextToPaste(plainText);
-      if (await await pastePlainTextOrDelta(plainTextToPaste,
+      if (await pastePlainTextOrDelta(plainTextToPaste,
           pastePlainText: _pastePlainText, pasteDelta: _pasteDelta)) {
         updateEditor?.call();
         return true;

--- a/lib/src/controller/quill_controller.dart
+++ b/lib/src/controller/quill_controller.dart
@@ -421,7 +421,8 @@ class QuillController extends ChangeNotifier {
     for (var i = 0; i < length; i++) {
       final newIndex = index + i;
       _styleCacheByIndex[newIndex] = document.collectStyle(newIndex, 1);
-      _dbg('[replaceText] retain[$newIndex] savedStyle: ${_styleCacheByIndex[newIndex]}');
+      _dbg(
+          '[replaceText] retain[$newIndex] savedStyle: ${_styleCacheByIndex[newIndex]}');
     }
   }
 
@@ -464,7 +465,8 @@ class QuillController extends ChangeNotifier {
       // isDeleteOnly가 아니어서 cacheStyle이 호출되지 않으므로,
       // 아직 캐시가 없는 위치의 스타일을 document.replace 전에 미리 저장한다.
       for (var i = index; i < index + len; i++) {
-        if (!_styleCacheByIndex.containsKey(i) && !_imePreservedStyles.containsKey(i)) {
+        if (!_styleCacheByIndex.containsKey(i) &&
+            !_imePreservedStyles.containsKey(i)) {
           _styleCacheByIndex[i] = document.collectStyle(i, 1);
         }
       }
@@ -484,7 +486,8 @@ class QuillController extends ChangeNotifier {
 
       final indexStyle = getCachedStyle(index);
 
-      _dbg('[replaceText] styleIndex=$index indexStyle=$indexStyle, $data replace[${delta.toJson()}]');
+      _dbg(
+          '[replaceText] styleIndex=$index indexStyle=$indexStyle, $data replace[${delta.toJson()}]');
 
       // 순수 삽입: [retain, insert] 또는 [insert]
       final isPureInsert = delta.length <= 2 && delta.last.isInsert;
@@ -525,7 +528,8 @@ class QuillController extends ChangeNotifier {
             }
             // 사용자가 OFF한 속성(null값) 중 캐시에 없는 것만 추가 (캐시 값은 덮어쓰지 않음).
             for (final activeAttr in activeStyle.values) {
-              if (activeAttr.value == null && !attrs.containsKey(activeAttr.key)) {
+              if (activeAttr.value == null &&
+                  !attrs.containsKey(activeAttr.key)) {
                 attrs[activeAttr.key] = activeAttr;
               }
             }
@@ -544,7 +548,8 @@ class QuillController extends ChangeNotifier {
           }
         }
 
-        _dbg('[replaceText] retain[$index ~ $number] isEnd:$isEnd activeStyle=$activeStyle');
+        _dbg(
+            '[replaceText] retain[$index ~ $number] isEnd:$isEnd activeStyle=$activeStyle');
 
         // retainDelta가 no-op retain만 포함하면 document.compose 내부 trim() 후
         // delta가 비어 assertion 실패하므로 사전에 체크한다.
@@ -804,7 +809,8 @@ class QuillController extends ChangeNotifier {
         _pendingInlineStyle =
             pendingMap.isNotEmpty ? Style.attr(pendingMap) : null;
         _preserveToggledStyleOnNextSelection = false;
-        _dbg('[replaceText] updateSelection 1:$toggledStyle [insertNewline && selection.start > 0] $insertNewline, ${selection.start}');
+        _dbg(
+            '[replaceText] updateSelection 1:$toggledStyle [insertNewline && selection.start > 0] $insertNewline, ${selection.start}');
       } else if (_preserveToggledStyleOnNextSelection) {
         // 서식 적용 직후 최초 selection 변경(재포커스 탭 등)은 toggledStyle을 보존한다.
         _preserveToggledStyleOnNextSelection = false;
@@ -812,16 +818,19 @@ class QuillController extends ChangeNotifier {
       } else {
         // Android에서 포커스 이벤트가 여러 번 올 때 _pendingInlineStyle로 복원한다.
         toggledStyle = _pendingInlineStyle ?? const Style();
-        _dbg('[replaceText] updateSelection 2:$toggledStyle [!] $insertNewline, ${selection.start}');
+        _dbg(
+            '[replaceText] updateSelection 2:$toggledStyle [!] $insertNewline, ${selection.start}');
       }
     } else {
       if (_preserveToggledStyleOnNextSelection) {
         _preserveToggledStyleOnNextSelection = false;
-        _dbg('[replaceText] updateSelection preserve(noKeepStyle):$toggledStyle');
+        _dbg(
+            '[replaceText] updateSelection preserve(noKeepStyle):$toggledStyle');
       } else {
         // Android에서 포커스 이벤트가 여러 번 올 때 _pendingInlineStyle로 복원한다.
         toggledStyle = _pendingInlineStyle ?? const Style();
-        _dbg('[replaceText] updateSelection 3:$toggledStyle !keepStyleOnNewLine');
+        _dbg(
+            '[replaceText] updateSelection 3:$toggledStyle !keepStyleOnNewLine');
       }
     }
 
@@ -972,7 +981,7 @@ class QuillController extends ChangeNotifier {
 
     if (plainText != null) {
       final plainTextToPaste = await getTextToPaste(plainText);
-      if (await pastePlainTextOrDelta(plainTextToPaste,
+      if (await await pastePlainTextOrDelta(plainTextToPaste,
           pastePlainText: _pastePlainText, pasteDelta: _pasteDelta)) {
         updateEditor?.call();
         return true;

--- a/lib/src/controller/quill_controller.dart
+++ b/lib/src/controller/quill_controller.dart
@@ -1,5 +1,8 @@
+import 'dart:developer';
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart' show kDebugMode;
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart' show ClipboardData, Clipboard;
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
@@ -21,6 +24,10 @@ import '../editor_toolbar_controller_shared/clipboard/clipboard_service_provider
 import 'clipboard/quill_controller_paste.dart';
 import 'clipboard/quill_controller_rich_paste.dart';
 import 'quill_controller_config.dart';
+
+void _dbg(String msg) {
+  if (kDebugMode) log(msg);
+}
 
 typedef ReplaceTextCallback = bool Function(int index, int len, Object? data);
 typedef DeleteCallback = void Function(int cursorPosition, bool forward);
@@ -111,9 +118,28 @@ class QuillController extends ChangeNotifier {
   /// It gets reset after each format action within the [document].
   Style toggledStyle = const Style();
 
+  /// Android에서 색상/서식 적용 후 에디터 재포커스 시 selection 변경으로
+  /// toggledStyle이 리셋되는 것을 한 번 방지하는 플래그.
+  bool _preserveToggledStyleOnNextSelection = false;
+
+  /// 포맷 버튼 클릭 시 저장되어, Android 포커스 이벤트로 toggledStyle이
+  /// 리셋되어도 첫 번째 글자에 올바른 서식이 유지되도록 하는 백업 스타일.
+  /// _preserveToggledStyleOnNextSelection 이 소비된 이후의 추가 selection
+  /// 이벤트에서도 toggledStyle을 복원하는 데 사용된다.
+  Style? _pendingInlineStyle;
+
+  /// IME composing 중 mixin이 안정적으로 참조할 수 있도록 공개한다.
+  /// toggledStyle은 selection 이벤트로 초기화될 수 있으므로, 이 값을 사용한다.
+  Style? get pendingInlineStyle => _pendingInlineStyle;
+
   /// [raw_editor_actions] handling of backspace event may need to force the style displayed in the toolbar
   void forceToggledStyle(Style style) {
     toggledStyle = style;
+    // _updateSelection이 나중에 toggledStyle을 리셋하더라도 _pendingInlineStyle로 복원되도록 함께 갱신한다.
+    if (style.isNotEmpty) {
+      _pendingInlineStyle = style;
+    }
+    _dbg('[replaceText] forceToggledStyle:$toggledStyle');
     notifyListeners();
   }
 
@@ -264,7 +290,7 @@ class QuillController extends ChangeNotifier {
         const TextSelection.collapsed(offset: 0));
   }
 
-  void replaceText(
+  void replaceTextOri(
     int index,
     int len,
     Object? data,
@@ -337,6 +363,271 @@ class QuillController extends ChangeNotifier {
     ignoreFocusOnTextChange = false;
   }
 
+  void toggleInlineStyle(int index, Style selectionStyle) {
+    forceImeStyle(index, selectionStyle);
+  }
+
+  Style? getCachedStyle(int index) {
+    return _styleCacheByIndex[index] ?? _imePreservedStyles[index];
+  }
+
+  Style _onlyInlineToggledStyleStyle() {
+    final sourceStyle = toggledStyle.isNotEmpty
+        ? toggledStyle
+        : (_pendingInlineStyle ?? const Style());
+    final result = Map<String, Attribute>.fromEntries(
+      sourceStyle.attributes.entries
+          .where((a) => a.value.scope != AttributeScope.block),
+    );
+    // _pendingInlineStyle의 null값 속성(서식 OFF 의도)을 누락 없이 반영한다.
+    // _updateSelection의 mergeAll이 null값 속성을 제거하면 toggledStyle에서 사라지는데,
+    // _pendingInlineStyle에는 보존되어 있으므로 여기서 다시 추가해 OFF 의도를 유지한다.
+    // 예: 엔터 후 background:null이 toggledStyle에서 사라지더라도 activeStyle에 포함됨.
+    if (_pendingInlineStyle != null) {
+      for (final attr in _pendingInlineStyle!.values) {
+        if (attr.value == null &&
+            attr.scope != AttributeScope.block &&
+            !result.containsKey(attr.key)) {
+          result[attr.key] = attr;
+        }
+      }
+    }
+    return Style.attr(result);
+  }
+
+  final Map<int, Style> _styleCacheByIndex = {};
+  // document.length<=1 클리어로부터 IME 조합 스타일을 보호하는 보조 캐시.
+  // DELETE로 문서가 일시 비워질 때 _styleCacheByIndex 값을 여기에 복사해두고,
+  // 바로 이어지는 INSERT에서 사용한 뒤 비운다.
+  final Map<int, Style> _imePreservedStyles = {};
+
+  // 전체 삭제 후 서식 초기화 예약 플래그.
+  // document.length <= 1이 되면 true로 설정하고 postFrameCallback으로 초기화 실행을 예약한다.
+  // 같은 프레임 내에 INSERT(IME 조합 완성)가 오면 false로 캔슬된다.
+  bool _pendingStyleReset = false;
+
+  // 문서 컨텍스트 상속을 방지하기 위한 bool 인라인 속성의 null 버전 목록.
+  // cachedChar 기반 retain 적용 시, charStyle에 없는 속성을 명시적으로 null 처리하여
+  // 앞 글자의 bold/italic 등이 새 글자로 자동 상속되는 것을 차단한다.
+  static final List<Attribute> _nullBoolInlineAttrs = [
+    Attribute.clone(Attribute.bold, null),
+    Attribute.clone(Attribute.italic, null),
+    Attribute.clone(Attribute.underline, null),
+    Attribute.clone(Attribute.strikeThrough, null),
+    Attribute.clone(Attribute.inlineCode, null),
+    Attribute.clone(Attribute.small, null),
+  ];
+  void cacheStyle(int index, int length) {
+    for (var i = 0; i < length; i++) {
+      final newIndex = index + i;
+      _styleCacheByIndex[newIndex] = document.collectStyle(newIndex, 1);
+      _dbg('[replaceText] retain[$newIndex] savedStyle: ${_styleCacheByIndex[newIndex]}');
+    }
+  }
+
+  /// 버튼 클릭 후 호출: 현재 커서 위치에 사용자가 원하는 스타일을 캐시에 미리 저장한다.
+  void forceImeStyle(int index, Style selectionStyle) {
+    _styleCacheByIndex[index] = selectionStyle;
+    _dbg('[replaceText] forceImeStyle index:[$index] style=$selectionStyle');
+  }
+
+  void replaceText(
+    int index,
+    int len,
+    Object? data,
+    TextSelection? textSelection, {
+    bool ignoreFocus = false,
+    bool shouldNotifyListeners = true,
+  }) {
+    assert(data is String || data is Embeddable || data is Delta);
+
+    if (onReplaceText != null && !onReplaceText!(index, len, data)) {
+      return;
+    }
+
+    final isDeleteOnly = data is String && data.isEmpty && len > 0;
+    final isInsertOnly = data is String && data.isNotEmpty && len == 0;
+
+    // INSERT(또는 IME 교체)가 오면 전체 삭제 후 서식 초기화 예약을 취소한다.
+    // 같은 프레임 내에 온 INSERT는 한국어 IME 조합 완성(ㄱ→가 등)이므로 서식을 보존해야 한다.
+    if (_pendingStyleReset && !isDeleteOnly) {
+      _pendingStyleReset = false;
+    }
+
+    final selectionStyle = getSelectionStyle();
+    final toggleStyle = toggledStyle;
+
+    if (isDeleteOnly) {
+      cacheStyle(index, len);
+    } else if (data is String && data.isNotEmpty && len > 0) {
+      // 안드로이드 IME는 composing range 전체를 replace하므로 이전 글자까지 포함된다.
+      // isDeleteOnly가 아니어서 cacheStyle이 호출되지 않으므로,
+      // 아직 캐시가 없는 위치의 스타일을 document.replace 전에 미리 저장한다.
+      for (var i = index; i < index + len; i++) {
+        if (!_styleCacheByIndex.containsKey(i) && !_imePreservedStyles.containsKey(i)) {
+          _styleCacheByIndex[i] = document.collectStyle(i, 1);
+        }
+      }
+    }
+
+    _dbg(
+      '[replaceText] ===> retain[$index] Delete[$len] Insert[$data] isInsert:$isInsertOnly, isDelete:$isDeleteOnly, ** selectionStyle=$selectionStyle ## toggledStyle=$toggleStyle',
+    );
+
+    // document.replace 전후로 toggledStyle/_pendingInlineStyle은 변경되지 않으므로
+    // 미리 계산해서 블록 안팎 두 곳에서 재사용한다.
+    final activeStyle = _onlyInlineToggledStyleStyle();
+
+    Delta? delta;
+    if (len > 0 || data is! String || data.isNotEmpty) {
+      delta = document.replace(index, len, data);
+
+      final indexStyle = getCachedStyle(index);
+
+      _dbg('[replaceText] styleIndex=$index indexStyle=$indexStyle, $data replace[${delta.toJson()}]');
+
+      // 순수 삽입: [retain, insert] 또는 [insert]
+      final isPureInsert = delta.length <= 2 && delta.last.isInsert;
+      // IME 조합 교체 (한국어 등): ㄱ→가 처럼 composing text를 교체하는 경우
+      final isImeCompose = data is String && data.isNotEmpty && len > 0;
+      var shouldRetainDelta = (activeStyle.isNotEmpty || indexStyle != null) &&
+          delta.isNotEmpty &&
+          (isPureInsert || isImeCompose);
+      final isEnd = activeStyle.isNotEmpty &&
+          delta.length == 2 &&
+          delta.last.data == '\n';
+
+      if (shouldRetainDelta && isEnd) {
+        // if all attributes are inline, shouldRetainDelta should be false
+        final anyAttributeNotInline =
+            activeStyle.values.any((attr) => !attr.isInline);
+        if (!anyAttributeNotInline) {
+          shouldRetainDelta = false;
+        }
+      }
+
+      final number = data is String ? data.length : 1;
+
+      if (shouldRetainDelta) {
+        final retainDelta = Delta()..retain(index);
+        for (var i = 0; i < number; i++) {
+          final cachedChar = getCachedStyle(index + i);
+          final Style charStyle;
+          if (cachedChar != null) {
+            // 캐시된 글자: 원래 서식 복원.
+            // cachedChar={} (서식 없음)도 캐시 분기로 처리 → activeStyle 전파 차단.
+            final attrs = Map<String, Attribute>.from(cachedChar.attributes);
+            // 앞 글자로부터 bool 속성 상속을 막기 위해 캐시에 없는 속성을 명시적 null로 채운다.
+            for (final nullAttr in _nullBoolInlineAttrs) {
+              if (!attrs.containsKey(nullAttr.key)) {
+                attrs[nullAttr.key] = nullAttr;
+              }
+            }
+            // 사용자가 OFF한 속성(null값) 중 캐시에 없는 것만 추가 (캐시 값은 덮어쓰지 않음).
+            for (final activeAttr in activeStyle.values) {
+              if (activeAttr.value == null && !attrs.containsKey(activeAttr.key)) {
+                attrs[activeAttr.key] = activeAttr;
+              }
+            }
+            charStyle = Style.attr(attrs);
+          } else {
+            charStyle = activeStyle;
+          }
+          // 안드로이드 IME 연속 compose replace 대비: 직전 retain 스타일을 다음 이벤트에서 재사용.
+          if (isImeCompose) {
+            _styleCacheByIndex[index + i] = charStyle;
+          }
+          if (charStyle.isNotEmpty) {
+            retainDelta.retain(1, charStyle.toJson());
+          } else {
+            retainDelta.retain(1);
+          }
+        }
+
+        _dbg('[replaceText] retain[$index ~ $number] isEnd:$isEnd activeStyle=$activeStyle');
+
+        // retainDelta가 no-op retain만 포함하면 document.compose 내부 trim() 후
+        // delta가 비어 assertion 실패하므로 사전에 체크한다.
+        retainDelta.trim();
+        if (retainDelta.isNotEmpty) {
+          document.compose(retainDelta, ChangeSource.local);
+        }
+      }
+
+      // isImeCompose: retain 루프에서 캐시를 이미 최신 charStyle로 업데이트했으므로 클리어 안 함.
+      // insert-only: 소비된 캐시 위치만 제거.
+      if (!isDeleteOnly && !isImeCompose) {
+        for (var i = 0; i < number; i++) {
+          _styleCacheByIndex.remove(index + i);
+          _imePreservedStyles.remove(index + i);
+        }
+      }
+    }
+
+    // 엔터('\n') 제외: 새 줄에서 toggledStyle이 iOS 다중 selection 이벤트에서도 유지되도록 한다.
+    // 비어있으면 기존 값 유지: 한국어 IME 조합 중 document 일시 비워짐 등으로 유실 방지.
+    if ((data is! String || data != '\n') && activeStyle.isNotEmpty) {
+      _pendingInlineStyle = activeStyle;
+    }
+
+    if (textSelection != null) {
+      if (delta == null || delta.isEmpty) {
+        _updateSelection(textSelection);
+      } else {
+        final user = Delta()
+          ..retain(index)
+          ..insert(data)
+          ..delete(len);
+        final positionDelta = getPositionDelta(user, delta);
+        _updateSelection(
+          textSelection.copyWith(
+            baseOffset: textSelection.baseOffset + positionDelta,
+            extentOffset: textSelection.extentOffset + positionDelta,
+          ),
+          insertNewline: data == '\n',
+        );
+      }
+    }
+
+    // document.length <= 1 (문서가 비워짐) 처리
+    if (document.length <= 1) {
+      _preserveToggledStyleOnNextSelection = false;
+      // 스타일 캐시를 보조 맵으로 옮겨 바로 이어지는 IME INSERT에서 사용 가능하도록 보존한다.
+      if (_styleCacheByIndex.isNotEmpty) {
+        _imePreservedStyles.addAll(_styleCacheByIndex);
+      }
+      _styleCacheByIndex.clear();
+      // 전체 삭제 후 서식 초기화를 다음 프레임으로 예약한다.
+      // 한국어 IME 'ㄱ→가' 변환처럼 DELETE 직후 같은 프레임 내에 INSERT가 오면
+      // replaceText 진입 시 _pendingStyleReset=false 로 취소되어 서식이 보존된다.
+      // 사용자가 직접 모두 삭제한 경우 같은 프레임 내에 INSERT가 없으므로
+      // 콜백이 실행되어 서식이 초기화된다.
+      _pendingStyleReset = true;
+      // scheduleFrame을 명시적으로 호출해 post-frame callback이 실행될 보장을 추가한다.
+      // 위젯 트리 없는 테스트 환경에서도 tester.pump()로 콜백이 실행되도록 한다.
+      SchedulerBinding.instance.scheduleFrame();
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (_pendingStyleReset) {
+          _pendingStyleReset = false;
+          toggledStyle = const Style();
+          _pendingInlineStyle = null;
+          _imePreservedStyles.clear();
+          notifyListeners();
+        }
+      });
+    }
+
+    if (ignoreFocus) {
+      ignoreFocusOnTextChange = true;
+    }
+
+    if (shouldNotifyListeners) {
+      notifyListeners();
+    }
+
+    ignoreFocusOnTextChange = false;
+  }
+
   /// Called in two cases:
   /// forward == false && textBefore.isEmpty
   /// forward == true && textAfter.isEmpty
@@ -361,11 +652,23 @@ class QuillController extends ChangeNotifier {
       // Add the attribute to our toggledStyle.
       // It will be used later upon insertion.
       toggledStyle = toggledStyle.put(attribute);
+      // Android에서 서식 적용 직후 에디터 재포커스 탭으로 인한 selection 변경이
+      // toggledStyle을 리셋하지 않도록 한 번 보호한다.
+      _preserveToggledStyleOnNextSelection = true;
+      // 여러 번의 selection 이벤트에서도 서식이 유지되도록 별도로 저장한다.
+      _pendingInlineStyle = toggledStyle;
+      // 사용자가 새 서식을 설정했으므로 forceImeStyle이 남긴 stale 캐시를 비운다.
+      // formatText → afterButtonPressed → forceImeStyle 순서이므로, 이 clear 이후
+      // forceImeStyle이 최신 getSelectionStyle()로 재설정한다.
+      // _imePreservedStyles도 함께 비워 이전 IME 사이클 데이터가 남지 않도록 한다.
+      _styleCacheByIndex.clear();
+      _imePreservedStyles.clear();
+      _dbg('[replaceText] toggledStyle:$toggledStyle');
     }
 
     final change = document.format(index, len, attribute);
     // Transform selection against the composed change and give priority to
-    // the change. This is needed in cases when format operation actually
+    // the change. This is needed in cases when format operation actually5
     // inserts data into the document (e.g. embeds).
     final adjustedSelection = selection.copyWith(
         baseOffset: change.transformPosition(selection.baseOffset),
@@ -464,23 +767,64 @@ class QuillController extends ChangeNotifier {
   void _updateSelection(TextSelection textSelection,
       {bool insertNewline = false}) {
     _selection = textSelection;
+
     final end = document.length - 1;
+
     _selection = selection.copyWith(
         baseOffset: math.min(selection.baseOffset, end),
         extentOffset: math.min(selection.extentOffset, end));
+
     if (keepStyleOnNewLine) {
       if (insertNewline && selection.start > 0) {
         final style = document.collectStyle(selection.start - 1, 0);
         final ignoredStyles = style.attributes.values.where(
-          (s) => !s.isInline || s.key == Attribute.link.key,
+          (s) =>
+              !s.isInline ||
+              s.key == Attribute.link.key ||
+              s.key == Attribute.color.key ||
+              s.key == Attribute.background.key,
         );
-        toggledStyle = style.removeAll(ignoredStyles.toSet());
+        final inheritedStyle = style.removeAll(ignoredStyles.toSet());
+        // 엔터 전 사용자가 변경한 서식(_pendingInlineStyle)을 우선 적용하고,
+        // 이전 줄에서 상속할 스타일로 부족한 부분을 채운다.
+        final prevPending = _pendingInlineStyle;
+        toggledStyle =
+            inheritedStyle.mergeAll(_pendingInlineStyle ?? toggledStyle);
+        // iOS는 Enter 한 번에 insertNewline=true 이벤트를 여러 번 보낸다.
+        // mergeAll은 null-값 attr(예: bold:null)을 map에서 제거하므로,
+        // prevPending의 null attr을 다시 추가하여 "서식 끄기" 의도를 보존한다.
+        final pendingMap = Map<String, Attribute>.from(toggledStyle.attributes);
+        if (prevPending != null) {
+          for (final attr in prevPending.values) {
+            if (attr.value == null && !pendingMap.containsKey(attr.key)) {
+              pendingMap[attr.key] = attr;
+            }
+          }
+        }
+        _pendingInlineStyle =
+            pendingMap.isNotEmpty ? Style.attr(pendingMap) : null;
+        _preserveToggledStyleOnNextSelection = false;
+        _dbg('[replaceText] updateSelection 1:$toggledStyle [insertNewline && selection.start > 0] $insertNewline, ${selection.start}');
+      } else if (_preserveToggledStyleOnNextSelection) {
+        // 서식 적용 직후 최초 selection 변경(재포커스 탭 등)은 toggledStyle을 보존한다.
+        _preserveToggledStyleOnNextSelection = false;
+        _dbg('[replaceText] updateSelection preserve:$toggledStyle');
       } else {
-        toggledStyle = const Style();
+        // Android에서 포커스 이벤트가 여러 번 올 때 _pendingInlineStyle로 복원한다.
+        toggledStyle = _pendingInlineStyle ?? const Style();
+        _dbg('[replaceText] updateSelection 2:$toggledStyle [!] $insertNewline, ${selection.start}');
       }
     } else {
-      toggledStyle = const Style();
+      if (_preserveToggledStyleOnNextSelection) {
+        _preserveToggledStyleOnNextSelection = false;
+        _dbg('[replaceText] updateSelection preserve(noKeepStyle):$toggledStyle');
+      } else {
+        // Android에서 포커스 이벤트가 여러 번 올 때 _pendingInlineStyle로 복원한다.
+        toggledStyle = _pendingInlineStyle ?? const Style();
+        _dbg('[replaceText] updateSelection 3:$toggledStyle !keepStyleOnNewLine');
+      }
     }
+
     onSelectionChanged?.call(textSelection);
   }
 
@@ -628,7 +972,7 @@ class QuillController extends ChangeNotifier {
 
     if (plainText != null) {
       final plainTextToPaste = await getTextToPaste(plainText);
-      if (pastePlainTextOrDelta(plainTextToPaste,
+      if (await pastePlainTextOrDelta(plainTextToPaste,
           pastePlainText: _pastePlainText, pasteDelta: _pasteDelta)) {
         updateEditor?.call();
         return true;

--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -1,3 +1,4 @@
+import 'dart:developer';
 import 'dart:ui' show lerpDouble;
 
 import 'package:flutter/cupertino.dart';
@@ -12,8 +13,11 @@ import '../../document/document.dart';
 import '../editor.dart';
 import 'raw_editor.dart';
 
-mixin RawEditorStateTextInputClientMixin on EditorState
-    implements TextInputClient {
+void _dbg(String msg) {
+  if (kDebugMode) log(msg);
+}
+
+mixin RawEditorStateTextInputClientMixin on EditorState implements TextInputClient {
   TextInputConnection? _textInputConnection;
   TextEditingValue? __lastKnownRemoteTextEditingValue;
 
@@ -24,8 +28,7 @@ mixin RawEditorStateTextInputClientMixin on EditorState
     }
   }
 
-  TextEditingValue? get _lastKnownRemoteTextEditingValue =>
-      __lastKnownRemoteTextEditingValue;
+  TextEditingValue? get _lastKnownRemoteTextEditingValue => __lastKnownRemoteTextEditingValue;
 
   /// The range of text that is currently being composed.
   final ValueNotifier<TextRange> composingRange = ValueNotifier<TextRange>(
@@ -48,14 +51,12 @@ mixin RawEditorStateTextInputClientMixin on EditorState
   bool get shouldCreateInputConnection => kIsWeb || !widget.config.readOnly;
 
   /// Returns `true` if there is open input connection.
-  bool get hasConnection =>
-      _textInputConnection != null && _textInputConnection!.attached;
+  bool get hasConnection => _textInputConnection != null && _textInputConnection!.attached;
 
   /// Opens or closes input connection based on the current state of
   /// [focusNode] and [value].
   void openOrCloseConnection() {
-    if (widget.config.focusNode.hasFocus &&
-        widget.config.focusNode.consumeKeyboardToken()) {
+    if (widget.config.focusNode.hasFocus && widget.config.focusNode.consumeKeyboardToken()) {
       openConnectionIfNeeded();
     } else if (!widget.config.focusNode.hasFocus) {
       closeConnectionIfNeeded();
@@ -66,9 +67,7 @@ mixin RawEditorStateTextInputClientMixin on EditorState
   @visibleForTesting
   @internal
   Brightness createKeyboardAppearance() =>
-      widget.config.keyboardAppearance ??
-      CupertinoTheme.maybeBrightnessOf(context) ??
-      Theme.of(context).brightness;
+      widget.config.keyboardAppearance ?? CupertinoTheme.maybeBrightnessOf(context) ?? Theme.of(context).brightness;
 
   void openConnectionIfNeeded() {
     if (!shouldCreateInputConnection) {
@@ -101,14 +100,10 @@ mixin RawEditorStateTextInputClientMixin on EditorState
 
       /// Trap selection extends off end of document
       if (_lastKnownRemoteTextEditingValue != null) {
-        if (_lastKnownRemoteTextEditingValue!.selection.end >
-            _lastKnownRemoteTextEditingValue!.text.length) {
-          _lastKnownRemoteTextEditingValue = _lastKnownRemoteTextEditingValue!
-              .copyWith(
-                  selection: _lastKnownRemoteTextEditingValue!.selection
-                      .copyWith(
-                          extentOffset:
-                              _lastKnownRemoteTextEditingValue!.text.length));
+        if (_lastKnownRemoteTextEditingValue!.selection.end > _lastKnownRemoteTextEditingValue!.text.length) {
+          _lastKnownRemoteTextEditingValue = _lastKnownRemoteTextEditingValue!.copyWith(
+              selection: _lastKnownRemoteTextEditingValue!.selection
+                  .copyWith(extentOffset: _lastKnownRemoteTextEditingValue!.text.length));
         }
       }
       _textInputConnection!.setEditingState(_lastKnownRemoteTextEditingValue!);
@@ -117,34 +112,26 @@ mixin RawEditorStateTextInputClientMixin on EditorState
   }
 
   void _updateComposingRectIfNeeded() {
-    final composingRange = _lastKnownRemoteTextEditingValue?.composing ??
-        textEditingValue.composing;
+    final composingRange = _lastKnownRemoteTextEditingValue?.composing ?? textEditingValue.composing;
     if (hasConnection) {
       assert(mounted);
       if (composingRange.isValid) {
         final offset = composingRange.start;
-        final composingRect =
-            renderEditor.getLocalRectForCaret(TextPosition(offset: offset));
+        final composingRect = renderEditor.getLocalRectForCaret(TextPosition(offset: offset));
         _textInputConnection!.setComposingRect(composingRect);
       }
-      SchedulerBinding.instance
-          .addPostFrameCallback((_) => _updateComposingRectIfNeeded());
+      SchedulerBinding.instance.addPostFrameCallback((_) => _updateComposingRectIfNeeded());
     }
   }
 
   void _updateCaretRectIfNeeded() {
     if (hasConnection) {
-      if (!dirty &&
-          renderEditor.selection.isValid &&
-          renderEditor.selection.isCollapsed) {
-        final currentTextPosition =
-            TextPosition(offset: renderEditor.selection.baseOffset);
-        final caretRect =
-            renderEditor.getLocalRectForCaret(currentTextPosition);
+      if (!dirty && renderEditor.selection.isValid && renderEditor.selection.isCollapsed) {
+        final currentTextPosition = TextPosition(offset: renderEditor.selection.baseOffset);
+        final caretRect = renderEditor.getLocalRectForCaret(currentTextPosition);
         _textInputConnection!.setCaretRect(caretRect);
       }
-      SchedulerBinding.instance
-          .addPostFrameCallback((_) => _updateCaretRectIfNeeded());
+      SchedulerBinding.instance.addPostFrameCallback((_) => _updateCaretRectIfNeeded());
     }
   }
 
@@ -195,8 +182,7 @@ mixin RawEditorStateTextInputClientMixin on EditorState
 
   // Start TextInputClient implementation
   @override
-  TextEditingValue? get currentTextEditingValue =>
-      _lastKnownRemoteTextEditingValue;
+  TextEditingValue? get currentTextEditingValue => _lastKnownRemoteTextEditingValue;
 
   // autofill is not needed
   @override
@@ -213,6 +199,7 @@ mixin RawEditorStateTextInputClientMixin on EditorState
       return;
     }
 
+    // 텍스트와 선택 영역이 같고 composing만 변한 경우 무시
     // Check if only composing range changed.
     if (_lastKnownRemoteTextEditingValue!.text == value.text &&
         _lastKnownRemoteTextEditingValue!.selection == value.selection) {
@@ -230,16 +217,44 @@ mixin RawEditorStateTextInputClientMixin on EditorState
     final oldText = effectiveLastKnownValue.text;
     final text = value.text;
     final cursorPosition = value.selection.extentOffset;
+
+    // getDiff를 통해 변경 범위 계산
     final diff = getDiff(oldText, text, cursorPosition);
+
     if (diff.deleted.isEmpty && diff.inserted.isEmpty) {
       widget.controller.updateSelection(value.selection, ChangeSource.local);
     } else {
+      // Android/iOS IME composing 중 toggledStyle 유실 방지:
+      // toggledStyle은 selection 이벤트로 먼저 리셋될 수 있으므로,
+      // pendingInlineStyle(더 안정적)을 우선 사용하고 toggledStyle을 fallback으로 쓴다.
+      final effectiveStyle = widget.controller.pendingInlineStyle ??
+          (widget.controller.toggledStyle.isNotEmpty ? widget.controller.toggledStyle : null);
+      // composing.isValid뿐 아니라, 직전 상태에서 composing이 활성이었던 경우도 포함:
+      // 한국어 IME에서 ㄱ→가 완성 시 최종 '가'가 composing 없이 전송될 수 있음.
+      final wasComposing = effectiveLastKnownValue.composing.isValid;
+      final composingStyle = ((value.composing.isValid || wasComposing) && effectiveStyle != null)
+          ? effectiveStyle
+          : null;
+
+      _dbg('[mixin] diff="${diff.deleted}"→"${diff.inserted}" '
+          'composing=${value.composing} wasComposing=$wasComposing '
+          'pendingInlineStyle=${widget.controller.pendingInlineStyle} '
+          'toggledStyle=${widget.controller.toggledStyle} '
+          'effectiveStyle=$effectiveStyle composingStyle=$composingStyle');
+
       widget.controller.replaceText(
         diff.start,
         diff.deleted.length,
         diff.inserted,
         value.selection,
       );
+
+      if (composingStyle != null) {
+        // replaceText 내부의 retain 로직이 위치별(cachedChar 기반)로 스타일을 이미 적용한다.
+        // 여기서 formatText로 전체 범위에 다시 적용하면 앞 글자의 원래 서식을 덮어쓰므로 제거.
+        // forceToggledStyle만 호출해 다음 IME 이벤트에서 toggledStyle 상태를 유지한다.
+        widget.controller.forceToggledStyle(composingStyle);
+      }
     }
   }
 
@@ -288,49 +303,39 @@ mixin RawEditorStateTextInputClientMixin on EditorState
         // we cache the position.
         _pointOffsetOrigin = point.offset;
 
-        final currentTextPosition =
-            TextPosition(offset: renderEditor.selection.baseOffset);
-        _startCaretRect =
-            renderEditor.getLocalRectForCaret(currentTextPosition);
+        final currentTextPosition = TextPosition(offset: renderEditor.selection.baseOffset);
+        _startCaretRect = renderEditor.getLocalRectForCaret(currentTextPosition);
 
-        _lastBoundedOffset = _startCaretRect!.center -
-            _floatingCursorOffset(currentTextPosition);
+        _lastBoundedOffset = _startCaretRect!.center - _floatingCursorOffset(currentTextPosition);
         _lastTextPosition = currentTextPosition;
-        renderEditor.setFloatingCursor(
-            point.state, _lastBoundedOffset!, _lastTextPosition!);
+        renderEditor.setFloatingCursor(point.state, _lastBoundedOffset!, _lastTextPosition!);
         break;
       case FloatingCursorDragState.Update:
         assert(_lastTextPosition != null, 'Last text position was not set');
         final floatingCursorOffset = _floatingCursorOffset(_lastTextPosition!);
         final centeredPoint = point.offset! - _pointOffsetOrigin!;
-        final rawCursorOffset =
-            _startCaretRect!.center + centeredPoint - floatingCursorOffset;
+        final rawCursorOffset = _startCaretRect!.center + centeredPoint - floatingCursorOffset;
 
-        final preferredLineHeight =
-            renderEditor.preferredLineHeight(_lastTextPosition!);
+        final preferredLineHeight = renderEditor.preferredLineHeight(_lastTextPosition!);
         _lastBoundedOffset = renderEditor.calculateBoundedFloatingCursorOffset(
           rawCursorOffset,
           preferredLineHeight,
         );
-        _lastTextPosition = renderEditor.getPositionForOffset(renderEditor
-            .localToGlobal(_lastBoundedOffset! + floatingCursorOffset));
-        renderEditor.setFloatingCursor(
-            point.state, _lastBoundedOffset!, _lastTextPosition!);
-        final newSelection = TextSelection.collapsed(
-            offset: _lastTextPosition!.offset,
-            affinity: _lastTextPosition!.affinity);
+        _lastTextPosition =
+            renderEditor.getPositionForOffset(renderEditor.localToGlobal(_lastBoundedOffset! + floatingCursorOffset));
+        renderEditor.setFloatingCursor(point.state, _lastBoundedOffset!, _lastTextPosition!);
+        final newSelection =
+            TextSelection.collapsed(offset: _lastTextPosition!.offset, affinity: _lastTextPosition!.affinity);
         // Setting selection as floating cursor moves will have scroll view
         // bring background cursor into view
-        renderEditor.onSelectionChanged(
-            newSelection, SelectionChangedCause.forcePress);
+        renderEditor.onSelectionChanged(newSelection, SelectionChangedCause.forcePress);
         break;
       case FloatingCursorDragState.End:
         // We skip animation if no update has happened.
         if (_lastTextPosition != null && _lastBoundedOffset != null) {
           floatingCursorResetController
             ..value = 0.0
-            ..animateTo(1,
-                duration: _floatingCursorResetTime, curve: Curves.decelerate);
+            ..animateTo(1, duration: _floatingCursorResetTime, curve: Curves.decelerate);
         }
         break;
     }
@@ -344,24 +349,19 @@ mixin RawEditorStateTextInputClientMixin on EditorState
   /// and current position of background cursor)
   void onFloatingCursorResetTick() {
     final finalPosition =
-        renderEditor.getLocalRectForCaret(_lastTextPosition!).centerLeft -
-            _floatingCursorOffset(_lastTextPosition!);
+        renderEditor.getLocalRectForCaret(_lastTextPosition!).centerLeft - _floatingCursorOffset(_lastTextPosition!);
     if (floatingCursorResetController.isCompleted) {
-      renderEditor.setFloatingCursor(
-          FloatingCursorDragState.End, finalPosition, _lastTextPosition!);
+      renderEditor.setFloatingCursor(FloatingCursorDragState.End, finalPosition, _lastTextPosition!);
       _startCaretRect = null;
       _lastTextPosition = null;
       _pointOffsetOrigin = null;
       _lastBoundedOffset = null;
     } else {
       final lerpValue = floatingCursorResetController.value;
-      final lerpX =
-          lerpDouble(_lastBoundedOffset!.dx, finalPosition.dx, lerpValue)!;
-      final lerpY =
-          lerpDouble(_lastBoundedOffset!.dy, finalPosition.dy, lerpValue)!;
+      final lerpX = lerpDouble(_lastBoundedOffset!.dx, finalPosition.dx, lerpValue)!;
+      final lerpY = lerpDouble(_lastBoundedOffset!.dy, finalPosition.dy, lerpValue)!;
 
-      renderEditor.setFloatingCursor(FloatingCursorDragState.Update,
-          Offset(lerpX, lerpY), _lastTextPosition!,
+      renderEditor.setFloatingCursor(FloatingCursorDragState.Update, Offset(lerpX, lerpY), _lastTextPosition!,
           resetLerpValue: lerpValue);
     }
   }
@@ -389,8 +389,7 @@ mixin RawEditorStateTextInputClientMixin on EditorState
       final size = renderEditor.size;
       final transform = renderEditor.getTransformTo(null);
       _textInputConnection?.setEditableSizeAndTransform(size, transform);
-      SchedulerBinding.instance
-          .addPostFrameCallback((_) => _updateSizeAndTransform());
+      SchedulerBinding.instance.addPostFrameCallback((_) => _updateSizeAndTransform());
     }
   }
 }

--- a/test/controller/controller_clipboard_test.dart
+++ b/test/controller/controller_clipboard_test.dart
@@ -14,17 +14,13 @@ void main() {
 
     setUp(() {
       controller = QuillController.basic()
-        ..compose(Delta()..insert(testDocumentContents),
-            const TextSelection.collapsed(offset: 0), ChangeSource.local);
+        ..compose(Delta()..insert(testDocumentContents), const TextSelection.collapsed(offset: 0), ChangeSource.local);
     });
 
-    test(
-        'should prioritize delta from onDeltaPaste callback over parsed delta when pasting Delta',
-        () async {
+    test('should prioritize delta from onDeltaPaste callback over parsed delta when pasting Delta', () async {
       var returnComposedDelta = true;
 
-      controller = QuillController.basic(
-          config: QuillControllerConfig(clipboardConfig: QuillClipboardConfig(
+      controller = QuillController.basic(config: QuillControllerConfig(clipboardConfig: QuillClipboardConfig(
         onRichTextPaste: (delta, isExternal) async {
           if (returnComposedDelta) {
             return delta.compose(Delta()..insert('composed delta\n'));
@@ -35,19 +31,18 @@ void main() {
 
       final initialDelta = Delta()..insert('plain text\n', {'bold': true});
 
-      expect(await controller.getDeltaToPaste(initialDelta),
+      expect(await controller.getDeltaToPaste(initialDelta, isExternal: false),
           initialDelta.compose(Delta()..insert('composed delta\n')));
 
       returnComposedDelta = false;
 
       final secondDelta = Delta()..insert('plain text\n', {'bold': true});
 
-      expect(await controller.getDeltaToPaste(secondDelta), secondDelta);
+      expect(await controller.getDeltaToPaste(secondDelta, isExternal: false), secondDelta);
     });
 
     test('clipboardSelection empty', () {
-      expect(controller.clipboardSelection(true), false,
-          reason: 'No effect when no selection');
+      expect(controller.clipboardSelection(true), false, reason: 'No effect when no selection');
       expect(controller.clipboardSelection(false), false);
     });
 
@@ -56,29 +51,25 @@ void main() {
         ..replaceText(0, 4, 'bold plain italic', null)
         ..formatText(0, 4, Attribute.bold)
         ..formatText(11, 17, Attribute.italic)
-        ..updateSelection(const TextSelection(baseOffset: 2, extentOffset: 14),
-            ChangeSource.local);
+        ..updateSelection(const TextSelection(baseOffset: 2, extentOffset: 14), ChangeSource.local);
       //
       expect(controller.clipboardSelection(true), true);
-      expect(controller.document.length, 18,
-          reason: 'Copy does not change the document');
+      expect(controller.document.length, 18, reason: 'Copy does not change the document');
       expect(controller.clipboardSelection(false), true);
       expect(controller.document.length, 6, reason: 'Cut changes the document');
       //
       controller
         ..readOnly = true
-        ..updateSelection(const TextSelection(baseOffset: 2, extentOffset: 4),
-            ChangeSource.local);
+        ..updateSelection(const TextSelection(baseOffset: 2, extentOffset: 4), ChangeSource.local);
       expect(controller.selection.isCollapsed, false);
       expect(controller.clipboardSelection(true), true);
       expect(controller.document.length, 6);
       expect(controller.clipboardSelection(false), false);
-      expect(controller.document.length, 6,
-          reason: 'Cut not permitted on readOnly document');
+      expect(controller.document.length, 6, reason: 'Cut not permitted on readOnly document');
     });
   });
 
-  bool pasteUsingPlainOrDelta(
+  Future<bool> pasteUsingPlainOrDelta(
     QuillController controller,
     String? clipboardText,
   ) =>
@@ -91,10 +82,8 @@ void main() {
   group('paste', () {
     test('Plain', () async {
       final controller = QuillController.basic()
-        ..compose(Delta()..insert('[]'),
-            const TextSelection.collapsed(offset: 0), ChangeSource.local)
-        ..updateSelection(
-            const TextSelection.collapsed(offset: 1), ChangeSource.local);
+        ..compose(Delta()..insert('[]'), const TextSelection.collapsed(offset: 0), ChangeSource.local)
+        ..updateSelection(const TextSelection.collapsed(offset: 1), ChangeSource.local);
       //
       expect(controller.document.toPlainText(), '[]\n');
       expect(pasteUsingPlainOrDelta(controller, 'insert'), true);
@@ -103,10 +92,8 @@ void main() {
 
     test('Plain lines', () async {
       final controller = QuillController.basic()
-        ..compose(Delta()..insert('[]'),
-            const TextSelection.collapsed(offset: 0), ChangeSource.local)
-        ..updateSelection(
-            const TextSelection.collapsed(offset: 1), ChangeSource.local);
+        ..compose(Delta()..insert('[]'), const TextSelection.collapsed(offset: 0), ChangeSource.local)
+        ..updateSelection(const TextSelection.collapsed(offset: 1), ChangeSource.local);
       //
       expect(controller.document.toPlainText(), '[]\n');
       expect(pasteUsingPlainOrDelta(controller, '1\n2\n3\n'), true);
@@ -115,31 +102,24 @@ void main() {
 
     test('Paste from external', () async {
       final source = QuillController.basic()
-        ..compose(Delta()..insert('Plain text'),
-            const TextSelection.collapsed(offset: 0), ChangeSource.local)
-        ..updateSelection(const TextSelection(baseOffset: 4, extentOffset: 8),
-            ChangeSource.local);
+        ..compose(Delta()..insert('Plain text'), const TextSelection.collapsed(offset: 0), ChangeSource.local)
+        ..updateSelection(const TextSelection(baseOffset: 4, extentOffset: 8), ChangeSource.local);
       assert(source.clipboardSelection(true));
       expect(source.pastePlainText, 'n te');
       //
       final controller = QuillController.basic()
-        ..compose(Delta()..insert('[]'),
-            const TextSelection.collapsed(offset: 0), ChangeSource.local)
-        ..updateSelection(
-            const TextSelection.collapsed(offset: 1), ChangeSource.local);
+        ..compose(Delta()..insert('[]'), const TextSelection.collapsed(offset: 0), ChangeSource.local)
+        ..updateSelection(const TextSelection.collapsed(offset: 1), ChangeSource.local);
       //
-      expect(pasteUsingPlainOrDelta(controller, 'insert'), true,
-          reason: 'External paste');
+      expect(pasteUsingPlainOrDelta(controller, 'insert'), true, reason: 'External paste');
       expect(controller.document.toPlainText(), '[insert]\n');
     });
 
     test('Delta simple', () async {
       final source = QuillController.basic()
-        ..compose(Delta()..insert('Plain text'),
-            const TextSelection.collapsed(offset: 0), ChangeSource.local)
+        ..compose(Delta()..insert('Plain text'), const TextSelection.collapsed(offset: 0), ChangeSource.local)
         ..formatText(6, 8, Attribute.bold)
-        ..updateSelection(const TextSelection(baseOffset: 4, extentOffset: 8),
-            ChangeSource.local);
+        ..updateSelection(const TextSelection(baseOffset: 4, extentOffset: 8), ChangeSource.local);
       assert(source.clipboardSelection(true));
       expect(source.pastePlainText, 'n te');
       expect(
@@ -149,13 +129,10 @@ void main() {
             ..insert('te', {'bold': true}));
       //
       final controller = QuillController.basic()
-        ..compose(Delta()..insert('[]'),
-            const TextSelection.collapsed(offset: 0), ChangeSource.local)
-        ..updateSelection(
-            const TextSelection.collapsed(offset: 1), ChangeSource.local);
+        ..compose(Delta()..insert('[]'), const TextSelection.collapsed(offset: 0), ChangeSource.local)
+        ..updateSelection(const TextSelection.collapsed(offset: 1), ChangeSource.local);
       //
-      expect(pasteUsingPlainOrDelta(controller, 'n te'), true,
-          reason: 'Internal paste');
+      expect(pasteUsingPlainOrDelta(controller, 'n te'), true, reason: 'Internal paste');
       expect(controller.document.toPlainText(), '[n te]\n');
       expect(
           controller.document.toDelta(),
@@ -170,16 +147,14 @@ void main() {
       const blockAttribute = Attribute.ol;
       const plainSelection = 'BC\nDEF\nGHI\nJK';
       final source = QuillController.basic()
-        ..compose(Delta()..insert('ABC\nDEF\nGHI\nJKL'),
-            const TextSelection.collapsed(offset: 0), ChangeSource.local)
+        ..compose(Delta()..insert('ABC\nDEF\nGHI\nJKL'), const TextSelection.collapsed(offset: 0), ChangeSource.local)
         ..formatText(1, 1, Attribute.underline) // ABC with B underlined
         ..formatText(4, 0, blockAttribute) // 1. DEF with E in italic
         ..formatText(5, 1, Attribute.italic)
         ..formatText(8, 0, blockAttribute) // 2. GHI with H as inline code
         ..formatText(9, 1, Attribute.inlineCode)
         ..formatText(13, 1, Attribute.strikeThrough) // JKL with K strikethrough
-        ..updateSelection(const TextSelection(baseOffset: 1, extentOffset: 14),
-            ChangeSource.local);
+        ..updateSelection(const TextSelection(baseOffset: 1, extentOffset: 14), ChangeSource.local);
       //
       assert(source.clipboardSelection(true));
       expect(source.pastePlainText, plainSelection);
@@ -199,13 +174,10 @@ void main() {
             ..insert('K', {'strike': true}));
       //
       final controller = QuillController.basic()
-        ..compose(Delta()..insert('[]'),
-            const TextSelection.collapsed(offset: 0), ChangeSource.local)
-        ..updateSelection(
-            const TextSelection.collapsed(offset: 1), ChangeSource.local);
+        ..compose(Delta()..insert('[]'), const TextSelection.collapsed(offset: 0), ChangeSource.local)
+        ..updateSelection(const TextSelection.collapsed(offset: 1), ChangeSource.local);
       //
-      expect(pasteUsingPlainOrDelta(controller, plainSelection), true,
-          reason: 'Internal paste');
+      expect(pasteUsingPlainOrDelta(controller, plainSelection), true, reason: 'Internal paste');
       expect(controller.document.toPlainText(), '[$plainSelection]\n');
       expect(
           controller.document.toDelta(),

--- a/test/controller/korean_ime_style_test.dart
+++ b/test/controller/korean_ime_style_test.dart
@@ -1,0 +1,387 @@
+// 한국어 IME 서식 보존 테스트
+//
+// 안드로이드 폰 없이 QuillController.replaceText() 시퀀스를 직접 시뮬레이션하여
+// 한국어 IME가 보내는 DELETE/INSERT 이벤트를 재현한다.
+//
+// 테스트 시나리오 목록:
+// T1. 이전 글자(bold) 뒤에 bold OFF → 이전 글자의 bold 유지
+// T2. bold 없는 이전 글자 위치를 IME가 재삽입 → 이전 글자에 bold 미적용 (cache 분기)
+// T3. 배경색 OFF 후 새 글자에 배경색 없음
+// T4. 이전 글자의 배경색은 IME 재삽입 시 보존
+// T5. 전체 삭제 후 IME 재삽입(같은 프레임) → 서식 보존
+// T6. 전체 삭제 후 직접 삭제(다음 프레임) → 서식 초기화
+// T7. AssertionError 없음 (빈 스타일 + 빈 activeStyle)
+// T8. 엔터 후 새 글자에 배경색 없음
+
+import 'package:flutter/material.dart';
+import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // ────────────────────────────────────────────────
+  // 헬퍼
+  // ────────────────────────────────────────────────
+
+  /// position offset의 collapsed selection 반환
+  TextSelection sel(int offset) => TextSelection.collapsed(offset: offset);
+
+  /// index 위치의 인라인 스타일 반환 (단일 글자)
+  Style styleAt(QuillController c, int index) =>
+      c.document.collectStyle(index, 1);
+
+  /// index 위치의 특정 attribute 값 반환
+  dynamic attrValueAt(QuillController c, int index, Attribute attr) =>
+      styleAt(c, index).attributes[attr.key]?.value;
+
+  /// activeStyle.isNotEmpty 기준으로 retain이 적용되는 replaceText 래퍼
+  void ime(QuillController c, int index, int len, String data) {
+    c.replaceText(index, len, data, sel(index + data.length));
+  }
+
+  // ────────────────────────────────────────────────
+  // 테스트 그룹
+  // ────────────────────────────────────────────────
+
+  group('한국어 IME 서식 보존', () {
+    late QuillController c;
+
+    setUp(() {
+      c = QuillController.basic();
+    });
+
+    tearDown(() {
+      c.dispose();
+    });
+
+    // --------------------------------------------------
+    // T1. 이전 글자(bold) 뒤에 bold OFF → 이전 글자 bold 유지
+    //
+    // 재현 시나리오:
+    //   "가"(bold) 입력 → bold OFF → "나" 입력 시
+    //   IME: DELETE "가ㄴ" → INSERT "가" → INSERT "나"
+    //   기대: "가"는 bold 유지, "나"는 bold 없음
+    // --------------------------------------------------
+    test('T1: 이전 글자(bold) 뒤에 bold OFF 후 한국어 입력 → 이전 글자 bold 유지', () {
+      // "가"(bold) 삽입
+      c.formatText(0, 0, Attribute.bold);
+      ime(c, 0, 0, '가');
+      expect(attrValueAt(c, 0, Attribute.bold), isTrue,
+          reason: '초기 "가"는 bold여야 함');
+
+      // bold OFF
+      c.updateSelection(sel(1), ChangeSource.local);
+      c.formatText(1, 0, Attribute.clone(Attribute.bold, null));
+
+      // "ㄴ" INSERT (새 글자, cachedChar=null)
+      ime(c, 1, 0, 'ㄴ');
+
+      // IME: "가ㄴ" DELETE → "가" INSERT → "나" INSERT
+      ime(c, 0, 2, '');
+      ime(c, 0, 0, '가');
+      ime(c, 1, 0, '나');
+
+      expect(attrValueAt(c, 0, Attribute.bold), isTrue,
+          reason: '"가"는 bold를 유지해야 함');
+      expect(attrValueAt(c, 1, Attribute.bold), isNot(isTrue),
+          reason: '"나"는 bold가 없어야 함');
+    });
+
+    // --------------------------------------------------
+    // T2. bold 없는 글자 위치를 IME가 재삽입 → 이전 글자에 bold 미적용
+    //
+    // 재현 시나리오:
+    //   "가나"(no bold) 있음 → bold ON → "ㄷ" 입력
+    //   IME: DELETE "가나" → INSERT "가" → INSERT "낟"
+    //   기대: "가"는 bold 없음, "낟"은 cachedChar(no bold) 복원이므로 bold 없음
+    // --------------------------------------------------
+    test('T2: bold 없는 이전 글자를 IME가 재삽입할 때 bold 미적용 (캐시 분기)', () {
+      // "가나" 삽입 (bold 없음)
+      ime(c, 0, 0, '가');
+      ime(c, 1, 0, '나');
+
+      // bold ON
+      c.updateSelection(sel(2), ChangeSource.local);
+      c.formatText(2, 0, Attribute.bold);
+
+      // "ㄷ" INSERT (새 위치, cachedChar=null → bold 적용됨)
+      ime(c, 2, 0, 'ㄷ');
+
+      // IME: "가나ㄷ" DELETE (또는 일부 DELETE) → "가" INSERT → "낟" INSERT
+      // 실제 IME에 따라 두 번에 걸쳐 DELETE될 수 있으나 최종 결과만 검증
+      ime(c, 0, 3, ''); // "가나ㄷ" DELETE
+      ime(c, 0, 0, '가'); // "가" 재삽입
+      ime(c, 1, 0, '낟'); // "낟" 삽입 (나의 캐시 위치 재사용)
+
+      expect(attrValueAt(c, 0, Attribute.bold), isNot(isTrue),
+          reason: '"가"는 bold 없는 원래 스타일로 복원되어야 함');
+    });
+
+    // --------------------------------------------------
+    // T3. 배경색 OFF 후 새 글자에 배경색 없음
+    //
+    // 재현 시나리오:
+    //   "가"(background:yellow) 있음 → background OFF → "나" 입력
+    //   IME: INSERT "ㄴ" → DELETE "가ㄴ" → INSERT "가" → INSERT "나"
+    //   기대: "나"에 배경색 없음
+    // --------------------------------------------------
+    test('T3: 배경색 OFF 후 새 글자에 배경색 없음', () {
+      const bgColor = '#FFF4D03F';
+
+      // "가"(background:yellow) 삽입
+      c.formatText(0, 0, BackgroundAttribute(bgColor));
+      ime(c, 0, 0, '가');
+      expect(attrValueAt(c, 0, Attribute.background), equals(bgColor),
+          reason: '초기 "가"는 background여야 함');
+
+      // background OFF
+      c.updateSelection(sel(1), ChangeSource.local);
+      c.formatText(1, 0, BackgroundAttribute(null));
+
+      // "ㄴ" INSERT (새 위치, cachedChar=null → background:null 적용)
+      ime(c, 1, 0, 'ㄴ');
+
+      // IME: "가ㄴ" DELETE → "가" INSERT → "나" INSERT
+      ime(c, 0, 2, '');
+      ime(c, 0, 0, '가');
+      ime(c, 1, 0, '나');
+
+      expect(attrValueAt(c, 1, Attribute.background), isNull,
+          reason: '"나"에 배경색이 없어야 함');
+    });
+
+    // --------------------------------------------------
+    // T4. 이전 글자의 배경색은 IME 재삽입 시 보존
+    //
+    // 재현 시나리오:
+    //   "가"(background:yellow) 있음 → background OFF → "나" 입력
+    //   "가"의 배경색은 유지되어야 함
+    // --------------------------------------------------
+    test('T4: IME 재삽입 시 이전 글자의 배경색 보존', () {
+      const bgColor = '#FFF4D03F';
+
+      // "가"(background:yellow) 삽입
+      c.formatText(0, 0, BackgroundAttribute(bgColor));
+      ime(c, 0, 0, '가');
+
+      // background OFF
+      c.updateSelection(sel(1), ChangeSource.local);
+      c.formatText(1, 0, BackgroundAttribute(null));
+
+      // "ㄴ" INSERT
+      ime(c, 1, 0, 'ㄴ');
+
+      // IME: "가ㄴ" DELETE → "가" INSERT → "나" INSERT
+      ime(c, 0, 2, '');
+      ime(c, 0, 0, '가');
+      ime(c, 1, 0, '나');
+
+      expect(attrValueAt(c, 0, Attribute.background), equals(bgColor),
+          reason: '"가"의 배경색은 유지되어야 함');
+    });
+
+    // --------------------------------------------------
+    // T5. 전체 삭제 후 IME 재삽입(같은 프레임) → 서식 보존
+    //
+    // 재현 시나리오:
+    //   "가"(bold) 있음 → DELETE "가" → IME INSERT "가" (같은 프레임)
+    //   기대: "가"의 bold 보존, toggledStyle 초기화 안 됨
+    // --------------------------------------------------
+    test('T5: 전체 삭제 후 같은 프레임에 IME 재삽입 → 서식 보존', () {
+      // "가"(bold) 삽입
+      c.formatText(0, 0, Attribute.bold);
+      ime(c, 0, 0, '가');
+      expect(attrValueAt(c, 0, Attribute.bold), isTrue);
+
+      // 전체 삭제 → document.length = 1
+      ime(c, 0, 1, '');
+      // 같은 프레임 내 IME INSERT → _pendingStyleReset 취소
+      ime(c, 0, 0, '가');
+
+      expect(attrValueAt(c, 0, Attribute.bold), isTrue,
+          reason: '전체 삭제 후 같은 프레임 IME INSERT는 서식을 보존해야 함');
+    });
+
+    // --------------------------------------------------
+    // T6. 전체 삭제 후 직접 삭제(다음 프레임) → 서식 초기화
+    //
+    // 재현 시나리오:
+    //   "가"(bold) 있음 → DELETE "가" → 다음 프레임 (IME INSERT 없음)
+    //   기대: toggledStyle 초기화
+    // --------------------------------------------------
+    testWidgets('T6: 전체 삭제 후 다음 프레임까지 INSERT 없으면 서식 초기화',
+        (tester) async {
+      c.formatText(0, 0, Attribute.bold);
+      ime(c, 0, 0, '가');
+      expect(c.toggledStyle.attributes[Attribute.bold.key]?.value, isTrue);
+
+      // 전체 삭제 → _pendingStyleReset = true 예약
+      ime(c, 0, 1, '');
+
+      // 프레임 펌핑 → addPostFrameCallback 실행
+      await tester.pump();
+
+      // toggledStyle 초기화 확인 (bold:null 또는 비어있음)
+      final boldAttr = c.toggledStyle.attributes[Attribute.bold.key];
+      expect(boldAttr?.value, isNot(isTrue),
+          reason: '전체 삭제 후 다음 프레임에 서식이 초기화되어야 함');
+    });
+
+    // --------------------------------------------------
+    // T7. AssertionError 없음: 빈 activeStyle + 빈 indexStyle
+    //
+    // 재현 시나리오:
+    //   아무 서식 없이 한국어 IME 입력 → retainDelta가 no-op 될 수 있음
+    //   기대: document.compose에서 assertion 미발생
+    // --------------------------------------------------
+    test('T7: 빈 스타일 + 빈 activeStyle → AssertionError 없음', () {
+      // 아무 서식 없이 "가" INSERT
+      expect(() => ime(c, 0, 0, '가'), returnsNormally,
+          reason: '빈 스타일에서 INSERT 시 크래시가 없어야 함');
+
+      // 전체 삭제 후 재삽입
+      expect(() {
+        ime(c, 0, 1, '');
+        ime(c, 0, 0, '가');
+      }, returnsNormally, reason: '전체 삭제 후 재삽입 시 크래시가 없어야 함');
+    });
+
+    // --------------------------------------------------
+    // T8. 엔터 후 새 줄에 배경색 없음
+    //
+    // 재현 시나리오:
+    //   "가나다"(background:yellow) 있음 → background OFF → 엔터
+    //   → 새 줄에서 "라" 입력 → 배경색 없어야 함
+    // --------------------------------------------------
+    test('T8: 엔터 후 새 줄에 배경색 없음', () {
+      const bgColor = '#FFF4D03F';
+
+      // "가나다"(background:yellow) 삽입
+      c.formatText(0, 0, BackgroundAttribute(bgColor));
+      ime(c, 0, 0, '가');
+      ime(c, 1, 0, '나');
+      ime(c, 2, 0, '다');
+
+      // background OFF
+      c.updateSelection(sel(3), ChangeSource.local);
+      c.formatText(3, 0, BackgroundAttribute(null));
+
+      // 엔터 삽입 (data='\n', insertNewline=true)
+      c.replaceText(3, 0, '\n', sel(4));
+
+      // 새 줄에서 "라" 입력 (cachedChar=null → activeStyle의 background:null 적용)
+      ime(c, 4, 0, '라');
+
+      expect(attrValueAt(c, 4, Attribute.background), isNull,
+          reason: '엔터 후 새 줄의 글자에 배경색이 없어야 함');
+    });
+
+    // --------------------------------------------------
+    // T9. 새 글자(cachedChar=null) → activeStyle 전체 적용 (bold:true)
+    //
+    // 재현 시나리오:
+    //   bold ON → 빈 에디터에 "가" 입력
+    //   기대: "가"에 bold 적용
+    // --------------------------------------------------
+    test('T9: 새 위치(cachedChar=null)에 bold ON 후 입력 → bold 적용', () {
+      c.formatText(0, 0, Attribute.bold);
+      ime(c, 0, 0, '가');
+
+      expect(attrValueAt(c, 0, Attribute.bold), isTrue,
+          reason: '빈 위치에 bold ON 후 입력한 글자는 bold여야 함');
+    });
+
+    // --------------------------------------------------
+    // T11. 안드로이드 IME: bold 있는 첫 글자 뒤에 bold OFF 후 두 번째 글자 입력
+    //
+    // 재현 시나리오 (안드로이드):
+    //   "가"(bold) → bold OFF → "나" 입력
+    //   Android IME: composing range가 이전 글자 포함 →
+    //     replaceText(0, 1, '간')  (ㄴ 조합 중)
+    //     replaceText(0, 1, '가나') (ㄴ→나 완성)
+    //   기대: "가"는 bold 유지, "나"는 bold 없음
+    // --------------------------------------------------
+    test('T11: 안드로이드 IME - bold 첫 글자 뒤 bold OFF 후 입력 → 첫 글자 bold 유지', () {
+      // "가"(bold) 삽입
+      c.formatText(0, 0, Attribute.bold);
+      ime(c, 0, 0, '가');
+      expect(attrValueAt(c, 0, Attribute.bold), isTrue, reason: '"가" bold여야 함');
+
+      // bold OFF (커서 index=1로 이동)
+      c.updateSelection(sel(1), ChangeSource.local);
+      c.formatText(1, 0, Attribute.clone(Attribute.bold, null));
+
+      // Android IME 패턴: composing range가 이전 글자("가") 포함
+      // step1: "간" compose (replaceText(0, 1, '간'))
+      ime(c, 0, 1, '간');
+      expect(attrValueAt(c, 0, Attribute.bold), isTrue,
+          reason: 'composing 중 "간"에도 bold 유지');
+
+      // step2: "가나" compose (replaceText(0, 1, '가나'))
+      ime(c, 0, 1, '가나');
+
+      expect(attrValueAt(c, 0, Attribute.bold), isTrue,
+          reason: '"가"의 bold는 유지되어야 함');
+      expect(attrValueAt(c, 1, Attribute.bold), isNot(isTrue),
+          reason: '"나"에는 bold가 없어야 함');
+    });
+
+    // --------------------------------------------------
+    // T12. 안드로이드 IME: 배경색 있는 첫 글자 뒤에 배경색 OFF 후 두 번째 글자 입력
+    //
+    // 재현 시나리오 (안드로이드):
+    //   "가"(background) → background OFF → "나" 입력 (Android composing replace)
+    //   기대: "가"는 background 유지, "나"는 background 없음
+    // --------------------------------------------------
+    test('T12: 안드로이드 IME - 배경색 첫 글자 뒤 배경색 OFF 후 입력 → 첫 글자 배경색 유지', () {
+      const bgColor = '#FFF4D03F';
+
+      // "가"(background) 삽입
+      c.formatText(0, 0, BackgroundAttribute(bgColor));
+      ime(c, 0, 0, '가');
+      expect(attrValueAt(c, 0, Attribute.background), equals(bgColor));
+
+      // background OFF
+      c.updateSelection(sel(1), ChangeSource.local);
+      c.formatText(1, 0, BackgroundAttribute(null));
+
+      // Android IME 패턴
+      ime(c, 0, 1, '간');
+      ime(c, 0, 1, '가나');
+
+      expect(attrValueAt(c, 0, Attribute.background), equals(bgColor),
+          reason: '"가"의 배경색은 유지되어야 함');
+      expect(attrValueAt(c, 1, Attribute.background), isNull,
+          reason: '"나"에는 배경색이 없어야 함');
+    });
+
+    // --------------------------------------------------
+    // T10. color 없는 상황에서 bold ON 후 IME 입력 → 이전 글자 bold 미오염
+    //
+    // 색상이 없을 때(cachedChar={}) 도 bold 오염 방지 검증
+    // --------------------------------------------------
+    test('T10: 색상 없는 이전 글자에 bold ON이 전파되지 않음', () {
+      // "가" 삽입 (no color, no bold)
+      ime(c, 0, 0, '가');
+      expect(attrValueAt(c, 0, Attribute.bold), isNot(isTrue));
+
+      // bold ON
+      c.updateSelection(sel(1), ChangeSource.local);
+      c.formatText(1, 0, Attribute.bold);
+
+      // "ㄴ" INSERT at 1 (새 위치, bold 적용)
+      ime(c, 1, 0, 'ㄴ');
+
+      // IME: "가ㄴ" DELETE → "가" INSERT → "나" INSERT
+      ime(c, 0, 2, '');
+      ime(c, 0, 0, '가'); // 캐시: "가"의 스타일 = {} (no bold)
+      ime(c, 1, 0, '나'); // 캐시: "ㄴ"의 스타일 = {bold:true}
+
+      // "가"는 bold 없음 (cachedChar={} → bold:null 적용)
+      expect(attrValueAt(c, 0, Attribute.bold), isNot(isTrue),
+          reason: '색상 없는 이전 글자("가")에 bold가 전파되면 안 됨');
+      // "나"는 원래 "ㄴ"의 bold:true 복원
+      expect(attrValueAt(c, 1, Attribute.bold), isTrue,
+          reason: '원래 bold로 입력된 "ㄴ"이 "나"가 될 때 bold 유지');
+    });
+  });
+}


### PR DESCRIPTION
fix: preserve inline styles during Korean/Android IME composing