### PR TITLE
feat: allow per-block-type content padding via DefaultTextBlockStyle

### DIFF
--- a/lib/src/editor/widgets/default_styles.dart
+++ b/lib/src/editor/widgets/default_styles.dart
@@ -37,8 +37,9 @@ class DefaultTextBlockStyle {
     this.horizontalSpacing,
     this.verticalSpacing,
     this.lineSpacing,
-    this.decoration,
-  );
+    this.decoration, {
+    this.contentPadding,
+  });
 
   /// Base text style for a text block.
   final TextStyle style;
@@ -53,6 +54,11 @@ class DefaultTextBlockStyle {
   ///
   final VerticalSpacing lineSpacing;
 
+  /// Padding inserted between a text block's content and its [decoration]
+  /// boundary. Forwarded to the block's rendering as `contentPadding`.
+  /// Falls back to the editor's global content padding if null.
+  final EdgeInsets? contentPadding;
+
   /// Decoration of a text block.
   ///
   /// Decoration, if present, is painted in the content area, excluding
@@ -64,6 +70,7 @@ class DefaultTextBlockStyle {
     HorizontalSpacing? horizontalSpacing,
     VerticalSpacing? verticalSpacing,
     VerticalSpacing? lineSpacing,
+    EdgeInsets? contentPadding,
     BoxDecoration? decoration,
   }) {
     return DefaultTextBlockStyle(
@@ -72,6 +79,7 @@ class DefaultTextBlockStyle {
       verticalSpacing ?? this.verticalSpacing,
       lineSpacing ?? this.lineSpacing,
       decoration ?? this.decoration,
+      contentPadding: contentPadding ?? this.contentPadding,
     );
   }
 }
@@ -183,6 +191,7 @@ class DefaultListBlockStyle extends DefaultTextBlockStyle {
     super.lineSpacing,
     super.decoration,
     this.checkboxUIBuilder, {
+    super.contentPadding,
     this.indentWidthBuilder = TextBlockUtils.defaultIndentWidthBuilder,
     this.numberPointWidthBuilder =
         TextBlockUtils.defaultNumberPointWidthBuilder,
@@ -198,6 +207,7 @@ class DefaultListBlockStyle extends DefaultTextBlockStyle {
     HorizontalSpacing? horizontalSpacing,
     VerticalSpacing? verticalSpacing,
     VerticalSpacing? lineSpacing,
+    EdgeInsets? contentPadding,
     BoxDecoration? decoration,
     QuillCheckboxBuilder? checkboxUIBuilder,
     LeadingBlockIndentWidth? indentWidthBuilder,
@@ -210,6 +220,7 @@ class DefaultListBlockStyle extends DefaultTextBlockStyle {
       lineSpacing ?? this.lineSpacing,
       decoration ?? this.decoration,
       checkboxUIBuilder ?? this.checkboxUIBuilder,
+      contentPadding: contentPadding ?? this.contentPadding,
       indentWidthBuilder: indentWidthBuilder ?? this.indentWidthBuilder,
       numberPointWidthBuilder:
           numberPointWidthBuilder ?? this.numberPointWidthBuilder,

--- a/lib/src/editor/widgets/text/text_block.dart
+++ b/lib/src/editor/widgets/text/text_block.dart
@@ -128,7 +128,8 @@ class EditableTextBlock extends StatelessWidget {
       scrollBottomInset: scrollBottomInset,
       decoration:
           _getDecorationForBlock(block, defaultStyles) ?? const BoxDecoration(),
-      contentPadding: contentPadding,
+      contentPadding:
+          _getContentPaddingForBlock(block, defaultStyles) ?? contentPadding,
       children: _buildChildren(context, indentLevelCounts, clearIndents),
     );
   }
@@ -152,6 +153,20 @@ class EditableTextBlock extends StatelessWidget {
     }
     if (attrs.containsKey(Attribute.codeBlock.key)) {
       return defaultStyles!.code!.decoration;
+    }
+    return null;
+  }
+
+  EdgeInsets? _getContentPaddingForBlock(
+    Block node,
+    DefaultStyles? defaultStyles,
+  ) {
+    final attrs = block.style.attributes;
+    if (attrs.containsKey(Attribute.blockQuote.key)) {
+      return defaultStyles?.quote?.contentPadding;
+    }
+    if (attrs.containsKey(Attribute.codeBlock.key)) {
+      return defaultStyles?.code?.contentPadding;
     }
     return null;
   }


### PR DESCRIPTION
## Problem

`DefaultTextBlockStyle` currently has no way to control the spacing
between a block's content and its own `decoration` (e.g. the left
border on a blockquote, the background box on a code block). The
only related padding is `EditableTextBlock.contentPadding`, which is
a single global value shared by every block type in the editor —
there's no per-block override.

As a result, something as simple as "add a bit of vertical breathing
room between the blockquote text and its left border" isn't possible
without reaching into `text_block.dart` and hardcoding values.

## Change

- Add an optional `EdgeInsets? contentPadding` field to
  `DefaultTextBlockStyle`, with the corresponding `copyWith` support.
- Forward it through `DefaultListBlockStyle`'s constructor and
  `copyWith` override, so list styles can opt in as well.
- In `EditableTextBlock`, add `_getContentPaddingForBlock()` (mirrors
  the existing `_getDecorationForBlock()`) to resolve a per-block
  `contentPadding` from `DefaultStyles.quote` / `DefaultStyles.code`,
  falling back to the editor's existing global `contentPadding` when
  the block style doesn't define one.

## Why this shape

This reuses the existing `contentPadding` → `RenderEditableTextBlock`
rendering path (which already separates decoration painting from
content padding) rather than introducing a new spacing concept, so
the actual rendering logic (`_paintDecoration`, `_EditableBlock`,
`RenderEditableTextBlock`) doesn't need to change at all.

## Compatibility

Fully backward compatible: the new field defaults to `null`, and
`EditableTextBlock` only uses it when a block style explicitly sets
it — otherwise the previous global `contentPadding` value is used
exactly as before. No existing call sites need to change.

## Example

```dart
quote: DefaultTextBlockStyle(
  ...,
  contentPadding: const EdgeInsets.symmetric(vertical: 8),
),
```

## Testing

- Verified blockquote/code block render unchanged when
  `contentPadding` is left unset.
- Verified setting `contentPadding` on `DefaultStyles.quote` adds
  vertical spacing between the text and the left border without
  shifting the border itself.