### PR TITLE
fix(android): sync IME selection so typing follows the tapped caret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed an issue where bullet points became visually detached from the text body when toggling text direction formatting (RTL) by locking the list leading block to the editor's base text direction.
+- Fixed typed text being inserted at the previous caret position on Android after moving the caret with a tap/mouse by keeping the platform IME's editing state in sync with the selection even when the keyboard is hidden.
 
 ### Removed
 

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -1041,6 +1041,12 @@ class QuillRawEditorState extends EditorState
       _onChangeTextEditingValue(ignoreFocus);
     } else {
       requestKeyboard();
+      // Keep the platform IME's editing state (selection) in sync even when the
+      // soft keyboard is not (yet) visible — e.g. Android with a hardware
+      // keyboard. Without this, after moving the caret with a tap/mouse the IME
+      // keeps its stale cursor position and inserts typed text there.
+      // Does nothing if no input connection is open.
+      updateRemoteValueIfNeeded();
       if (mounted) {
         // Use controller.value in build()
         // Mark widget as dirty and trigger build and updateChildren


### PR DESCRIPTION
## Description

Fixes an Android-only bug where typing inserted text at the **previous** caret
position after the caret was moved with a tap/mouse.

### Issue

Open the editor → tap a different spot (caret visibly moves there) → type → text lands at the **original** position, not the
tapped one. Android only.

Reproduces with both the soft keyboard and a hardware keyboard, and only when the caret is moved by **tap/mouse** — moving it with the keyboard (arrow keys) works.

### Root cause

The tapped selection is applied framework-side (`controller.updateSelection`) but never pushed to the platform IME. `_didChangeTextEditingValue` calls `updateRemoteValueIfNeeded()` only when `ignoreFocus || _keyboardVisible`. On
Android `_keyboardVisible` is `false` while the soft keyboard is hidden (always the case with a hardware keyboard), so after a tap the IME keeps its stale cursor and inserts there.

The issue surfaced after the Flutter 3.44 migration, whose Android text-input behavior no longer compensates for the missing `setEditingState` after a programmatic/tap selection change.

### Fix

Call `updateRemoteValueIfNeeded()` in the keyboard-hidden branch as well.

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
