### PR TITLE
Migrate to the standalone material_ui / cupertino_ui packages

### DIFF
--- a/example/integration_test/flutter_quill_integration_test.dart
+++ b/example/integration_test/flutter_quill_integration_test.dart
@@ -1,8 +1,8 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_quill_test/flutter_quill_test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/example/lib/custom_toolbar.dart
+++ b/example/lib/custom_toolbar.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill_extensions/flutter_quill_extensions.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Custom toolbar that uses the buttons of [`flutter_quill`](https://pub.dev/packages/flutter_quill).
 ///

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,11 +2,11 @@ import 'dart:convert';
 import 'dart:io' as io show Directory, File;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill_example/quill_delta_sample.dart';
 import 'package:flutter_quill_extensions/flutter_quill_extensions.dart';
+import 'package:material_ui/material_ui.dart' hide GlobalMaterialLocalizations;
 import 'package:path/path.dart' as path;
 
 void main() => runApp(const MainApp());

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  cupertino_ui:
+    dependency: transitive
+    description:
+      name: cupertino_ui
+      sha256: e9dfe7fac704028f8928cbe4028a0be5e8a709498e8daf8247de99e99a32aef3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   dart_quill_delta:
     dependency: transitive
     description:
@@ -365,10 +373,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   leak_tracker:
     dependency: transitive
     description:
@@ -413,10 +421,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -425,14 +433,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  material_ui:
+    dependency: "direct main"
+    description:
+      name: material_ui
+      sha256: fbfb53cab6c4629438feeade5f3d305f72944bc9d9f25786b19106d32b80ec45
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -602,10 +618,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   typed_data:
     dependency: transitive
     description:
@@ -682,10 +698,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   video_player:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   flutter_quill_extensions: ^11.0.0-dev.3
   path: ^1.9.0
 
+  material_ui: ^1.2.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/flutter_quill_extensions/lib/src/common/image_video_utils.dart
+++ b/flutter_quill_extensions/lib/src/common/image_video_utils.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart' show QuillDialogTheme;
 import 'package:flutter_quill/internal.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'utils/patterns.dart';
 

--- a/flutter_quill_extensions/lib/src/editor/image/image_embed.dart
+++ b/flutter_quill_extensions/lib/src/editor/image/image_embed.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../common/utils/element_utils/element_utils.dart';
 import 'config/image_config.dart';

--- a/flutter_quill_extensions/lib/src/editor/image/image_menu.dart
+++ b/flutter_quill_extensions/lib/src/editor/image/image_menu.dart
@@ -1,9 +1,9 @@
-import 'package:flutter/cupertino.dart' show showCupertinoModalPopup;
+import 'package:cupertino_ui/cupertino_ui.dart' show showCupertinoModalPopup;
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart'
     show ImageUrl, QuillController, StyleAttribute, getEmbedNode;
 import 'package:flutter_quill/internal.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:path/path.dart' as p;
 import 'package:url_launcher/url_launcher.dart';
 

--- a/flutter_quill_extensions/lib/src/editor/image/image_save_utils.dart
+++ b/flutter_quill_extensions/lib/src/editor/image/image_save_utils.dart
@@ -2,9 +2,9 @@
 library;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_quill/internal.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:path/path.dart' as p;
 
 import 'image_load_utils.dart';

--- a/flutter_quill_extensions/lib/src/editor/image/widgets/image.dart
+++ b/flutter_quill_extensions/lib/src/editor/image/widgets/image.dart
@@ -2,8 +2,8 @@ import 'dart:convert' show base64;
 import 'dart:io' show File;
 
 import 'package:flutter/foundation.dart' show kIsWeb;
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:photo_view/photo_view.dart';
 
 import '../../../common/utils/utils.dart';

--- a/flutter_quill_extensions/lib/src/editor/image/widgets/image_resizer.dart
+++ b/flutter_quill_extensions/lib/src/editor/image/widgets/image_resizer.dart
@@ -1,8 +1,8 @@
-import 'package:flutter/cupertino.dart'
+import 'package:cupertino_ui/cupertino_ui.dart'
     show CupertinoActionSheet, CupertinoActionSheetAction;
-import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart' show SchedulerBinding;
 import 'package:flutter_quill/internal.dart';
+import 'package:material_ui/material_ui.dart';
 
 class ImageResizer extends StatefulWidget {
   const ImageResizer({

--- a/flutter_quill_extensions/lib/src/editor/video/video_embed.dart
+++ b/flutter_quill_extensions/lib/src/editor/video/video_embed.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../common/utils/element_utils/element_utils.dart';
 import 'config/video_config.dart';

--- a/flutter_quill_extensions/lib/src/editor/video/widgets/video_app.dart
+++ b/flutter_quill_extensions/lib/src/editor/video/widgets/video_app.dart
@@ -1,8 +1,8 @@
 import 'dart:io' show File;
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:video_player/video_player.dart';
 

--- a/flutter_quill_extensions/lib/src/toolbar/camera/camera_button.dart
+++ b/flutter_quill_extensions/lib/src/toolbar/camera/camera_button.dart
@@ -1,8 +1,8 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill/internal.dart';
-
 import 'package:image_picker/image_picker.dart';
+import 'package:material_ui/material_ui.dart';
+
 import '../../common/default_image_insert.dart';
 import '../../common/default_video_insert.dart';
 import '../quill_simple_toolbar_api.dart';

--- a/flutter_quill_extensions/lib/src/toolbar/camera/select_camera_action.dart
+++ b/flutter_quill_extensions/lib/src/toolbar/camera/select_camera_action.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/internal.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'camera_types.dart';
 

--- a/flutter_quill_extensions/lib/src/toolbar/image/image_button.dart
+++ b/flutter_quill_extensions/lib/src/toolbar/image/image_button.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill/internal.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../common/default_image_insert.dart';
 import '../../common/image_video_utils.dart';

--- a/flutter_quill_extensions/lib/src/toolbar/image/select_image_source.dart
+++ b/flutter_quill_extensions/lib/src/toolbar/image/select_image_source.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/internal.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../editor/image/image_embed_types.dart';
 

--- a/flutter_quill_extensions/lib/src/toolbar/video/select_video_source.dart
+++ b/flutter_quill_extensions/lib/src/toolbar/video/select_video_source.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/internal.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'config/video.dart';
 

--- a/flutter_quill_extensions/lib/src/toolbar/video/video_button.dart
+++ b/flutter_quill_extensions/lib/src/toolbar/video/video_button.dart
@@ -1,13 +1,11 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill/internal.dart';
-
 import 'package:image_picker/image_picker.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../common/default_video_insert.dart';
 import '../../common/image_video_utils.dart';
 import '../quill_simple_toolbar_api.dart';
-
 import 'config/video.dart';
 import 'config/video_config.dart';
 import 'select_video_source.dart';

--- a/flutter_quill_extensions/pubspec.yaml
+++ b/flutter_quill_extensions/pubspec.yaml
@@ -44,6 +44,8 @@ dependencies:
   url_launcher: ^6.2.1
   image_picker: ^1.0.0
 
+  material_ui: ^1.2.0
+  cupertino_ui: ^1.0.2
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/flutter_quill_extensions/pubspec_overrides.yaml
+++ b/flutter_quill_extensions/pubspec_overrides.yaml
@@ -1,0 +1,7 @@
+# Local override for the Material UI migration: build against the in-repo
+# flutter_quill (migrated to material_ui) instead of the published release,
+# which still imports package:flutter/material.dart. Ignored by consumers and
+# excluded from `pub publish`, so it only affects local/CI resolution.
+dependency_overrides:
+  flutter_quill:
+    path: ../

--- a/flutter_quill_extensions/test/editor/image/widgets/image_menu_test.dart
+++ b/flutter_quill_extensions/test/editor/image/widgets/image_menu_test.dart
@@ -1,13 +1,13 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill_extensions/src/common/utils/element_utils/element_utils.dart';
 import 'package:flutter_quill_extensions/src/editor/image/config/image_config.dart';
 import 'package:flutter_quill_extensions/src/editor/image/image_menu.dart';
 import 'package:flutter_quill_extensions/src/editor/image/image_save_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../quill_test_app.dart';

--- a/flutter_quill_extensions/test/quill_test_app.dart
+++ b/flutter_quill_extensions/test/quill_test_app.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill/internal.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 class QuillTestApp extends StatelessWidget {
   QuillTestApp({required this.home, required this.scaffoldBody, super.key}) {

--- a/flutter_quill_test/lib/src/test/selection_interactions/widget_tester_cursor_movement_extension.dart
+++ b/flutter_quill_test/lib/src/test/selection_interactions/widget_tester_cursor_movement_extension.dart
@@ -1,5 +1,6 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+
 import '../widget_tester_extension.dart';
 
 extension QuillWidgetTesterCursorMovementExtension on WidgetTester {

--- a/flutter_quill_test/lib/src/test/text_interactions/widget_tester_insert_extension.dart
+++ b/flutter_quill_test/lib/src/test/text_interactions/widget_tester_insert_extension.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../widget_tester_extension.dart';
 

--- a/flutter_quill_test/lib/src/test/text_interactions/widget_tester_remove_extension.dart
+++ b/flutter_quill_test/lib/src/test/text_interactions/widget_tester_remove_extension.dart
@@ -1,5 +1,6 @@
-import 'package:flutter/material.dart' show TextSelection;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart' show TextSelection;
+
 import '../widget_tester_extension.dart';
 
 extension QuillWidgetTesterRemoveExt on WidgetTester {

--- a/flutter_quill_test/lib/src/test/text_interactions/widget_tester_replace_extension.dart
+++ b/flutter_quill_test/lib/src/test/text_interactions/widget_tester_replace_extension.dart
@@ -1,5 +1,6 @@
-import 'package:flutter/material.dart' show TextSelection;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart' show TextSelection;
+
 import '../widget_tester_extension.dart';
 
 extension QuillWidgetTesterReplaceExt on WidgetTester {

--- a/flutter_quill_test/lib/src/test/widget_tester_extension.dart
+++ b/flutter_quill_test/lib/src/test/widget_tester_extension.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Extensions on [WidgetTester] that have utilities that help
 /// simplify interacting with the editor in test cases.

--- a/flutter_quill_test/pubspec.yaml
+++ b/flutter_quill_test/pubspec.yaml
@@ -18,6 +18,8 @@ dependencies:
   flutter_test:
     sdk: flutter
 
+  material_ui: ^1.2.0
+  cupertino_ui: ^1.0.2
 dev_dependencies:
   flutter_lints: ^5.0.0
 

--- a/flutter_quill_test/test/flutter_quill_test_test.dart
+++ b/flutter_quill_test/test/flutter_quill_test_test.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill_test/flutter_quill_test.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   late QuillController controller;

--- a/lib/src/common/utils/color.dart
+++ b/lib/src/common/utils/color.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../editor/widgets/default_styles.dart';
 

--- a/lib/src/common/utils/platform.dart
+++ b/lib/src/common/utils/platform.dart
@@ -2,7 +2,7 @@ import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart'
     show TargetPlatform, defaultTargetPlatform, kDebugMode, kIsWeb;
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'quill_native_provider.dart';
 

--- a/lib/src/common/utils/widgets.dart
+++ b/lib/src/common/utils/widgets.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 typedef WidgetWrapper = Widget Function(Widget child);
 

--- a/lib/src/editor/config/editor_config.dart
+++ b/lib/src/editor/config/editor_config.dart
@@ -3,8 +3,8 @@ library;
 
 import 'dart:ui' as ui;
 
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:meta/meta.dart' show experimental;
 
 import '../../document/nodes/node.dart';

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -1,13 +1,13 @@
 import 'dart:math' as math;
 
-import 'package:flutter/cupertino.dart'
+import 'package:cupertino_ui/cupertino_ui.dart'
     show CupertinoTheme, cupertinoTextSelectionControls;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../common/utils/platform.dart';
 import '../controller/quill_controller.dart';

--- a/lib/src/editor/raw_editor/builders/leading_block_builder.dart
+++ b/lib/src/editor/raw_editor/builders/leading_block_builder.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import '../../../document/attribute.dart';
 import '../../../document/nodes/node.dart';
 import '../../style_widgets/checkbox_point.dart';

--- a/lib/src/editor/raw_editor/config/raw_editor_config.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_config.dart
@@ -1,6 +1,6 @@
 import 'dart:ui' as ui;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:meta/meta.dart';
 
 import '../../../document/nodes/node.dart';

--- a/lib/src/editor/raw_editor/keyboard_shortcuts/default_single_activator_intents.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/default_single_activator_intents.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:meta/meta.dart';
 
 import '../../../common/utils/platform.dart';

--- a/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcut_actions.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcut_actions.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../document/attribute.dart';
 import '../../../document/style.dart';

--- a/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
+++ b/lib/src/editor/raw_editor/keyboard_shortcuts/editor_keyboard_shortcuts.dart
@@ -1,6 +1,6 @@
 import 'package:collection/collection.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:meta/meta.dart';
 
 import '../../../common/utils/cast.dart';

--- a/lib/src/editor/raw_editor/quill_single_child_scroll_view.dart
+++ b/lib/src/editor/raw_editor/quill_single_child_scroll_view.dart
@@ -1,8 +1,8 @@
 import 'dart:math' as math;
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Very similar to [SingleChildView] but with a [ViewportBuilder] argument
 /// instead of a [Widget]

--- a/lib/src/editor/raw_editor/raw_editor_render_object.dart
+++ b/lib/src/editor/raw_editor/raw_editor_render_object.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show ViewportOffset;
+import 'package:material_ui/material_ui.dart';
 
 import '../../document/document.dart';
 import '../editor.dart';

--- a/lib/src/editor/raw_editor/raw_editor_state.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state.dart
@@ -5,12 +5,12 @@ import 'dart:ui' as ui hide TextStyle;
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb;
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show RenderAbstractViewport;
 import 'package:flutter/scheduler.dart' show SchedulerBinding;
 import 'package:flutter/services.dart';
 import 'package:flutter_keyboard_visibility_temp_fork/flutter_keyboard_visibility_temp_fork.dart'
     show KeyboardVisibilityController;
+import 'package:material_ui/material_ui.dart';
 
 import '../../common/structs/horizontal_spacing.dart';
 import '../../common/structs/offset_value.dart';

--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -1,10 +1,10 @@
 import 'dart:ui' show lerpDouble;
 
-import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../common/extensions/view_id_ext.dart';
 import '../../delta/delta_diff.dart';

--- a/lib/src/editor/raw_editor/raw_editor_text_boundaries.dart
+++ b/lib/src/editor/raw_editor/raw_editor_text_boundaries.dart
@@ -1,7 +1,7 @@
 import 'dart:math' as math;
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show TextLayoutMetrics;
+import 'package:material_ui/material_ui.dart';
 
 /// An interface for retrieving the logical text boundary
 /// (left-closed-right-open)

--- a/lib/src/editor/raw_editor/scribble_focusable.dart
+++ b/lib/src/editor/raw_editor/scribble_focusable.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../common/extensions/view_id_ext.dart';
 

--- a/lib/src/editor/style_widgets/checkbox_point.dart
+++ b/lib/src/editor/style_widgets/checkbox_point.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class QuillCheckboxPoint extends StatefulWidget {
   const QuillCheckboxPoint({

--- a/lib/src/editor/widgets/default_leading_components/bullet_point_leading.dart
+++ b/lib/src/editor/widgets/default_leading_components/bullet_point_leading.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import '../../raw_editor/builders/leading_block_builder.dart';
 import '../../style_widgets/style_widgets.dart';
 

--- a/lib/src/editor/widgets/default_leading_components/check_box_leading.dart
+++ b/lib/src/editor/widgets/default_leading_components/check_box_leading.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import '../../raw_editor/builders/leading_block_builder.dart';
 import '../../style_widgets/style_widgets.dart';
 

--- a/lib/src/editor/widgets/default_leading_components/codeblock_line_number_leading.dart
+++ b/lib/src/editor/widgets/default_leading_components/codeblock_line_number_leading.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import '../../raw_editor/builders/leading_block_builder.dart';
 import '../../style_widgets/style_widgets.dart';
 

--- a/lib/src/editor/widgets/default_leading_components/number_point_leading.dart
+++ b/lib/src/editor/widgets/default_leading_components/number_point_leading.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import '../../raw_editor/builders/leading_block_builder.dart';
 import '../../style_widgets/style_widgets.dart';
 

--- a/lib/src/editor/widgets/default_styles.dart
+++ b/lib/src/editor/widgets/default_styles.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../common/structs/horizontal_spacing.dart';
 import '../../common/structs/vertical_spacing.dart';

--- a/lib/src/editor/widgets/delegate.dart
+++ b/lib/src/editor/widgets/delegate.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../common/utils/platform.dart';
 import '../../document/attribute.dart';

--- a/lib/src/editor/widgets/keyboard_listener.dart
+++ b/lib/src/editor/widgets/keyboard_listener.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 class QuillPressedKeys extends ChangeNotifier {
   static QuillPressedKeys of(BuildContext context) {

--- a/lib/src/editor/widgets/link.dart
+++ b/lib/src/editor/widgets/link.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../controller/quill_controller.dart';
 import '../../document/attribute.dart';

--- a/lib/src/editor/widgets/text/magnifier.dart
+++ b/lib/src/editor/widgets/text/magnifier.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 typedef QuillMagnifierBuilder = Widget Function(Offset dragPosition);
 

--- a/lib/src/editor/widgets/text/text_block.dart
+++ b/lib/src/editor/widgets/text/text_block.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../common/structs/horizontal_spacing.dart';
 import '../../../common/structs/vertical_spacing.dart';

--- a/lib/src/editor/widgets/text/text_line.dart
+++ b/lib/src/editor/widgets/text/text_line.dart
@@ -3,9 +3,9 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../../../flutter_quill.dart';

--- a/lib/src/editor/widgets/text/text_selection.dart
+++ b/lib/src/editor/widgets/text/text_selection.dart
@@ -3,9 +3,9 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../document/nodes/node.dart';
 import '../../editor.dart';

--- a/lib/src/editor/widgets/text/utils/text_block_utils.dart
+++ b/lib/src/editor/widgets/text/utils/text_block_utils.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../../common/structs/horizontal_spacing.dart';
 import '../../../../document/attribute.dart';

--- a/lib/src/editor_toolbar_shared/color.dart
+++ b/lib/src/editor_toolbar_shared/color.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 Color hexToColor(String? hexString) {
   if (hexString == null) {

--- a/lib/src/toolbar/base_button/base_value_button.dart
+++ b/lib/src/toolbar/base_button/base_value_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:meta/meta.dart';
 
 import '../../../flutter_quill.dart';

--- a/lib/src/toolbar/base_button/stateless_base_button.dart
+++ b/lib/src/toolbar/base_button/stateless_base_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:meta/meta.dart';
 
 import '../../controller/quill_controller.dart';

--- a/lib/src/toolbar/buttons/alignment/select_alignment_button.dart
+++ b/lib/src/toolbar/buttons/alignment/select_alignment_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../controller/quill_controller.dart';
 import '../../../document/attribute.dart';

--- a/lib/src/toolbar/buttons/alignment/select_alignment_buttons.dart
+++ b/lib/src/toolbar/buttons/alignment/select_alignment_buttons.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../controller/quill_controller.dart';
 import '../../../document/attribute.dart';

--- a/lib/src/toolbar/buttons/arrow_indicated_list_button.dart
+++ b/lib/src/toolbar/buttons/arrow_indicated_list_button.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Scrollable list with arrow indicators.
 ///

--- a/lib/src/toolbar/buttons/clear_format_button.dart
+++ b/lib/src/toolbar/buttons/clear_format_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../document/attribute.dart';
 import '../../l10n/extensions/localizations_ext.dart';

--- a/lib/src/toolbar/buttons/clipboard_button.dart
+++ b/lib/src/toolbar/buttons/clipboard_button.dart
@@ -4,7 +4,7 @@ library;
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:meta/meta.dart';
 
 import '../../common/utils/widgets.dart';

--- a/lib/src/toolbar/buttons/color/color_button.dart
+++ b/lib/src/toolbar/buttons/color/color_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../common/utils/color.dart';
 import '../../../document/attribute.dart';

--- a/lib/src/toolbar/buttons/color/color_dialog.dart
+++ b/lib/src/toolbar/buttons/color/color_dialog.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart'
     as color_picker
     show ColorPicker, MaterialPicker, colorToHex;
+import 'package:material_ui/material_ui.dart';
 
 import '../../../document/style.dart';
 import '../../../editor_toolbar_shared/color.dart';

--- a/lib/src/toolbar/buttons/custom_button_button.dart
+++ b/lib/src/toolbar/buttons/custom_button_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../controller/quill_controller.dart';
 import '../base_button/base_button_options_resolver.dart';

--- a/lib/src/toolbar/buttons/font_family_button.dart
+++ b/lib/src/toolbar/buttons/font_family_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../common/utils/widgets.dart';
 import '../../document/attribute.dart';

--- a/lib/src/toolbar/buttons/font_size_button.dart
+++ b/lib/src/toolbar/buttons/font_size_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../common/utils/font.dart';
 import '../../common/utils/widgets.dart';

--- a/lib/src/toolbar/buttons/hearder_style/select_header_style_buttons.dart
+++ b/lib/src/toolbar/buttons/hearder_style/select_header_style_buttons.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart' show kIsWeb;
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../document/attribute.dart';
 import '../../../document/style.dart';

--- a/lib/src/toolbar/buttons/hearder_style/select_header_style_dropdown_button.dart
+++ b/lib/src/toolbar/buttons/hearder_style/select_header_style_dropdown_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../document/attribute.dart';
 import '../../../l10n/extensions/localizations_ext.dart';

--- a/lib/src/toolbar/buttons/history_button.dart
+++ b/lib/src/toolbar/buttons/history_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../l10n/extensions/localizations_ext.dart';
 import '../base_button/base_value_button.dart';

--- a/lib/src/toolbar/buttons/indent_button.dart
+++ b/lib/src/toolbar/buttons/indent_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../l10n/extensions/localizations_ext.dart';
 import '../base_button/base_value_button.dart';

--- a/lib/src/toolbar/buttons/link_style/link_dialog.dart
+++ b/lib/src/toolbar/buttons/link_style/link_dialog.dart
@@ -1,7 +1,7 @@
 @internal
 library;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:meta/meta.dart';
 
 import '../../../common/utils/link_validator.dart';

--- a/lib/src/toolbar/buttons/link_style/link_style2_button.dart
+++ b/lib/src/toolbar/buttons/link_style/link_style2_button.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:url_launcher/link.dart';
 
 import '../../../common/utils/link_validator.dart';

--- a/lib/src/toolbar/buttons/link_style/link_style_button.dart
+++ b/lib/src/toolbar/buttons/link_style/link_style_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../editor/widgets/link.dart';
 import '../../../l10n/extensions/localizations_ext.dart';

--- a/lib/src/toolbar/buttons/quill_icon_button.dart
+++ b/lib/src/toolbar/buttons/quill_icon_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../theme/quill_icon_theme.dart';
 

--- a/lib/src/toolbar/buttons/search/search_button.dart
+++ b/lib/src/toolbar/buttons/search/search_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../l10n/extensions/localizations_ext.dart';
 import '../../base_button/stateless_base_button.dart';

--- a/lib/src/toolbar/buttons/search/search_dialog.dart
+++ b/lib/src/toolbar/buttons/search/search_dialog.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../common/utils/platform.dart';
 import '../../../controller/quill_controller.dart';

--- a/lib/src/toolbar/buttons/select_line_height_dropdown_button.dart
+++ b/lib/src/toolbar/buttons/select_line_height_dropdown_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../document/attribute.dart';
 import '../../l10n/extensions/localizations_ext.dart';

--- a/lib/src/toolbar/buttons/toggle_check_list_button.dart
+++ b/lib/src/toolbar/buttons/toggle_check_list_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../common/utils/widgets.dart';
 import '../../document/attribute.dart';

--- a/lib/src/toolbar/buttons/toggle_style_button.dart
+++ b/lib/src/toolbar/buttons/toggle_style_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../common/utils/widgets.dart';
 import '../../document/attribute.dart';

--- a/lib/src/toolbar/config/buttons/font_family_options.dart
+++ b/lib/src/toolbar/config/buttons/font_family_options.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../document/attribute.dart';
 import '../../buttons/font_family_button.dart';

--- a/lib/src/toolbar/config/buttons/font_size_options.dart
+++ b/lib/src/toolbar/config/buttons/font_size_options.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../document/attribute.dart';
 import '../../../editor_toolbar_controller_shared/quill_config.dart';

--- a/lib/src/toolbar/config/buttons/search_options.dart
+++ b/lib/src/toolbar/config/buttons/search_options.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../../flutter_quill.dart';
 

--- a/lib/src/toolbar/simple_toolbar.dart
+++ b/lib/src/toolbar/simple_toolbar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../controller/quill_controller.dart';
 import '../document/attribute.dart';

--- a/lib/src/toolbar/theme/quill_dialog_theme.dart
+++ b/lib/src/toolbar/theme/quill_dialog_theme.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart' show Diagnosticable, immutable;
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Used to configure the dialog's look and feel.
 

--- a/lib/src/toolbar/theme/quill_icon_theme.dart
+++ b/lib/src/toolbar/theme/quill_icon_theme.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 @immutable
 class QuillIconTheme {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,8 @@ dependencies:
   flutter_keyboard_visibility_temp_fork: ^0.1.1
   quill_native_bridge: ^11.0.0
 
+  material_ui: ^1.2.0
+  cupertino_ui: ^1.0.2
 dev_dependencies:
   flutter_lints: ^5.0.0
   flutter_test:

--- a/test/bug_fix_test.dart
+++ b/test/bug_fix_test.dart
@@ -1,9 +1,9 @@
-import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill_test/flutter_quill_test.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'common/utils/quill_test_app.dart';
 import 'editor/editor_config_utils.dart';

--- a/test/common/utils/quill_test_app.dart
+++ b/test/common/utils/quill_test_app.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill/internal.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 typedef LocalizationsAvailableCallback =
     void Function(FlutterQuillLocalizations quillLocalizations);

--- a/test/controller/controller_clipboard_test.dart
+++ b/test/controller/controller_clipboard_test.dart
@@ -1,8 +1,8 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill/quill_delta.dart';
 import 'package:flutter_quill/src/controller/clipboard/quill_controller_paste.dart';
 import 'package:flutter_quill/src/controller/clipboard/quill_controller_rich_paste.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/controller/controller_test.dart
+++ b/test/controller/controller_test.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill/quill_delta.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/document/document_search_test.dart
+++ b/test/document/document_search_test.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill/quill_delta.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 class TestTimeStampEmbed extends Embeddable {
   const TestTimeStampEmbed(String value) : super(timeStampType, value);
@@ -104,11 +104,9 @@ void main() {
           searchEmbedMode: SearchEmbedMode.plainText,
         )
         ..embedBuilders = [const TestTimeStampEmbedBuilderWidget()];
-      expect(
-        document.search('2024'),
-        [7],
-        reason: 'timeStamp embed builder overrides toPlainText',
-      );
+      expect(document.search('2024'), [
+        7,
+      ], reason: 'timeStamp embed builder overrides toPlainText');
       expect(
         document.search('18'),
         [],

--- a/test/editor/editor_config_utils.dart
+++ b/test/editor/editor_config_utils.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:material_ui/material_ui.dart';
 
 QuillRawEditorConfig createFakeRawEditorConfig({
   Brightness? keyboardAppearance,

--- a/test/editor/editor_test.dart
+++ b/test/editor/editor_test.dart
@@ -1,11 +1,11 @@
 import 'dart:convert' show jsonDecode;
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill/src/l10n/extensions/localizations_ext.dart';
 import 'package:flutter_quill_test/flutter_quill_test.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   late QuillController controller;

--- a/test/editor_toolbar_shared/color_test.dart
+++ b/test/editor_toolbar_shared/color_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/src/editor_toolbar_shared/color.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/toolbar/buttons/color/color_dialog_test.dart
+++ b/test/toolbar/buttons/color/color_dialog_test.dart
@@ -1,8 +1,8 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_quill/src/editor_toolbar_shared/color.dart';
 import 'package:flutter_quill/src/toolbar/buttons/color/color_dialog.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../../common/utils/quill_test_app.dart';
 

--- a/test/toolbar/buttons/link_style_button_test.dart
+++ b/test/toolbar/buttons/link_style_button_test.dart
@@ -1,11 +1,10 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_quill/src/common/utils/link_validator.dart';
 import 'package:flutter_quill/src/controller/quill_controller.dart';
 import 'package:flutter_quill/src/l10n/generated/quill_localizations.dart';
-
 import 'package:flutter_quill/src/toolbar/buttons/link_style/link_dialog.dart';
 import 'package:flutter_quill/src/toolbar/buttons/link_style/link_style_button.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../../common/utils/quill_test_app.dart';
 


### PR DESCRIPTION
## Description

Migrates the packages off `package:flutter/material.dart` / `package:flutter/cupertino.dart` and onto the new standalone **`material_ui`** / **`cupertino_ui`** packages, following the Flutter breaking change:
https://docs.flutter.dev/release/breaking-changes/material-ui-and-cupertino-ui

### How it was done

Following the documented procedure:

```bash
dart fix --apply --code=migrate_design_widgets   # rewrite imports
flutter pub add material_ui cupertino_ui         # add the new deps (per package)
dart fix --apply --code=directives_ordering      # re-sort imports
```

Applied across all packages: `flutter_quill`, `flutter_quill_extensions`, `flutter_quill_test` and `example`.

### Changes
- **97 Dart files**: imports rewritten from `package:flutter/material.dart` → `package:material_ui/material_ui.dart` and `package:flutter/cupertino.dart` → `package:cupertino_ui/cupertino_ui.dart`.
- **Dependencies**: added `material_ui: ^1.2.0` (all packages) and `cupertino_ui: ^1.0.2` (packages that use Cupertino widgets).
- **`example/lib/main.dart`**: `hide GlobalMaterialLocalizations` on the `material_ui` import — it now also exports that symbol, which was ambiguous against `flutter_localizations`.
- **`flutter_quill_extensions/pubspec_overrides.yaml`**: path override so the package builds against the in-repo (migrated) `flutter_quill` rather than the published release (which still imports `package:flutter/material.dart`, breaking the `ThemeData.isCupertino` extension). The override is ignored by consumers and excluded from `pub publish`, so it only affects local/CI resolution during the transition.

### Verification
- `dart analyze` — **no issues** in all four packages (lib + tests).
- `dart format --set-exit-if-changed .` — clean.

### Note for maintainers
CI (`.github/workflows/checks.yml`) pins `flutter-version: 3.44.1`. The `material_ui` / `cupertino_ui` packages require a newer Flutter (verified locally on **3.47.2**), so the pinned CI version will need bumping alongside this migration.
