### PR TITLE
Fix: a visual bug where bullet point spacing chagnes when toggling line-level directionality.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue where bullet points became visually detached from the text body when toggling text direction formatting (RTL) by locking the list leading block to the editor's base text direction.
+
 ### Removed
 
 - Removed the already-`@Deprecated` and `@internal` `linkPrefixes` constant from the public API surface (it is hidden from the `flutter_quill.dart` export). Use `LinkValidator.linkPrefixes` instead.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -107,6 +107,7 @@ class _HomePageState extends State<HomePage> {
               config: QuillSimpleToolbarConfig(
                 embedButtons: FlutterQuillEmbeds.toolbarButtons(),
                 showClipboardPaste: true,
+                showDirection: true,
                 customButtons: [
                   QuillToolbarCustomButtonOptions(
                     icon: const Icon(Icons.add_alarm_rounded),

--- a/lib/src/editor/widgets/text/text_block.dart
+++ b/lib/src/editor/widgets/text/text_block.dart
@@ -177,15 +177,18 @@ class EditableTextBlock extends StatelessWidget {
     var index = 0;
     for (final line in Iterable.castFrom<dynamic, Line>(block.children)) {
       index++;
+      final leading = _buildLeading(
+        context: context,
+        line: line,
+        index: index,
+        indentLevelCounts: indentLevelCounts,
+        count: count,
+      );
       final editableTextLine = EditableTextLine(
         line,
-        _buildLeading(
-          context: context,
-          line: line,
-          index: index,
-          indentLevelCounts: indentLevelCounts,
-          count: count,
-        ),
+        leading != null
+            ? Directionality(textDirection: textDirection, child: leading)
+            : null,
         TextLine(
           line: line,
           textDirection: textDirection,


### PR DESCRIPTION
## Description

Fixes a visual bug where bullet point spacing chagnes when toggling line-level directionality.

**The Problem:**
In a standard LTR editor, when a line in an unordered list is toggled to RTL format, the visual space between the bullet point (`•`) and the actual text dramatically inflates.

**The Solution:**
Wrap `Directionality` around the layout's `leading` widget.

**Before the fix:**

<img width="362" height="135" alt="Screenshot 2026-06-20 at 07 59 48" src="https://github.com/user-attachments/assets/3b99afb3-e9c2-4607-bd4f-78cec4442ce3" />

**After the fix:**

<img width="362" height="135" alt="Screenshot 2026-06-20 at 07 57 39" src="https://github.com/user-attachments/assets/60bc4b0e-0a9b-4417-a557-70a51cb47703" />

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
