### PR TITLE
fix: prevent toolbar flicker when tapping a checklist checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed an issue where bullet points became visually detached from the text body when toggling text direction formatting (RTL) by locking the list leading block to the editor's base text direction.
+- Fixed a brief toolbar flicker when tapping a checkbox: the header, inline, and color buttons momentarily reflected the tapped line's style and the checklist button briefly toggled before the selection was restored. The checkbox tap's gesture-driven caret move is now ignored and the checkbox is formatted silently.
+
+### Deprecated
+
+- Deprecated `QuillController.toolbarButtonToggler`. It was an internal-only workaround for syncing a few toolbar block buttons during checkbox taps and no longer has any effect now that the flicker is fixed at its source. Toolbar button state derives from `getSelectionStyle()`. It will be removed in future versions.
 
 ### Removed
 

--- a/lib/src/controller/quill_controller.dart
+++ b/lib/src/controller/quill_controller.dart
@@ -500,7 +500,12 @@ class QuillController extends ChangeNotifier {
     return document.querySegmentLeafNode(offset).leaf;
   }
 
-  // Notify toolbar buttons directly with attributes
+  @Deprecated(
+    'No longer used and will be silently ignored. '
+    'Toolbar button state now derives from getSelectionStyle(). '
+    'Will be removed in future versions',
+  )
+  @internal
   Map<String, Attribute> toolbarButtonToggler = const {};
 
   /// Clipboard caches last copy to allow paste with styles. Static to allow paste between multiple instances of editor.

