### PR TITLE
feat: add onFocusReceived implementation for Flutter 3.44 compatibility

### DIFF
--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -382,6 +382,9 @@ mixin RawEditorStateTextInputClientMixin on EditorState
     _lastKnownRemoteTextEditingValue = null;
   }
 
+  @override
+  bool onFocusReceived() => false;
+
   void _updateSizeAndTransform() {
     if (hasConnection) {
       // Asking for renderEditor.size here can cause errors if layout hasn't


### PR DESCRIPTION
Implements the new TextInputClient.onFocusReceived method required by Flutter SDK 3.44+. Returns false as the editor handles focus internally.

> [!NOTE]
> Added by @EchoEllet:
> This PR [seems to be AI-assisted](https://patch-diff.githubusercontent.com/raw/singerdmx/flutter-quill/pull/2726.patch).

## Related issues

- Fixes #2732

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [X] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
