### PR TITLE
fix: fall back to caret offset when a text line yields no glyph boxes (selection endpoints & line boundary)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a crash (assert in debug, fatal `RangeError` in release) when painting selection endpoints for a selection edge that produces no glyph boxes, e.g. an offset inside an emoji grapheme cluster [#2751](https://github.com/singerdmx/flutter-quill/pull/2751).
+- Fixed a fatal `Bad state: No element` crash in `getLineBoundary` when resolving the line boundary of an empty line (e.g. line-boundary navigation with Home/End/Shift+Home on a hardware keyboard), which produced no glyph boxes; falls back to the caret position [#2751](https://github.com/singerdmx/flutter-quill/pull/2751).
 - Fixed an issue where bullet points became visually detached from the text body when toggling text direction formatting (RTL) by locking the list leading block to the editor's base text direction.
 - Fixed typed text being inserted at the previous caret position on Android after moving the caret with a tap/mouse by keeping the platform IME's editing state in sync with the selection even when the keyboard is hidden.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a crash (assert in debug, fatal `RangeError` in release) when painting selection endpoints for a selection edge that produces no glyph boxes, e.g. an offset inside an emoji grapheme cluster [#2751](https://github.com/singerdmx/flutter-quill/pull/2751).
 - Fixed an issue where bullet points became visually detached from the text body when toggling text direction formatting (RTL) by locking the list leading block to the editor's base text direction.
 - Fixed typed text being inserted at the previous caret position on Android after moving the caret with a tap/mouse by keeping the platform IME's editing state in sync with the selection even when the keyboard is hidden.
 

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -1084,7 +1084,17 @@ class RenderEditableTextLine extends RenderEditableBox {
       );
     }
     final boxes = _getBoxes(textSelection);
-    assert(boxes.isNotEmpty);
+    if (boxes.isEmpty) {
+      // A selection edge can land on a position that produces no glyph
+      // boxes, e.g. inside a grapheme cluster such as an emoji. Fall back to
+      // the caret offset for that edge instead of crashing on boxes.first /
+      // boxes.last while painting the selection.
+      final edge = first ? textSelection.base : textSelection.extent;
+      return TextSelectionPoint(
+        Offset(0, preferredLineHeight(edge)) + getOffsetForCaret(edge),
+        null,
+      );
+    }
     final targetBox = first ? boxes.first : boxes.last;
     return TextSelectionPoint(
       Offset(first ? targetBox.start : targetBox.end, targetBox.bottom),

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -1111,6 +1111,15 @@ class RenderEditableTextLine extends RenderEditableBox {
         _getBoxes(TextSelection(baseOffset: 0, extentOffset: line.length - 1))
             .where((element) => element.top < lineDy && element.bottom > lineDy)
             .toList(growable: false);
+    if (lineBoxes.isEmpty) {
+      // An empty line (Line.length == 1, so the [0, line.length - 1] == [0, 0]
+      // box selection is collapsed and yields no glyph boxes) has no boxes to
+      // derive left/right edges from. Fall back to the caret position so
+      // line-boundary navigation (e.g. Home/End/Shift+Home on a hardware
+      // keyboard) collapses to the caret instead of crashing on
+      // lineBoxes.first / lineBoxes.last.
+      return TextRange(start: position.offset, end: position.offset);
+    }
     return TextRange(
       start: getPositionForOffset(Offset(lineBoxes.first.left, lineDy)).offset,
       end: getPositionForOffset(Offset(lineBoxes.last.right, lineDy)).offset,

--- a/test/bug_fix_test.dart
+++ b/test/bug_fix_test.dart
@@ -242,4 +242,32 @@ void main() {
       );
     },
   );
+  group('selection endpoint crash when getBoxesForSelection is empty', () {
+    testWidgets(
+      'getEndpointsForSelection falls back to the caret offset when a '
+      'selection edge produces no glyph boxes',
+      (tester) async {
+        final controller = QuillController.basic()
+          ..document.insert(0, '\u{1F44D} thumbs up');
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(
+          QuillTestApp.withScaffold(QuillEditor.basic(controller: controller)),
+        );
+        await tester.pumpAndSettle();
+
+        final renderEditor = tester.allRenderObjects
+            .whereType<RenderEditor>()
+            .first;
+
+        // A selection edge inside the emoji's surrogate pair yields no glyph
+        // boxes from getBoxesForSelection; this used to crash on boxes.last
+        // (release) or fail an assert (debug) while painting the selection.
+        final endpoints = renderEditor.getEndpointsForSelection(
+          const TextSelection(baseOffset: 0, extentOffset: 1),
+        );
+        expect(endpoints, hasLength(2));
+      },
+    );
+  });
 }

--- a/test/bug_fix_test.dart
+++ b/test/bug_fix_test.dart
@@ -270,4 +270,36 @@ void main() {
       },
     );
   });
