### PR TITLE
Search bar: whole-word seach fixed for Unicode, search dialog style improved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added localization support for `mn` (Mongolian, Mongolia)
 
+### Changed
+
+- Search dialog buttons now adopt the toolbar's `QuillIconTheme`; bar height and spacing tightened.
+
+### Fixed
+
+- Whole-word search now matches non-ASCII text (Cyrillic, CJK, accented Latin).
+
 ## [11.5.0] - 2025-10-18
 
 ### Fixed

--- a/lib/src/document/document.dart
+++ b/lib/src/document/document.dart
@@ -362,10 +362,13 @@ class Document {
     var index = -1;
     final lineText = line.toPlainText();
     var pattern = RegExp.escape(substring);
+    // Dart's `\b`/`\w` are ASCII-only. Use Unicode-aware lookarounds instead.
     if (wholeWord) {
-      pattern = r'\b' + pattern + r'\b';
+      pattern =
+          r'(?<![\p{L}\p{N}\p{M}_])' + pattern + r'(?![\p{L}\p{N}\p{M}_])';
     }
-    final searchExpression = RegExp(pattern, caseSensitive: caseSensitive);
+    final searchExpression =
+        RegExp(pattern, caseSensitive: caseSensitive, unicode: true);
     while (true) {
       index = lineText.indexOf(searchExpression, index + 1);
       if (index < 0) {

--- a/lib/src/toolbar/buttons/search/search_button.dart
+++ b/lib/src/toolbar/buttons/search/search_button.dart
@@ -35,6 +35,8 @@ class QuillToolbarSearchButton extends QuillToolbarBaseButtonStateless {
         controller: controller,
         dialogTheme: options?.dialogTheme,
         searchBarAlignment: options?.searchBarAlignment,
+        size: iconSize(context) * iconButtonFactor(context),
+        iconTheme: iconTheme(context),
       ),
     );
   }

--- a/lib/src/toolbar/buttons/search/search_dialog.dart
+++ b/lib/src/toolbar/buttons/search/search_dialog.dart
@@ -7,7 +7,9 @@ import '../../../controller/quill_controller.dart';
 import '../../../document/document.dart';
 import '../../../document/nodes/leaf.dart';
 import '../../../l10n/extensions/localizations_ext.dart';
+import '../../simple_toolbar.dart';
 import '../../theme/quill_dialog_theme.dart';
+import '../../theme/quill_icon_theme.dart';
 
 @immutable
 class QuillToolbarSearchDialogChildBuilderExtraOptions {
@@ -48,6 +50,8 @@ class QuillToolbarSearchDialog extends StatefulWidget {
     this.text,
     this.childBuilder,
     this.searchBarAlignment,
+    this.size,
+    this.iconTheme,
     super.key,
   });
 
@@ -56,6 +60,8 @@ class QuillToolbarSearchDialog extends StatefulWidget {
   final String? text;
   final QuillToolbarSearchDialogChildBuilder? childBuilder;
   final AlignmentGeometry? searchBarAlignment;
+  final double? size;
+  final QuillIconTheme? iconTheme;
 
   @override
   QuillToolbarSearchDialogState createState() =>
@@ -112,7 +118,7 @@ class QuillToolbarSearchDialogState extends State<QuillToolbarSearchDialog> {
         (searchBarAlignment == Alignment.bottomLeft) ||
         (searchBarAlignment == Alignment.bottomRight);
     final addBottomPadding = searchBarAtBottom && isMobile;
-    var matchShown = '';
+    String? matchShown;
     if (_text.isNotEmpty) {
       if (_offsets.isEmpty) {
         matchShown = '0/0';
@@ -121,29 +127,65 @@ class QuillToolbarSearchDialogState extends State<QuillToolbarSearchDialog> {
       }
     }
 
+    const buttonBox = BoxConstraints.tightFor(width: 40, height: 40);
+    const buttonStyle = ButtonStyle(
+      shape: WidgetStatePropertyAll<OutlinedBorder?>(CircleBorder()),
+    );
+    final iconTheme = widget.iconTheme?.copyWith(
+          iconButtonUnselectedData: const IconButtonData(
+            visualDensity: VisualDensity.compact,
+            constraints: buttonBox,
+            style: buttonStyle,
+          ),
+          iconButtonSelectedData: const IconButtonData(
+            visualDensity: VisualDensity.compact,
+            constraints: buttonBox,
+            style: buttonStyle,
+          ),
+        ) ??
+        const QuillIconTheme(
+          iconButtonUnselectedData: IconButtonData(
+            visualDensity: VisualDensity.compact,
+            constraints: buttonBox,
+            style: buttonStyle,
+          ),
+          iconButtonSelectedData: IconButtonData(
+            visualDensity: VisualDensity.compact,
+            constraints: buttonBox,
+            style: buttonStyle,
+          ),
+        );
+
     final searchBar = Container(
-      height: addBottomPadding ? 50 : 45,
+      height: addBottomPadding ? 52 : 40,
       padding: addBottomPadding ? const EdgeInsets.only(bottom: 12) : null,
       child: Row(
         children: [
-          IconButton(
-            icon: const Icon(Icons.close),
+          QuillToolbarIconButton(
             tooltip: context.loc.close,
-            visualDensity: VisualDensity.compact,
+            icon: Icon(
+              Icons.close,
+              size: widget.size,
+            ),
+            isSelected: false,
             onPressed: () {
               Navigator.of(context).pop();
             },
+            iconTheme: iconTheme,
           ),
-          IconButton(
-            icon: const Icon(Icons.more_vert),
-            isSelected: _caseSensitive || _wholeWord,
+          QuillToolbarIconButton(
             tooltip: context.loc.searchSettings,
-            visualDensity: VisualDensity.compact,
+            icon: Icon(
+              Icons.more_vert,
+              size: widget.size,
+            ),
+            isSelected: _caseSensitive || _wholeWord,
             onPressed: () {
               setState(() {
                 _searchSettingsUnfolded = !_searchSettingsUnfolded;
               });
             },
+            iconTheme: iconTheme,
           ),
           Expanded(
             child: TextField(
@@ -152,6 +194,7 @@ class QuillToolbarSearchDialogState extends State<QuillToolbarSearchDialog> {
                 isDense: true,
                 suffixText: matchShown,
                 suffixStyle: widget.dialogTheme?.labelTextStyle,
+                contentPadding: const EdgeInsets.symmetric(horizontal: 4),
               ),
               autofocus: true,
               onChanged: _textChanged,
@@ -160,22 +203,32 @@ class QuillToolbarSearchDialogState extends State<QuillToolbarSearchDialog> {
               controller: _textController,
             ),
           ),
-          IconButton(
-            icon: const Icon(Icons.keyboard_arrow_up),
+          QuillToolbarIconButton(
             tooltip: context.loc.moveToPreviousOccurrence,
+            icon: Icon(
+              Icons.keyboard_arrow_up,
+              size: widget.size,
+            ),
+            isSelected: false,
             onPressed: (_offsets.isNotEmpty) ? _moveToPrevious : null,
+            iconTheme: iconTheme,
           ),
-          IconButton(
-            icon: const Icon(Icons.keyboard_arrow_down),
+          QuillToolbarIconButton(
             tooltip: context.loc.moveToNextOccurrence,
+            icon: Icon(
+              Icons.keyboard_arrow_down,
+              size: widget.size,
+            ),
+            isSelected: false,
             onPressed: (_offsets.isNotEmpty) ? _moveToNext : null,
+            iconTheme: iconTheme,
           ),
         ],
       ),
     );
 
     final searchSettings = SizedBox(
-      height: 45,
+      height: 40,
       child: Row(
         children: [
           Expanded(


### PR DESCRIPTION
## Description

1. **Unicode-aware whole-word search.** Dart's `\b`/`\w` are ASCII-only,
   so toggling "whole word" produced no matches for non-ASCII text
   (Cyrillic, CJK, accented Latin, etc.). The pattern now uses Unicode
   property escapes `[\p{L}\p{N}\p{M}_]` in lookarounds with
   `unicode: true` on the `RegExp`.

2. **Search bar restyled to match the toolbar better** The dialog's
   close / settings / prev / next buttons now use
   `QuillToolbarIconButton` and inherit the toolbar's `QuillIconTheme`
   (size, colors, hover/selected styling). Heights tightened, buttons get a circular shape and compact visual density, etc.

## Type of Change

- [x] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
