### PR TITLE
fix: guard focus/keyboard callbacks with mounted checks in QuillRawEditorState

### DIFF
--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -1090,10 +1090,13 @@ class QuillRawEditorState extends EditorState
   }
 
   void _handleFocusChanged() {
+    if (!mounted) return;
     if (dirty) {
       requestKeyboard();
-      SchedulerBinding.instance
-          .addPostFrameCallback((_) => _handleFocusChanged());
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _handleFocusChanged();
+      });
       return;
     }
     openOrCloseConnection();
@@ -1185,6 +1188,7 @@ class QuillRawEditorState extends EditorState
   /// keyboard become visible.
   @override
   void requestKeyboard() {
+    if (!mounted) return;
     if (controller.skipRequestKeyboard) {
       controller.skipRequestKeyboard = false;
       return;

--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -71,6 +71,7 @@ mixin RawEditorStateTextInputClientMixin on EditorState
       Theme.of(context).brightness;
 
   void openConnectionIfNeeded() {
+    if (!mounted) return;
     if (!shouldCreateInputConnection) {
       return;
     }


### PR DESCRIPTION
<!-- 
Briefly describe your changes and summarize in the title.
Contributor Guide: https://github.com/singerdmx/flutter-quill/blob/master/CONTRIBUTING.md
Package versioning is automated.
Add updates to `Unreleased` in `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
-->

## Description

Fixes a lifecycle race where `_handleFocusChanged` schedules post-frame work that can run after `QuillRawEditorState` is disposed, causing a crash when `createKeyboardAppearance()` accesses `context`.

### Problem
When the render object is dirty, `_handleFocusChanged`:
1. Calls `requestKeyboard()` immediately
2. Schedules another `_handleFocusChanged()` via `addPostFrameCallback`
If the editor is unmounted between scheduling and execution (e.g. parent widget structure changes during async UI updates), the callback throws:

## Related Issues
Related #2737 

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