--- a/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcut_actions.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcut_actions.dart
@@ -693,16 +693,9 @@ class QuillEditorApplyCheckListAction
   final QuillRawEditorState state;
 
   bool _getIsToggled() {
-    final attrs = state.controller.getSelectionStyle().attributes;
-    var attribute = state.controller.toolbarButtonToggler[Attribute.list.key];
-
-    if (attribute == null) {
-      attribute = attrs[Attribute.list.key];
-    } else {
-      // checkbox tapping causes controller.selection to go to offset 0
-      state.controller.toolbarButtonToggler.remove(Attribute.list.key);
-    }
-
+    final attribute = state.controller
+        .getSelectionStyle()
+        .attributes[Attribute.list.key];
     if (attribute == null) {
       return false;
     }

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -513,6 +513,11 @@ class QuillRawEditorState extends EditorState
     TextSelection selection,
     SelectionChangedCause cause,
   ) {
+    // Swallow the caret placement caused by tapping a checkbox (see _handleCheckboxTap).
+    if (_ignoreCheckboxTapSelectionChange) {
+      _ignoreCheckboxTapSelectionChange = false;
+      return;
+    }
     final oldSelection = controller.selection;
     controller.updateSelection(selection, ChangeSource.local);
 
@@ -549,20 +554,25 @@ class QuillRawEditorState extends EditorState
       final currentSelection = controller.selection.copyWith();
       final attribute = value ? Attribute.checked : Attribute.unchecked;
 
+      // The same tap also fires the editor's selection gesture (onSingleTapUp), which
+      // would move the caret to this line. Ignore that gesture-driven change so the
+      // caret stays put and the toolbar doesn't flicker to this line's style.
+      _ignoreCheckboxTapSelectionChange = true;
+
       _markNeedsBuild();
       controller
         ..ignoreFocusOnTextChange = true
         ..skipRequestKeyboard = !requestKeyboardFocusOnCheckListChanged
-        ..formatText(offset, 0, attribute)
-        // Checkbox tapping causes controller.selection to go to offset 0
-        // Stop toggling those two toolbar buttons
-        ..toolbarButtonToggler = {
-          Attribute.list.key: attribute,
-          Attribute.header.key: Attribute.header,
-        };
+        // Format silently: formatText() stages the checked/unchecked attribute into
+        // toggledStyle, which getSelectionStyle() merges — notifying now would briefly
+        // light up the checklist toolbar button. The post-frame updateSelection below
+        // resets toggledStyle and notifies once with the clean state.
+        ..formatText(offset, 0, attribute, shouldNotifyListeners: false);
 
-      // Go back from offset 0 to current selection
       SchedulerBinding.instance.addPostFrameCallback((_) {
+        // Fallback: clear the guard (in case the gesture never fired) and restore the
+        // selection in case it moved despite it.
+        _ignoreCheckboxTapSelectionChange = false;
         controller
           ..ignoreFocusOnTextChange = false
           ..skipRequestKeyboard = !requestKeyboardFocusOnCheckListChanged
@@ -1155,6 +1165,12 @@ class QuillRawEditorState extends EditorState
   // block of the same style
   // This causes controller.selection to go to offset 0
   bool _disableScrollControllerAnimateOnce = false;
+
+  // Tapping a checkbox also triggers the editor's tap gesture (onSingleTapUp), which
+  // would move the caret to the tapped line and make the toolbar briefly reflect that
+  // line's style. This flag lets _handleSelectionChanged ignore that one gesture-driven
+  // selection change so the caret — and the toolbar — stay put.
+  bool _ignoreCheckboxTapSelectionChange = false;
 
   void _showCaretOnScreen() {
     if (!widget.config.showCursor || _showCaretOnScreenScheduled) {

--- a/lib/src/toolbar/buttons/hearder_style/select_header_style_buttons.dart
+++ b/lib/src/toolbar/buttons/hearder_style/select_header_style_buttons.dart
@@ -144,12 +144,6 @@ class QuillToolbarSelectHeaderStyleButtonsState
   }
 
   Attribute<dynamic> _getHeaderValue() {
-    final attr = controller.toolbarButtonToggler[Attribute.header.key];
-    if (attr != null) {
-      // checkbox tapping causes controller.selection to go to offset 0
-      controller.toolbarButtonToggler.remove(Attribute.header.key);
-      return attr;
-    }
     return _selectionStyle.attributes[Attribute.header.key] ?? Attribute.header;
   }
 

--- a/lib/src/toolbar/buttons/hearder_style/select_header_style_dropdown_button.dart
+++ b/lib/src/toolbar/buttons/hearder_style/select_header_style_dropdown_button.dart
@@ -86,12 +86,6 @@ class _QuillToolbarSelectHeaderStyleDropdownButtonState
   }
 
   Attribute<dynamic> _getHeaderValue() {
-    final attr = widget.controller.toolbarButtonToggler[Attribute.header.key];
-    if (attr != null) {
-      // checkbox tapping causes controller.selection to go to offset 0
-      widget.controller.toolbarButtonToggler.remove(Attribute.header.key);
-      return attr;
-    }
     return widget.controller
             .getSelectionStyle()
             .attributes[Attribute.header.key] ??

--- a/lib/src/toolbar/buttons/select_line_height_dropdown_button.dart
+++ b/lib/src/toolbar/buttons/select_line_height_dropdown_button.dart
@@ -87,12 +87,6 @@ class _QuillToolbarSelectLineHeightStyleDropdownButtonState
   }
 
   Attribute<dynamic> _getLineHeightValue() {
-    final attr =
-        widget.controller.toolbarButtonToggler[Attribute.lineHeight.key];
-    if (attr != null) {
-      widget.controller.toolbarButtonToggler.remove(Attribute.lineHeight.key);
-      return attr;
-    }
     return widget.controller
             .getSelectionStyle()
             .attributes[Attribute.lineHeight.key] ??

--- a/lib/src/toolbar/buttons/toggle_check_list_button.dart
+++ b/lib/src/toolbar/buttons/toggle_check_list_button.dart
@@ -43,15 +43,7 @@ class QuillToolbarToggleCheckListButtonState
   bool get currentStateValue => _getIsToggled(_selectionStyle.attributes);
 
   bool _getIsToggled(Map<String, Attribute> attrs) {
-    var attribute = controller.toolbarButtonToggler[Attribute.list.key];
-
-    if (attribute == null) {
-      attribute = attrs[Attribute.list.key];
-    } else {
-      // checkbox tapping causes controller.selection to go to offset 0
-      controller.toolbarButtonToggler.remove(Attribute.list.key);
-    }
-
+    final attribute = attrs[Attribute.list.key];
     if (attribute == null) {
       return false;
     }


### PR DESCRIPTION
## Description

Fixes a brief toolbar flicker when tapping a checklist checkbox, and retires the internal `QuillController.toolbarButtonToggler` workaround by deprecating it rather than removing it.

**Current behavior:** Tapping a checklist checkbox also fires the editor's tap gesture (`onSingleTapUp → selectPosition`), which moves the caret to the tapped line for one frame. The toolbar briefly reflects that line's style — the header, inline, and color buttons flicker — before `_handleCheckboxTap`'s post-frame restore puts the selection back. The checklist button additionally flashes because `formatText` stages the checked/unchecked attribute into `toggledStyle`, which `getSelectionStyle()` merges.

**New behavior:** The gesture-driven selection change from the checkbox tap is ignored (`_ignoreCheckboxTapSelectionChange`), so the caret — and the toolbar — stay put. The checkbox is formatted silently (`shouldNotifyListeners: false`) so the staged `toggledStyle` doesn't momentarily light up the checklist button; the
existing post-frame `updateSelection` emits a single clean notification.

This removes the need for the old `toolbarButtonToggler` workaround, so its consumers (header buttons/dropdown, checklist button, line-height dropdown) are removed.
The field itself is public but undocumented and internal-only; instead of hard-removing it (a breaking change in a minor release), it's kept as a `@Deprecated`, `@internal` no-op and scheduled for removal in a future version.

## Type of Change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [ ] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [x] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
