### PR TITLE
fix: make _selectedRects growable to avoid 'Cannot add to a fixed-length list'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `UnsupportedError: Cannot add to a fixed-length list` thrown during `paint()` in `RenderEditableTextLine` when a selection contains an empty line. `_selectedRects` is now a growable list.
+
 ## [11.5.1] - 2026-05-20
 
 ### Added

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -1419,9 +1419,14 @@ class RenderEditableTextLine extends RenderEditableBox {
           line.documentOffset <= textSelection.end &&
           textSelection.start <= line.documentOffset + line.length - 1) {
         final local = localSelection(line, textSelection, false);
-        _selectedRects ??= _body!.getBoxesForSelection(
-          local,
-        );
+        // `getBoxesForSelection` may return a fixed-length/unmodifiable list.
+        // We append to `_selectedRects` below for empty lines, so it must be
+        // growable, otherwise `.add` throws `Cannot add to a fixed-length list`.
+        _selectedRects ??= _body!
+            .getBoxesForSelection(
+              local,
+            )
+            .toList();
 
         // Paint a small rect at the start of empty lines that
         // are contained by the selection.


### PR DESCRIPTION
## Description

`RenderEditableTextLine.paint` appends a `TextBox` to `_selectedRects` when a selection contains an **empty line**:

https://github.com/singerdmx/flutter-quill/blob/master/lib/src/editor/widgets/text/text_line.dart#L1436

`_selectedRects` is assigned from `RenderBox.getBoxesForSelection(...)`, which can return a **fixed-length / unmodifiable** list. The subsequent `.add(...)` then throws:

```
UnsupportedError: Unsupported operation: Cannot add to a fixed-length list
  at FixedLengthListMixin.add (list.dart)
  at RenderEditableTextLine.paint (text_line.dart:1436)
```

This is a `thrown during paint()` crash, so it takes down the frame. We observed it in production (Flutter 3.41.2 / Dart 3.11, both Android and iOS) on a screen with a Quill editor. Repro: place the caret selection so that it spans an empty line within the document.

## Fix

Convert the result of `getBoxesForSelection(...)` to a growable list with `.toList()` before any `.add(...)`. One-line change; no behavioral difference other than the list now being mutable as the code already assumes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)