### PR TITLE
fix: don't split a surrogate pair when applying the composing style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed an issue where bullet points became visually detached from the text body when toggling text direction formatting (RTL) by locking the list leading block to the editor's base text direction.
 - Fixed typed text being inserted at the previous caret position on Android after moving the caret with a tap/mouse by keeping the platform IME's editing state in sync with the selection even when the keyboard is hidden.
+- Fixed an `Invalid argument(s): string is not well-formed UTF-16` crash in `addText` while laying out a line: `_TextLineState._splitAndApplyComposingStyle` cut the node text at the composing offsets without checking that they land on a code-point boundary, so a composing range carried over from an older document state could split a surrogate pair (an emoji) in half. The composing decoration is now skipped when the range is out of range or would split a pair.
 
 ### Removed
 

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -351,6 +351,23 @@ class _TextLineState extends State<TextLine> {
     final composingEnd = widget.composingRange.end - node.documentOffset;
     final text = child.toPlainText();
 
+    // The composing range is reported by the platform IME and is carried over
+    // to the new value when the document changes (see updateRemoteValueIfNeeded
+    // in RawEditorStateTextInputClientMixin, which only checks that the range
+    // still fits the text length). A programmatic edit can therefore leave the
+    // range pointing at different characters than the IME meant, and cutting
+    // there can split a UTF-16 surrogate pair (an emoji) in half. Malformed
+    // UTF-16 throws in the engine's paragraph builder when the line is laid
+    // out, so drop the composing decoration instead of building a span that
+    // cannot be rendered.
+    if (composingStart < 0 ||
+        composingEnd > text.length ||
+        composingStart > composingEnd ||
+        _splitsSurrogatePair(text, composingStart) ||
+        _splitsSurrogatePair(text, composingEnd)) {
+      return [child];
+    }
+
     final textBefore = text.substring(0, composingStart);
     final textComposing = text.substring(composingStart, composingEnd);
     final textAfter = text.substring(composingEnd);
@@ -761,6 +778,18 @@ class _TextLineState extends State<TextLine> {
           ),
         );
   }
+}
+
+/// Whether splitting [text] at [index] would cut a UTF-16 surrogate pair in
+/// half, leaving a lone surrogate in each part. Such a string is malformed and
+/// throws in the engine's paragraph builder when it is laid out.
+bool _splitsSurrogatePair(String text, int index) {
+  if (index <= 0 || index >= text.length) {
+    return false;
+  }
+  final high = text.codeUnitAt(index - 1);
+  final low = text.codeUnitAt(index);
+  return high >= 0xD800 && high <= 0xDBFF && low >= 0xDC00 && low <= 0xDFFF;
 }
 
 class EditableTextLine extends RenderObjectWidget {

--- a/test/bug_fix_test.dart
+++ b/test/bug_fix_test.dart
@@ -242,4 +242,52 @@ void main() {
       );
     },
   );
+  group('malformed UTF-16 crash when the composing range splits an emoji', () {
+    testWidgets(
+      'the composing decoration is skipped when the range cuts a surrogate '
+      'pair instead of laying out a malformed span',
+      (tester) async {
+        // The emoji occupies code units 2 and 3.
+        final controller = QuillController.basic()
+          ..document.insert(0, 'ab\u{1F600}cd');
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(
+          QuillTestApp.withScaffold(
+            QuillEditor.basic(
+              controller: controller,
+              config: const QuillEditorConfig(autoFocus: true),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // A composing range the IME reported against an older document state
+        // can end inside the surrogate pair. Splitting the text there used to
+        // hand a lone surrogate to the paragraph builder, which throws
+        // 'string is not well-formed UTF-16' from addText during layout.
+        tester.testTextInput.updateEditingValue(
+          TextEditingValue(
+            text: controller.document.toPlainText(),
+            selection: const TextSelection.collapsed(offset: 2),
+            composing: const TextRange(start: 0, end: 3),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+
+        // Clear the composing range: closeConnectionIfNeeded notifies the
+        // composing listener from dispose, which asserts on the defunct
+        // element when the editor is torn down with a range still set.
+        tester.testTextInput.updateEditingValue(
+          TextEditingValue(
+            text: controller.document.toPlainText(),
+            selection: const TextSelection.collapsed(offset: 2),
+          ),
+        );
+        await tester.pumpAndSettle();
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Description

`_TextLineState._splitAndApplyComposingStyle` cuts the node's text at the composing offsets with plain `substring`:

```dart
final composingStart = widget.composingRange.start - node.documentOffset;
final composingEnd = widget.composingRange.end - node.documentOffset;
final text = child.toPlainText();

final textBefore = text.substring(0, composingStart);
final textComposing = text.substring(composingStart, composingEnd);
final textAfter = text.substring(composingEnd);
```

Nothing checks that those offsets land on a code-point boundary. The composing range comes from the platform IME, and it is carried forward onto the new value every time the document changes — `RawEditorStateTextInputClientMixin.updateRemoteValueIfNeeded` only drops it when it no longer fits the text length:

```dart
final composingRange = _lastKnownRemoteTextEditingValue!.composing;
final actualValue = value.copyWith(
  // Ignore last known composing range if it exceeds current text length.
  composing: composingRange.end > value.text.length ? null : composingRange,
);
```

So a programmatic edit that shifts the text (in our app, formatting links and inserting a character ahead of the composing range) leaves a range that still "fits" but now points at different characters. When a boundary lands inside a UTF-16 surrogate pair, each part keeps a lone surrogate, and malformed UTF-16 throws in the engine's paragraph builder as soon as the line is laid out — taking down the frame:

```
Fatal Exception: Invalid argument(s): string is not well-formed UTF-16
0  _NativeParagraphBuilder.addText (dart:ui)
1  TextSpan.build (text_span.dart:298)
2  TextSpan.build (text_span.dart:316)
3  TextPainter._createParagraph (text_painter.dart:1203)
4  TextPainter.layout (text_painter.dart:1264)
5  RenderParagraph.performLayout (paragraph.dart:943)
...
6  RenderEditableTextLine.performLayout (text_line.dart:1328)
7  RenderEditor.performLayout (editor.dart:1142)
```

We see this in production (Crashlytics, flutter_quill 11.5.1, Android) in an editor whose document is mutated programmatically while the user types, on notes that contain an emoji.

The guards above the split only compare numbers, so they don't help: `isComposingRangeOutOfLine` checks the range against the line bounds and `isNodeInComposingRange` against the node bounds — a stale range passes both.

## Fix

Skip the composing decoration when the range is out of range or would split a surrogate pair, instead of building a span that cannot be rendered. The composing underline is lost for that frame; the text still renders and the next IME update restores it.

## Test

`test/bug_fix_test.dart` reproduces it: an editor holding `ab😀cd` plus a composing range ending at code unit 3 (inside the emoji's surrogate pair) throws the exact stack above before the fix and lays out cleanly after it.

## Notes

While writing the test I hit a second, unrelated issue: `closeConnectionIfNeeded` sets `_lastKnownRemoteTextEditingValue = null`, whose setter notifies `composingRange`, so `QuillRawEditorState._onComposingRangeChanged` calls `setState` from `dispose` and asserts `_lifecycleState != _ElementLifecycle.defunct` when the editor is torn down with a composing range still set. The test works around it by clearing the composing range first. Happy to send a separate PR for that if you'd like.
