### PR TITLE
fix: guard link recognizer against stale/detached node in _tapNodeLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed an issue where bullet points became visually detached from the text body when toggling text direction formatting (RTL) by locking the list leading block to the editor's base text direction.
 - Fixed typed text being inserted at the previous caret position on Android after moving the caret with a tap/mouse by keeping the platform IME's editing state in sync with the selection even when the keyboard is hidden.
+- Fixed a `Null check operator used on a null value` crash in `_TextLineState._tapNodeLink`/`_longPressLink` when a cached link gesture recognizer fires after the document mutates: the captured node can be detached or have lost its `link` attribute by the time the tap is swept by the gesture arena (`_linkRecognizers` is not cleared when the line content changes), so the link attribute is now read defensively instead of force-unwrapped.
 
 ### Removed
 

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -698,7 +698,12 @@ class _TextLineState extends State<TextLine> {
   }
 
   void _tapNodeLink(Node node) {
-    final link = node.style.attributes[Attribute.link.key]!.value;
+    // The recognizer's onTap closure captures a specific node, but the cached
+    // recognizer outlives document mutations (_linkRecognizers is not cleared
+    // when the line content changes). By the time a queued tap is swept by the
+    // gesture arena, the captured node may be detached or have lost its link
+    // attribute, so read it defensively instead of force-unwrapping.
+    final link = node.style.attributes[Attribute.link.key]?.value;
 
     _tapLink(link);
   }
@@ -723,7 +728,12 @@ class _TextLineState extends State<TextLine> {
   }
 
   Future<void> _longPressLink(Node node) async {
-    final link = node.style.attributes[Attribute.link.key]!.value!;
+    // See _tapNodeLink: the captured node may no longer carry a link attribute
+    // by the time the gesture fires, so guard instead of force-unwrapping.
+    final link = node.style.attributes[Attribute.link.key]?.value;
+    if (link == null) {
+      return;
+    }
     final action = await widget.linkActionPicker(node);
     switch (action) {
       case LinkMenuAction.launch:


### PR DESCRIPTION
## Description

`_TextLineState` caches per-node link gesture recognizers in `_linkRecognizers` (`Map<Node, GestureRecognizer>`), and the recognizer's callback captures a specific `segment` node:

```dart
_linkRecognizers[segment] = TapGestureRecognizer()
  ..onTap = () => _tapNodeLink(segment);
```

That map is only cleared on a `readOnly` toggle (`didUpdateWidget`), a meta/ctrl key change (`_pressedKeysChanged`), or `dispose` — **never when the line's document content changes**. So the cached recognizer (and the node it captured) can outlive a document mutation/re-render.

When the gesture finally fires, `_tapNodeLink`/`_longPressLink` re-read the node's link attribute and force-unwrap it:

```dart
void _tapNodeLink(Node node) {
  final link = node.style.attributes[Attribute.link.key]!.value; // throws if null
  _tapLink(link);
}
```

If the document mutated between recognizer creation and the tap being swept by the gesture arena, the captured node can be detached or no longer carry a `link` attribute, so `attributes[Attribute.link.key]` is `null` and the `!` throws.

We see this crash in production (Crashlytics, flutter_quill 11.5.1, Android) on a read-only document with many links that is re-rendered while the user navigates — a queued tap is delivered during `GestureArenaManager.sweep` against a now-stale recognizer:

```
Fatal Exception: Null check operator used on a null value
0  _TextLineState._tapNodeLink (text_line.dart:670)
1  _TextLineState._getRecognizer.<fn> (text_line.dart:656)
2  GestureRecognizer.invokeCallback (recognizer.dart:345)
3  TapGestureRecognizer.handleTapUp (tap.dart:758)
4  BaseTapGestureRecognizer._checkUp (tap.dart:383)
5  BaseTapGestureRecognizer.acceptGesture (tap.dart:353)
6  GestureArenaManager.sweep (arena.dart:173)
```

## Fix

Read the link attribute defensively (`?.value`) in both `_tapNodeLink` and `_longPressLink` instead of force-unwrapping. `_tapLink` already no-ops on a `null` link; `_longPressLink` gets an early return. When the captured node is stale, the gesture simply does nothing instead of crashing.

## Notes

This is a defensive guard against a timing/staleness window (stale cached recognizer fired during arena sweep after a document mutation), which is awkward to reproduce deterministically in a widget test. Happy to add a regression test if a maintainer can point me at the preferred way to drive a cached recognizer against a mutated node.