+  group('line boundary crash when a line has no glyph boxes', () {
+    testWidgets(
+      'getLineAtOffset falls back to the caret offset on an empty line '
+      'instead of crashing on lineBoxes.first/last',
+      (tester) async {
+        // An empty first paragraph: the caret at offset 0 sits on a line whose
+        // [0, line.length - 1] == [0, 0] box selection is collapsed and yields
+        // no glyph boxes.
+        final controller = QuillController.basic()
+          ..document.insert(0, '\nsecond line');
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(
+          QuillTestApp.withScaffold(QuillEditor.basic(controller: controller)),
+        );
+        await tester.pumpAndSettle();
+
+        final renderEditor = tester.allRenderObjects
+            .whereType<RenderEditor>()
+            .first;
+
+        // Line-boundary navigation (Home/End/Shift+Home on a hardware
+        // keyboard) resolves the line at the caret; on the empty line this
+        // used to throw 'Bad state: No element' from lineBoxes.first.
+        final line = renderEditor.getLineAtOffset(
+          const TextPosition(offset: 0),
+        );
+        expect(line.baseOffset, 0);
+        expect(line.extentOffset, 0);
+      },
+    );
+  });
 }


### PR DESCRIPTION
This PR contains two closely-related crash fixes in `text_line.dart`. Both stem from the same root cause — code that reads glyph-box geometry and assumes `getBoxesForSelection` returns at least one box — and both apply the same remedy: fall back to the caret offset when there are no boxes.

## Fix 1 — selection endpoints (`_getEndpointForSelection`)

`RenderEditableTextLine._getEndpointForSelection` assumes `getBoxesForSelection` always returns at least one box for a non-collapsed selection:

```dart
final boxes = _getBoxes(textSelection);
assert(boxes.isNotEmpty);
final targetBox = first ? boxes.first : boxes.last;
```

That assumption doesn't hold when a selection edge lands on a position that produces no glyph boxes — for example an offset inside a grapheme cluster (emoji surrogate pair). When that happens, `boxes.first`/`boxes.last` throws during `RenderEditor.paint` → `getEndpointsForSelection`: an assert failure in debug and a fatal `RangeError` in release.

Production crash (Crashlytics, flutter_quill 11.5.1, iOS):

```
Fatal Exception: FlutterError
0  _Array.last (dart:core)
1  RenderEditableTextLine._getEndpointForSelection (text_line.dart)
2  RenderEditableTextLine.getExtentEndpointForSelection (text_line.dart)
3  RenderEditor.getEndpointsForSelection (editor.dart)
4  RenderEditor.paint (editor.dart)
```

**Fix:** when `boxes` is empty, fall back to the caret offset for that selection edge — the same geometry the method already uses for collapsed selections — instead of throwing.

## Fix 2 — line boundary (`getLineBoundary`)

`getLineBoundary` derives the line's left/right edges from `lineBoxes.first` / `lineBoxes.last`. An empty line (`Line.length == 1`) makes the `[0, line.length - 1]` == `[0, 0]` box selection collapsed, so `getBoxesForSelection` returns no boxes and `lineBoxes` ends up empty. It then threw `Bad state: No element` during line-boundary navigation (Home / End / Shift+Home on a hardware keyboard) with the caret on an empty line.

**Fix:** mirror the empty-boxes guard from Fix 1 — when `lineBoxes` is empty, fall back to the caret position (`TextRange(start: position.offset, end: position.offset)`) instead of reading `.first` / `.last`.

## Tests

Added regression tests to `test/bug_fix_test.dart`:
- Fix 1 drives `RenderEditor.getEndpointsForSelection` with a selection edge inside an emoji surrogate pair — fails the `boxes.isNotEmpty` assert without the fix, passes with it.
- Fix 2 drives `getLineBoundary` on an empty line — throws `Bad state: No element` without the fix, passes with it.
